### PR TITLE
feat: add phase 2 data structure commands

### DIFF
--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -2,6 +2,9 @@ package command
 
 import (
 	"context"
+	"math"
+	"strconv"
+	"strings"
 
 	"github.com/maltemindedal/godis/internal/protocol"
 	"github.com/maltemindedal/godis/internal/storage"
@@ -52,7 +55,13 @@ func (e *Executor) handleGet(_ context.Context, request *Request) (protocol.Valu
 		return nil, wrongNumberOfArgumentsError("GET")
 	}
 
-	value, ok := e.store.Get(string(request.Args[0]))
+	value, ok, err := e.store.Get(string(request.Args[0]))
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return nil, ErrWrongTypeError()
+		}
+		return nil, err
+	}
 	if !ok {
 		return protocol.BulkString{Null: true}, nil
 	}
@@ -93,6 +102,282 @@ func (e *Executor) handleIncr(_ context.Context, request *Request) (protocol.Val
 	}
 
 	return protocol.Integer{Value: value}, nil
+}
+
+func (e *Executor) handleLPush(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) < 2 {
+		return nil, wrongNumberOfArgumentsError("LPUSH")
+	}
+
+	length, err := e.store.LeftPush(string(request.Args[0]), request.Args[1:])
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return nil, ErrWrongTypeError()
+		}
+		return nil, err
+	}
+
+	return protocol.Integer{Value: length}, nil
+}
+
+func (e *Executor) handleRPush(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) < 2 {
+		return nil, wrongNumberOfArgumentsError("RPUSH")
+	}
+
+	length, err := e.store.RightPush(string(request.Args[0]), request.Args[1:])
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return nil, ErrWrongTypeError()
+		}
+		return nil, err
+	}
+
+	return protocol.Integer{Value: length}, nil
+}
+
+func (e *Executor) handleLRange(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 3 {
+		return nil, wrongNumberOfArgumentsError("LRANGE")
+	}
+
+	start, err := parseIntegerArgument(request.Args[1])
+	if err != nil {
+		return nil, err
+	}
+	stop, err := parseIntegerArgument(request.Args[2])
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := e.store.ListRange(string(request.Args[0]), start, stop)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return nil, ErrWrongTypeError()
+		}
+		return nil, err
+	}
+
+	return listResponse(values), nil
+}
+
+func (e *Executor) handleBLPop(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 1 {
+		return nil, wrongNumberOfArgumentsError("BLPOP")
+	}
+
+	key := string(request.Args[0])
+	for {
+		waiter := e.store.SubscribeListPush(key)
+
+		value, ok, err := e.store.LeftPop(key)
+		if err != nil {
+			e.store.UnsubscribeListPush(key, waiter)
+			if err == storage.ErrWrongType {
+				return nil, ErrWrongTypeError()
+			}
+			return nil, err
+		}
+		if ok {
+			e.store.UnsubscribeListPush(key, waiter)
+			return protocol.Array{Elements: []protocol.Value{
+				protocol.BulkString{Data: clone(request.Args[0])},
+				protocol.BulkString{Data: value},
+			}}, nil
+		}
+
+		select {
+		case <-waiter:
+			e.store.UnsubscribeListPush(key, waiter)
+		case <-ctx.Done():
+			e.store.UnsubscribeListPush(key, waiter)
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (e *Executor) handleZAdd(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) < 3 || len(request.Args)%2 == 0 {
+		return nil, wrongNumberOfArgumentsError("ZADD")
+	}
+
+	entries := make([]storage.ZSetEntry, 0, (len(request.Args)-1)/2)
+	for i := 1; i < len(request.Args); i += 2 {
+		score, err := parseFloatArgument(request.Args[i])
+		if err != nil {
+			return nil, err
+		}
+
+		entries = append(entries, storage.ZSetEntry{
+			Member: clone(request.Args[i+1]),
+			Score:  score,
+		})
+	}
+
+	added, err := e.store.ZAdd(string(request.Args[0]), entries)
+	if err != nil {
+		switch err {
+		case storage.ErrWrongType:
+			return nil, ErrWrongTypeError()
+		case storage.ErrSyntax:
+			return nil, ErrSyntaxError()
+		default:
+			return nil, err
+		}
+	}
+
+	return protocol.Integer{Value: added}, nil
+}
+
+func (e *Executor) handleZRange(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 3 && len(request.Args) != 4 {
+		return nil, wrongNumberOfArgumentsError("ZRANGE")
+	}
+
+	withScores := false
+	if len(request.Args) == 4 {
+		if !strings.EqualFold(string(request.Args[3]), "WITHSCORES") {
+			return nil, ErrSyntaxError()
+		}
+		withScores = true
+	}
+
+	start, err := parseIntegerArgument(request.Args[1])
+	if err != nil {
+		return nil, err
+	}
+	stop, err := parseIntegerArgument(request.Args[2])
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := e.store.ZRange(string(request.Args[0]), start, stop)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return nil, ErrWrongTypeError()
+		}
+		return nil, err
+	}
+
+	return zsetResponse(entries, withScores), nil
+}
+
+func (e *Executor) handleXAdd(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) < 4 || len(request.Args)%2 != 0 {
+		return nil, wrongNumberOfArgumentsError("XADD")
+	}
+
+	id, err := e.store.XAdd(string(request.Args[0]), string(request.Args[1]), request.Args[2:])
+	if err != nil {
+		switch err {
+		case storage.ErrWrongType:
+			return nil, ErrWrongTypeError()
+		case storage.ErrSyntax:
+			return nil, ErrSyntaxError()
+		case storage.ErrInvalidStreamID:
+			return nil, ErrInvalidStreamIDError()
+		case storage.ErrStreamIDTooSmall:
+			return nil, ErrStreamIDTooSmallError()
+		default:
+			return nil, err
+		}
+	}
+
+	return protocol.BulkString{Data: []byte(id)}, nil
+}
+
+func (e *Executor) handleXRead(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) == 0 {
+		return nil, wrongNumberOfArgumentsError("XREAD")
+	}
+	if !strings.EqualFold(string(request.Args[0]), "STREAMS") {
+		return nil, ErrSyntaxError()
+	}
+	if len(request.Args) != 3 {
+		return nil, ErrSyntaxError()
+	}
+
+	entries, err := e.store.XRead(string(request.Args[1]), string(request.Args[2]))
+	if err != nil {
+		switch err {
+		case storage.ErrWrongType:
+			return nil, ErrWrongTypeError()
+		case storage.ErrInvalidStreamID:
+			return nil, ErrInvalidStreamIDError()
+		default:
+			return nil, err
+		}
+	}
+
+	return streamReadResponse(request.Args[1], entries), nil
+}
+
+func listResponse(values [][]byte) protocol.Array {
+	elements := make([]protocol.Value, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, protocol.BulkString{Data: clone(value)})
+	}
+
+	return protocol.Array{Elements: elements}
+}
+
+func zsetResponse(entries []storage.ZSetEntry, withScores bool) protocol.Array {
+	elements := make([]protocol.Value, 0, len(entries))
+	if withScores {
+		elements = make([]protocol.Value, 0, len(entries)*2)
+	}
+
+	for _, entry := range entries {
+		elements = append(elements, protocol.BulkString{Data: clone(entry.Member)})
+		if withScores {
+			elements = append(elements, protocol.BulkString{Data: formatFloatScore(entry.Score)})
+		}
+	}
+
+	return protocol.Array{Elements: elements}
+}
+
+func streamReadResponse(key []byte, entries []storage.StreamEntry) protocol.Array {
+	if len(entries) == 0 {
+		return protocol.Array{Elements: []protocol.Value{}}
+	}
+
+	streamEntries := make([]protocol.Value, 0, len(entries))
+	for _, entry := range entries {
+		streamEntries = append(streamEntries, protocol.Array{Elements: []protocol.Value{
+			protocol.BulkString{Data: []byte(entry.ID)},
+			listResponse(entry.Values),
+		}})
+	}
+
+	return protocol.Array{Elements: []protocol.Value{
+		protocol.Array{Elements: []protocol.Value{
+			protocol.BulkString{Data: clone(key)},
+			protocol.Array{Elements: streamEntries},
+		}},
+	}}
+}
+
+func parseIntegerArgument(raw []byte) (int64, error) {
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	if err != nil {
+		return 0, ErrValueNotIntegerError()
+	}
+
+	return value, nil
+}
+
+func parseFloatArgument(raw []byte) (float64, error) {
+	value, err := strconv.ParseFloat(string(raw), 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, ErrValueNotFloatError()
+	}
+
+	return value, nil
+}
+
+func formatFloatScore(score float64) []byte {
+	return []byte(strconv.FormatFloat(score, 'g', -1, 64))
 }
 
 func clone(value []byte) []byte {

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +91,22 @@ func TestExecutorExecute(t *testing.T) {
 			},
 		},
 		{
+			name: "GET rejects list values with wrong type",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("RPUSH", "queue", "job-1")); err != nil {
+					t.Fatalf("RPUSH error = %v", err)
+				}
+			},
+			request: requestValue("GET", "queue"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrWrongType) {
+					t.Fatalf("Execute() error = %v, want ErrWrongType", err)
+				}
+			},
+		},
+		{
 			name: "DEL removes existing keys and returns count",
 			setup: func(t *testing.T, executor *Executor) {
 				t.Helper()
@@ -121,6 +139,208 @@ func TestExecutorExecute(t *testing.T) {
 					t.Fatalf("Execute() error = %v", err)
 				}
 				assertValueEqual(t, value, protocol.Integer{Value: 0})
+			},
+		},
+		{
+			name: "LPUSH and LRANGE return list contents",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("LPUSH", "letters", "a", "b")); err != nil {
+					t.Fatalf("LPUSH error = %v", err)
+				}
+				if _, err := executor.Execute(context.Background(), requestValue("RPUSH", "letters", "c")); err != nil {
+					t.Fatalf("RPUSH error = %v", err)
+				}
+			},
+			request: requestValue("LRANGE", "letters", "0", "-1"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+					protocol.BulkString{Data: []byte("b")},
+					protocol.BulkString{Data: []byte("a")},
+					protocol.BulkString{Data: []byte("c")},
+				}})
+			},
+		},
+		{
+			name: "ZADD and ZRANGE WITHSCORES return sorted contents",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("ZADD", "leaders", "2", "beta", "1", "alpha", "2", "aardvark")); err != nil {
+					t.Fatalf("ZADD error = %v", err)
+				}
+			},
+			request: requestValue("ZRANGE", "leaders", "0", "-1", "WITHSCORES"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+					protocol.BulkString{Data: []byte("alpha")},
+					protocol.BulkString{Data: []byte("1")},
+					protocol.BulkString{Data: []byte("aardvark")},
+					protocol.BulkString{Data: []byte("2")},
+					protocol.BulkString{Data: []byte("beta")},
+					protocol.BulkString{Data: []byte("2")},
+				}})
+			},
+		},
+		{
+			name: "ZADD returns count of newly added members only",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("ZADD", "leaders", "1", "alpha")); err != nil {
+					t.Fatalf("initial ZADD error = %v", err)
+				}
+			},
+			request: requestValue("ZADD", "leaders", "2", "alpha", "3", "beta"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 1})
+			},
+		},
+		{
+			name:    "ZADD rejects invalid score",
+			request: requestValue("ZADD", "leaders", "oops", "alpha"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrValueNotFloat) {
+					t.Fatalf("Execute() error = %v, want ErrValueNotFloat", err)
+				}
+			},
+		},
+		{
+			name: "XADD and XREAD return stream entries",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("XADD", "events", "1-0", "type", "start")); err != nil {
+					t.Fatalf("first XADD error = %v", err)
+				}
+				if _, err := executor.Execute(context.Background(), requestValue("XADD", "events", "2-0", "type", "finish", "user", "42")); err != nil {
+					t.Fatalf("second XADD error = %v", err)
+				}
+			},
+			request: requestValue("XREAD", "STREAMS", "events", "0-0"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+					protocol.Array{Elements: []protocol.Value{
+						protocol.BulkString{Data: []byte("events")},
+						protocol.Array{Elements: []protocol.Value{
+							protocol.Array{Elements: []protocol.Value{
+								protocol.BulkString{Data: []byte("1-0")},
+								protocol.Array{Elements: []protocol.Value{
+									protocol.BulkString{Data: []byte("type")},
+									protocol.BulkString{Data: []byte("start")},
+								}},
+							}},
+							protocol.Array{Elements: []protocol.Value{
+								protocol.BulkString{Data: []byte("2-0")},
+								protocol.Array{Elements: []protocol.Value{
+									protocol.BulkString{Data: []byte("type")},
+									protocol.BulkString{Data: []byte("finish")},
+									protocol.BulkString{Data: []byte("user")},
+									protocol.BulkString{Data: []byte("42")},
+								}},
+							}},
+						}},
+					}},
+				}})
+			},
+		},
+		{
+			name:    "XREAD returns empty array for missing stream",
+			request: requestValue("XREAD", "STREAMS", "missing", "0-0"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{}})
+			},
+		},
+		{
+			name:    "XADD rejects malformed IDs",
+			request: requestValue("XADD", "events", "bad-id", "field", "value"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrInvalidStreamID) {
+					t.Fatalf("Execute() error = %v, want ErrInvalidStreamID", err)
+				}
+			},
+		},
+		{
+			name: "XADD rejects non monotonic explicit IDs",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("XADD", "events", "1-0", "field", "value")); err != nil {
+					t.Fatalf("initial XADD error = %v", err)
+				}
+			},
+			request: requestValue("XADD", "events", "1-0", "field", "value"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrStreamIDTooSmall) {
+					t.Fatalf("Execute() error = %v, want ErrStreamIDTooSmall", err)
+				}
+			},
+		},
+		{
+			name: "XREAD rejects wrong value type",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				executor.store.Set("events", []byte("plain"), 0)
+			},
+			request: requestValue("XREAD", "STREAMS", "events", "0-0"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrWrongType) {
+					t.Fatalf("Execute() error = %v, want ErrWrongType", err)
+				}
+			},
+		},
+		{
+			name:    "XREAD rejects invalid syntax",
+			request: requestValue("XREAD", "COUNT", "2", "STREAMS", "events", "0-0"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrSyntax) {
+					t.Fatalf("Execute() error = %v, want ErrSyntax", err)
+				}
+			},
+		},
+		{
+			name:    "ZRANGE rejects invalid trailing option",
+			request: requestValue("ZRANGE", "leaders", "0", "-1", "REV"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrSyntax) {
+					t.Fatalf("Execute() error = %v, want ErrSyntax", err)
+				}
+			},
+		},
+		{
+			name: "LPUSH rejects wrong value type",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				executor.store.Set("letters", []byte("hello"), 0)
+			},
+			request: requestValue("LPUSH", "letters", "a"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrWrongType) {
+					t.Fatalf("Execute() error = %v, want ErrWrongType", err)
+				}
 			},
 		},
 		{
@@ -226,6 +446,83 @@ func TestExecutorExecute(t *testing.T) {
 			tt.assert(t, value, err)
 		})
 	}
+}
+
+func TestExecutorXAddAutoGeneratesIDs(t *testing.T) {
+	executor := newTestExecutor()
+
+	first, err := executor.Execute(context.Background(), requestValue("XADD", "events", "*", "field", "one"))
+	if err != nil {
+		t.Fatalf("first XADD error = %v", err)
+	}
+	second, err := executor.Execute(context.Background(), requestValue("XADD", "events", "*", "field", "two"))
+	if err != nil {
+		t.Fatalf("second XADD error = %v", err)
+	}
+
+	firstBulk, ok := first.(protocol.BulkString)
+	if !ok {
+		t.Fatalf("first response type = %T, want protocol.BulkString", first)
+	}
+	secondBulk, ok := second.(protocol.BulkString)
+	if !ok {
+		t.Fatalf("second response type = %T, want protocol.BulkString", second)
+	}
+
+	firstID, err := storageParseStreamIDForTest(string(firstBulk.Data))
+	if err != nil {
+		t.Fatalf("parse first ID error = %v", err)
+	}
+	secondID, err := storageParseStreamIDForTest(string(secondBulk.Data))
+	if err != nil {
+		t.Fatalf("parse second ID error = %v", err)
+	}
+	if secondID.milliseconds < firstID.milliseconds || (secondID.milliseconds == firstID.milliseconds && secondID.sequence <= firstID.sequence) {
+		t.Fatalf("second auto-generated ID %q is not greater than first ID %q", string(secondBulk.Data), string(firstBulk.Data))
+	}
+}
+
+func storageParseStreamIDForTest(raw string) (struct{ milliseconds, sequence int64 }, error) {
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 {
+		return struct{ milliseconds, sequence int64 }{}, errors.New("invalid stream ID")
+	}
+	milliseconds, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return struct{ milliseconds, sequence int64 }{}, err
+	}
+	sequence, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return struct{ milliseconds, sequence int64 }{}, err
+	}
+	return struct{ milliseconds, sequence int64 }{milliseconds: milliseconds, sequence: sequence}, nil
+}
+
+func TestExecutorBLPop(t *testing.T) {
+	executor := newTestExecutor()
+
+	pushErrCh := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_, err := executor.Execute(context.Background(), requestValue("RPUSH", "jobs", "build"))
+		pushErrCh <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	value, err := executor.Execute(ctx, requestValue("BLPOP", "jobs"))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if pushErr := <-pushErrCh; pushErr != nil {
+		t.Fatalf("RPUSH error = %v", pushErr)
+	}
+
+	assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("jobs")},
+		protocol.BulkString{Data: []byte("build")},
+	}})
 }
 
 func TestDecodeRequest(t *testing.T) {
@@ -354,6 +651,20 @@ func assertValueEqual(t *testing.T, got protocol.Value, want protocol.Value) {
 		}
 		if typedGot.Value != typedWant.Value {
 			t.Fatalf("integer = %d, want %d", typedGot.Value, typedWant.Value)
+		}
+	case protocol.Array:
+		typedGot, ok := got.(protocol.Array)
+		if !ok {
+			t.Fatalf("value type = %T, want %T", got, want)
+		}
+		if typedGot.Null != typedWant.Null {
+			t.Fatalf("array null = %v, want %v", typedGot.Null, typedWant.Null)
+		}
+		if len(typedGot.Elements) != len(typedWant.Elements) {
+			t.Fatalf("len(array) = %d, want %d", len(typedGot.Elements), len(typedWant.Elements))
+		}
+		for i := range typedWant.Elements {
+			assertValueEqual(t, typedGot.Elements[i], typedWant.Elements[i])
 		}
 	default:
 		t.Fatalf("unsupported wanted type %T", want)

--- a/internal/command/executor.go
+++ b/internal/command/executor.go
@@ -10,8 +10,14 @@ var (
 	ErrSyntax = errors.New("syntax error")
 	// ErrInvalidExpireTime reports an invalid EX/PX duration.
 	ErrInvalidExpireTime = errors.New("invalid expire time in 'SET' command")
+	// ErrInvalidStreamID reports that a stream ID could not be parsed.
+	ErrInvalidStreamID = errors.New("invalid stream ID specified as stream command argument")
+	// ErrStreamIDTooSmall reports that XADD was given a non-monotonic explicit ID.
+	ErrStreamIDTooSmall = errors.New("stream ID is equal or smaller than the target stream top item")
 	// ErrValueNotInteger reports that a value cannot be parsed as a 64-bit integer.
 	ErrValueNotInteger = errors.New("value is not an integer or out of range")
+	// ErrValueNotFloat reports that a value cannot be parsed as a float64.
+	ErrValueNotFloat = errors.New("value is not a valid float")
 	// ErrWrongType reports that a command targeted the wrong logical value type.
 	ErrWrongType = errors.New("operation against a key holding the wrong kind of value")
 	// ErrNoAuth reports that the client must authenticate before running a command.
@@ -76,9 +82,24 @@ func ErrInvalidExpireTimeError() error {
 	return newRESPWrappedError("ERR", ErrInvalidExpireTime)
 }
 
+// ErrInvalidStreamIDError reports that a stream ID argument could not be parsed.
+func ErrInvalidStreamIDError() error {
+	return newRESPWrappedError("ERR", ErrInvalidStreamID)
+}
+
+// ErrStreamIDTooSmallError reports that XADD received a non-monotonic explicit ID.
+func ErrStreamIDTooSmallError() error {
+	return newRESPError("ERR", "The ID specified in XADD is equal or smaller than the target stream top item", ErrStreamIDTooSmall)
+}
+
 // ErrValueNotIntegerError reports that a string value cannot be incremented.
 func ErrValueNotIntegerError() error {
 	return newRESPWrappedError("ERR", ErrValueNotInteger)
+}
+
+// ErrValueNotFloatError reports that a score could not be parsed as a float.
+func ErrValueNotFloatError() error {
+	return newRESPWrappedError("ERR", ErrValueNotFloat)
 }
 
 // ErrWrongTypeError reports a Redis-style wrong-type failure.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -32,12 +32,20 @@ func NewExecutor(store *storage.Store, logger *slog.Logger) *Executor {
 		logger: logger,
 	}
 	executor.handlers = map[string]Handler{
-		"PING": executor.handlePing,
-		"ECHO": executor.handleEcho,
-		"SET":  executor.handleSet,
-		"GET":  executor.handleGet,
-		"DEL":  executor.handleDel,
-		"INCR": executor.handleIncr,
+		"PING":   executor.handlePing,
+		"ECHO":   executor.handleEcho,
+		"SET":    executor.handleSet,
+		"GET":    executor.handleGet,
+		"DEL":    executor.handleDel,
+		"INCR":   executor.handleIncr,
+		"LPUSH":  executor.handleLPush,
+		"RPUSH":  executor.handleRPush,
+		"LRANGE": executor.handleLRange,
+		"BLPOP":  executor.handleBLPop,
+		"ZADD":   executor.handleZAdd,
+		"ZRANGE": executor.handleZRange,
+		"XADD":   executor.handleXAdd,
+		"XREAD":  executor.handleXRead,
 	}
 	return executor
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -55,6 +55,9 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 
 		response, execErr := s.executor.Execute(ctx, value)
 		if execErr != nil {
+			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
+				return
+			}
 			logger.Debug("command execution failed", "error", execErr)
 			response = responseError(execErr)
 		}

--- a/internal/storage/list_waiters.go
+++ b/internal/storage/list_waiters.go
@@ -1,0 +1,64 @@
+package storage
+
+import "sync"
+
+type listWaiters struct {
+	mu      sync.Mutex
+	waiters map[string][]chan struct{}
+}
+
+func newListWaiters() *listWaiters {
+	return &listWaiters{waiters: make(map[string][]chan struct{})}
+}
+
+func (w *listWaiters) subscribe(key string) chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	ch := make(chan struct{}, 1)
+	w.waiters[key] = append(w.waiters[key], ch)
+	return ch
+}
+
+func (w *listWaiters) unsubscribe(key string, ch chan struct{}) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	waiters := w.waiters[key]
+	for i, waiter := range waiters {
+		if waiter != ch {
+			continue
+		}
+
+		waiters = append(waiters[:i], waiters[i+1:]...)
+		if len(waiters) == 0 {
+			delete(w.waiters, key)
+		} else {
+			w.waiters[key] = waiters
+		}
+		return
+	}
+}
+
+func (w *listWaiters) notifyOne(key string) {
+	w.mu.Lock()
+	waiters := w.waiters[key]
+	if len(waiters) == 0 {
+		w.mu.Unlock()
+		return
+	}
+
+	ch := waiters[0]
+	remaining := append(waiters[:0:0], waiters[1:]...)
+	if len(remaining) == 0 {
+		delete(w.waiters, key)
+	} else {
+		w.waiters[key] = remaining
+	}
+	w.mu.Unlock()
+
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -137,7 +137,8 @@ func (s *Store) LeftPop(key string) ([]byte, bool, error) {
 	}
 
 	item := cloneBytes(value.List[0])
-	value.List = cloneList(value.List[1:])
+	value.List[0] = nil
+	value.List = value.List[1:]
 	if len(value.List) == 0 {
 		delete(s.data, key)
 	} else {
@@ -240,7 +241,7 @@ func (s *Store) ZRange(key string, start, stop int64) ([]ZSetEntry, error) {
 	raw := value.ZSet.rangeByRank(from, to)
 	entries := make([]ZSetEntry, 0, len(raw))
 	for _, item := range raw {
-		entries = append(entries, ZSetEntry{Member: cloneBytes([]byte(item.member)), Score: item.score})
+		entries = append(entries, ZSetEntry{Member: []byte(item.member), Score: item.score})
 	}
 	s.mu.RUnlock()
 
@@ -405,13 +406,17 @@ func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) 
 
 	additions := cloneList(values)
 	if left {
-		prefix := make([][]byte, len(additions))
-		for i := range additions {
-			prefix[len(additions)-1-i] = additions[i]
+		combined := make([][]byte, 0, len(list)+len(additions))
+		for i := len(additions) - 1; i >= 0; i-- {
+			combined = append(combined, additions[i])
 		}
-		list = append(prefix, list...)
+		combined = append(combined, list...)
+		list = combined
 	} else {
-		list = append(cloneList(list), additions...)
+		combined := make([][]byte, 0, len(list)+len(additions))
+		combined = append(combined, list...)
+		combined = append(combined, additions...)
+		list = combined
 	}
 
 	s.data[key] = newListValue(list, expiresAt)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -14,21 +14,28 @@ var (
 	ErrSyntax = errors.New("syntax error")
 	// ErrInvalidExpireTime reports an invalid EX/PX duration.
 	ErrInvalidExpireTime = errors.New("invalid expire time in 'SET' command")
+	// ErrInvalidStreamID reports that a stream ID could not be parsed.
+	ErrInvalidStreamID = errors.New("invalid stream ID specified as stream command argument")
+	// ErrStreamIDTooSmall reports that XADD was given a non-monotonic explicit ID.
+	ErrStreamIDTooSmall = errors.New("stream ID is equal or smaller than the target stream top item")
 	// ErrValueNotInteger reports that a stored string cannot be parsed as a 64-bit integer.
 	ErrValueNotInteger = errors.New("value is not an integer or out of range")
+	// ErrValueNotFloat reports that a command argument is not a valid float.
+	ErrValueNotFloat = errors.New("value is not a valid float")
 	// ErrWrongType reports that a command targeted the wrong logical value type.
 	ErrWrongType = errors.New("operation against a key holding the wrong kind of value")
 )
 
 // Store is a thread-safe in-memory key/value store.
 type Store struct {
-	mu   sync.RWMutex
-	data map[string]StoredValue
+	mu      sync.RWMutex
+	data    map[string]StoredValue
+	waiters *listWaiters
 }
 
 // NewStore constructs an empty Store.
 func NewStore() *Store {
-	return &Store{data: make(map[string]StoredValue)}
+	return &Store{data: make(map[string]StoredValue), waiters: newListWaiters()}
 }
 
 // Set stores a byte slice under the provided key.
@@ -36,41 +43,20 @@ func (s *Store) Set(key string, value []byte, expiresAt int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.data[key] = StoredValue{
-		Data:      cloneBytes(value),
-		ExpiresAt: expiresAt,
-		Kind:      ValueKindString,
-	}
+	s.data[key] = newStringValue(value, expiresAt)
 }
 
 // Get fetches a value from the store, passively evicting it if it has expired.
-func (s *Store) Get(key string) ([]byte, bool) {
-	now := time.Now().UnixMilli()
-
-	s.mu.RLock()
-	value, ok := s.data[key]
-	s.mu.RUnlock()
+func (s *Store) Get(key string) ([]byte, bool, error) {
+	value, ok := s.loadValue(key)
 	if !ok {
-		return nil, false
+		return nil, false, nil
+	}
+	if value.Kind != ValueKindString {
+		return nil, true, ErrWrongType
 	}
 
-	if !isExpired(value, now) {
-		return cloneBytes(value.Data), true
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	value, ok = s.data[key]
-	if !ok || !isExpired(value, time.Now().UnixMilli()) {
-		if ok {
-			return cloneBytes(value.Data), true
-		}
-		return nil, false
-	}
-
-	delete(s.data, key)
-	return nil, false
+	return cloneBytes(value.String), true, nil
 }
 
 // Delete removes a key from the store.
@@ -101,22 +87,247 @@ func (s *Store) Increment(key string) (int64, error) {
 	}
 
 	if !ok {
-		s.data[key] = StoredValue{Data: []byte("1"), Kind: ValueKindString}
+		s.data[key] = newStringValue([]byte("1"), 0)
 		return 1, nil
 	}
 	if value.Kind != ValueKindString {
 		return 0, ErrWrongType
 	}
 
-	current, err := strconv.ParseInt(string(value.Data), 10, 64)
+	current, err := strconv.ParseInt(string(value.String), 10, 64)
 	if err != nil || current == math.MaxInt64 {
 		return 0, ErrValueNotInteger
 	}
 
 	current++
-	value.Data = []byte(strconv.FormatInt(current, 10))
+	value.String = []byte(strconv.FormatInt(current, 10))
 	s.data[key] = value
 	return current, nil
+}
+
+// LeftPush prepends one or more values to the list stored at key and returns the new length.
+func (s *Store) LeftPush(key string, values [][]byte) (int64, error) {
+	return s.pushList(key, values, true)
+}
+
+// RightPush appends one or more values to the list stored at key and returns the new length.
+func (s *Store) RightPush(key string, values [][]byte) (int64, error) {
+	return s.pushList(key, values, false)
+}
+
+// LeftPop removes and returns the left-most value from the list stored at key.
+func (s *Store) LeftPop(key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.data[key]
+	if ok && isExpired(value, time.Now().UnixMilli()) {
+		delete(s.data, key)
+		ok = false
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	if value.Kind != ValueKindList {
+		return nil, false, ErrWrongType
+	}
+	if len(value.List) == 0 {
+		delete(s.data, key)
+		return nil, false, nil
+	}
+
+	item := cloneBytes(value.List[0])
+	value.List = cloneList(value.List[1:])
+	if len(value.List) == 0 {
+		delete(s.data, key)
+	} else {
+		s.data[key] = value
+	}
+
+	return item, true, nil
+}
+
+// ListRange returns an inclusive range of values from the list stored at key.
+func (s *Store) ListRange(key string, start, stop int64) ([][]byte, error) {
+	value, ok := s.loadValue(key)
+	if !ok {
+		return [][]byte{}, nil
+	}
+	if value.Kind != ValueKindList {
+		return nil, ErrWrongType
+	}
+
+	from, to, ok := normalizeListRange(len(value.List), start, stop)
+	if !ok {
+		return [][]byte{}, nil
+	}
+
+	return cloneList(value.List[from : to+1]), nil
+}
+
+// ZAdd inserts or updates one or more sorted-set members and returns the number of newly added members.
+func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
+	if len(entries) == 0 {
+		return 0, ErrSyntax
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.data[key]
+	if ok && isExpired(value, time.Now().UnixMilli()) {
+		delete(s.data, key)
+		ok = false
+	}
+
+	var (
+		set       *sortedSet
+		expiresAt int64
+	)
+	if ok {
+		if value.Kind != ValueKindZSet {
+			return 0, ErrWrongType
+		}
+		set = value.ZSet
+		expiresAt = value.ExpiresAt
+	} else {
+		set = newSortedSet()
+	}
+
+	added := int64(0)
+	for _, entry := range entries {
+		if set.add(string(entry.Member), entry.Score) {
+			added++
+		}
+	}
+
+	s.data[key] = newZSetValue(set, expiresAt)
+	return added, nil
+}
+
+// ZRange returns an inclusive rank range from the sorted set stored at key.
+func (s *Store) ZRange(key string, start, stop int64) ([]ZSetEntry, error) {
+	now := time.Now().UnixMilli()
+
+	s.mu.RLock()
+	value, ok := s.data[key]
+	if !ok {
+		s.mu.RUnlock()
+		return []ZSetEntry{}, nil
+	}
+	if isExpired(value, now) {
+		s.mu.RUnlock()
+
+		s.mu.Lock()
+		value, ok = s.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			delete(s.data, key)
+		}
+		s.mu.Unlock()
+		return []ZSetEntry{}, nil
+	}
+	if value.Kind != ValueKindZSet {
+		s.mu.RUnlock()
+		return nil, ErrWrongType
+	}
+
+	from, to, ok := normalizeListRange(value.ZSet.len(), start, stop)
+	if !ok {
+		s.mu.RUnlock()
+		return []ZSetEntry{}, nil
+	}
+
+	raw := value.ZSet.rangeByRank(from, to)
+	entries := make([]ZSetEntry, 0, len(raw))
+	for _, item := range raw {
+		entries = append(entries, ZSetEntry{Member: cloneBytes([]byte(item.member)), Score: item.score})
+	}
+	s.mu.RUnlock()
+
+	return entries, nil
+}
+
+// XAdd appends a new stream entry to the stream stored at key and returns its ID.
+func (s *Store) XAdd(key, rawID string, values [][]byte) (string, error) {
+	if len(values) == 0 || len(values)%2 != 0 {
+		return "", ErrSyntax
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.data[key]
+	if ok && isExpired(value, time.Now().UnixMilli()) {
+		delete(s.data, key)
+		ok = false
+	}
+
+	var (
+		stream    *streamValue
+		expiresAt int64
+	)
+	if ok {
+		if value.Kind != ValueKindStream {
+			return "", ErrWrongType
+		}
+		stream = value.Stream
+		expiresAt = value.ExpiresAt
+	} else {
+		stream = newStream()
+	}
+
+	id, err := stream.add(rawID, values, time.Now().UnixMilli())
+	if err != nil {
+		return "", err
+	}
+
+	s.data[key] = newStreamValue(stream, expiresAt)
+	return id, nil
+}
+
+// XRead returns stream entries whose IDs are greater than the supplied ID.
+func (s *Store) XRead(key, rawID string) ([]StreamEntry, error) {
+	now := time.Now().UnixMilli()
+
+	s.mu.RLock()
+	value, ok := s.data[key]
+	if !ok {
+		s.mu.RUnlock()
+		return []StreamEntry{}, nil
+	}
+	if isExpired(value, now) {
+		s.mu.RUnlock()
+
+		s.mu.Lock()
+		value, ok = s.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			delete(s.data, key)
+		}
+		s.mu.Unlock()
+		return []StreamEntry{}, nil
+	}
+	if value.Kind != ValueKindStream {
+		s.mu.RUnlock()
+		return nil, ErrWrongType
+	}
+
+	entries, err := value.Stream.readAfter(rawID)
+	s.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// SubscribeListPush registers a waiter that is notified when a push occurs for key.
+func (s *Store) SubscribeListPush(key string) chan struct{} {
+	return s.waiters.subscribe(key)
+}
+
+// UnsubscribeListPush removes a previously registered list push waiter.
+func (s *Store) UnsubscribeListPush(key string, ch chan struct{}) {
+	s.waiters.unsubscribe(key, ch)
 }
 
 // Len returns the current number of stored keys.
@@ -154,6 +365,124 @@ func cloneBytes(src []byte) []byte {
 	dst := make([]byte, len(src))
 	copy(dst, src)
 	return dst
+}
+
+func cloneList(items [][]byte) [][]byte {
+	if items == nil {
+		return nil
+	}
+
+	cloned := make([][]byte, len(items))
+	for i, item := range items {
+		cloned[i] = cloneBytes(item)
+	}
+
+	return cloned
+}
+
+func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) {
+	if len(values) == 0 {
+		return 0, ErrSyntax
+	}
+
+	s.mu.Lock()
+	value, ok := s.data[key]
+	if ok && isExpired(value, time.Now().UnixMilli()) {
+		delete(s.data, key)
+		ok = false
+	}
+
+	var list [][]byte
+	var expiresAt int64
+	if ok {
+		if value.Kind != ValueKindList {
+			s.mu.Unlock()
+			return 0, ErrWrongType
+		}
+		list = value.List
+		expiresAt = value.ExpiresAt
+	}
+
+	additions := cloneList(values)
+	if left {
+		prefix := make([][]byte, len(additions))
+		for i := range additions {
+			prefix[len(additions)-1-i] = additions[i]
+		}
+		list = append(prefix, list...)
+	} else {
+		list = append(cloneList(list), additions...)
+	}
+
+	s.data[key] = newListValue(list, expiresAt)
+	newLen := int64(len(list))
+	s.mu.Unlock()
+
+	s.waiters.notifyOne(key)
+	return newLen, nil
+}
+
+func (s *Store) loadValue(key string) (StoredValue, bool) {
+	now := time.Now().UnixMilli()
+
+	s.mu.RLock()
+	value, ok := s.data[key]
+	s.mu.RUnlock()
+	if !ok {
+		return StoredValue{}, false
+	}
+
+	if !isExpired(value, now) {
+		return value, true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok = s.data[key]
+	if !ok {
+		return StoredValue{}, false
+	}
+	if !isExpired(value, time.Now().UnixMilli()) {
+		return value, true
+	}
+
+	delete(s.data, key)
+	return StoredValue{}, false
+}
+
+func normalizeListRange(length int, start, stop int64) (int, int, bool) {
+	if length == 0 {
+		return 0, 0, false
+	}
+
+	from := normalizeListIndex(length, start)
+	to := normalizeListIndex(length, stop)
+	if from < 0 {
+		from = 0
+	}
+	if to < 0 {
+		return 0, 0, false
+	}
+	if from >= length {
+		return 0, 0, false
+	}
+	if to >= length {
+		to = length - 1
+	}
+	if from > to {
+		return 0, 0, false
+	}
+
+	return from, to, true
+}
+
+func normalizeListIndex(length int, index int64) int {
+	if index < 0 {
+		return length + int(index)
+	}
+
+	return int(index)
 }
 
 func isExpired(value StoredValue, now int64) bool {

--- a/internal/storage/store_benchmark_test.go
+++ b/internal/storage/store_benchmark_test.go
@@ -26,7 +26,9 @@ func BenchmarkStore(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
-			if _, ok := store.Get("hot"); !ok {
+			if _, ok, err := store.Get("hot"); err != nil {
+				b.Fatalf("Get() error = %v", err)
+			} else if !ok {
 				b.Fatal("Get() ok = false, want true")
 			}
 		}
@@ -37,7 +39,9 @@ func BenchmarkStore(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
-			if _, ok := store.Get("missing"); ok {
+			if _, ok, err := store.Get("missing"); err != nil {
+				b.Fatalf("Get() error = %v", err)
+			} else if ok {
 				b.Fatal("Get() ok = true, want false")
 			}
 		}
@@ -50,7 +54,9 @@ func BenchmarkStore(b *testing.B) {
 
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				if _, ok := store.Get("hot"); !ok {
+				if _, ok, err := store.Get("hot"); err != nil {
+					b.Fatalf("Get() error = %v", err)
+				} else if !ok {
 					b.Fatal("Get() ok = false, want true")
 				}
 			}
@@ -80,7 +86,7 @@ func BenchmarkStore(b *testing.B) {
 				case 0:
 					store.Set("hot", payload, 0)
 				case 1:
-					_, _ = store.Get("hot")
+					_, _, _ = store.Get("hot")
 				default:
 					_ = store.Delete("hot")
 				}
@@ -97,7 +103,7 @@ func BenchmarkStore(b *testing.B) {
 			for pb.Next() {
 				key := fmt.Sprintf("key-%d", counter.Add(1)%128)
 				store.Set(key, payload, 0)
-				_, _ = store.Get(key)
+				_, _, _ = store.Get(key)
 			}
 		})
 	})
@@ -109,7 +115,7 @@ func BenchmarkStore(b *testing.B) {
 
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				_, _ = store.Get("expired")
+				_, _, _ = store.Get("expired")
 			}
 		})
 	})
@@ -128,7 +134,7 @@ func BenchmarkStore(b *testing.B) {
 				key := fmt.Sprintf("ttl-%d", index%64)
 				expiresAt := time.Now().Add(2 * time.Millisecond).UnixMilli()
 				store.Set(key, payload, expiresAt)
-				_, _ = store.Get(key)
+				_, _, _ = store.Get(key)
 			}
 		})
 	})

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -22,7 +23,10 @@ func TestStoreValueBehavior(t *testing.T) {
 				store.Set("greeting", payload, 0)
 				payload[0] = 'H'
 
-				got, ok := store.Get("greeting")
+				got, ok, err := store.Get("greeting")
+				if err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
 				if !ok {
 					t.Fatal("Get() ok = false, want true")
 				}
@@ -37,7 +41,9 @@ func TestStoreValueBehavior(t *testing.T) {
 				t.Helper()
 				store.Set("expired", []byte("value"), time.Now().Add(-time.Millisecond).UnixMilli())
 
-				if _, ok := store.Get("expired"); ok {
+				if _, ok, err := store.Get("expired"); err != nil {
+					t.Fatalf("Get() error = %v", err)
+				} else if ok {
 					t.Fatal("Get() ok = true, want false for expired key")
 				}
 				if store.Len() != 0 {
@@ -92,6 +98,19 @@ func TestStoreValueBehavior(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Get rejects list values with wrong type",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+				if _, err := store.LeftPush("numbers", [][]byte{[]byte("one")}); err != nil {
+					t.Fatalf("LeftPush() error = %v", err)
+				}
+
+				if _, _, err := store.Get("numbers"); err != ErrWrongType {
+					t.Fatalf("Get() error = %v, want ErrWrongType", err)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -137,7 +156,10 @@ func TestStoreConcurrentAccess(t *testing.T) {
 			key := fmt.Sprintf("key-%d", i)
 			for j := 0; j < 100; j++ {
 				store.Set(key, []byte(strconv.Itoa(j)), 0)
-				if _, ok := store.Get(key); !ok {
+				if _, ok, err := store.Get(key); err != nil {
+					t.Errorf("Get(%q) error = %v", key, err)
+					return
+				} else if !ok {
 					t.Errorf("Get(%q) ok = false, want true", key)
 					return
 				}
@@ -150,4 +172,521 @@ func TestStoreConcurrentAccess(t *testing.T) {
 	if store.Len() == 0 {
 		t.Fatal("Len() = 0, want at least one stored key")
 	}
+}
+
+func TestStoreListBehavior(t *testing.T) {
+	t.Run("LeftPush and RightPush preserve Redis-style ordering", func(t *testing.T) {
+		store := NewStore()
+
+		length, err := store.LeftPush("letters", [][]byte{[]byte("a"), []byte("b")})
+		if err != nil {
+			t.Fatalf("LeftPush() error = %v", err)
+		}
+		if length != 2 {
+			t.Fatalf("LeftPush() length = %d, want 2", length)
+		}
+
+		length, err = store.RightPush("letters", [][]byte{[]byte("c"), []byte("d")})
+		if err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+		if length != 4 {
+			t.Fatalf("RightPush() length = %d, want 4", length)
+		}
+
+		values, err := store.ListRange("letters", 0, -1)
+		if err != nil {
+			t.Fatalf("ListRange() error = %v", err)
+		}
+
+		want := []string{"b", "a", "c", "d"}
+		if len(values) != len(want) {
+			t.Fatalf("len(ListRange()) = %d, want %d", len(values), len(want))
+		}
+		for i, got := range values {
+			if string(got) != want[i] {
+				t.Fatalf("ListRange()[%d] = %q, want %q", i, string(got), want[i])
+			}
+		}
+	})
+
+	t.Run("ListRange supports negative indexes", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.RightPush("numbers", [][]byte{[]byte("1"), []byte("2"), []byte("3"), []byte("4")}); err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+
+		values, err := store.ListRange("numbers", -2, -1)
+		if err != nil {
+			t.Fatalf("ListRange() error = %v", err)
+		}
+		want := []string{"3", "4"}
+		for i, got := range values {
+			if string(got) != want[i] {
+				t.Fatalf("ListRange()[%d] = %q, want %q", i, string(got), want[i])
+			}
+		}
+	})
+
+	t.Run("LeftPop removes head and clears empty list key", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.RightPush("jobs", [][]byte{[]byte("one")}); err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+
+		value, ok, err := store.LeftPop("jobs")
+		if err != nil {
+			t.Fatalf("LeftPop() error = %v", err)
+		}
+		if !ok || string(value) != "one" {
+			t.Fatalf("LeftPop() = (%q, %v), want (%q, true)", string(value), ok, "one")
+		}
+		if store.Len() != 0 {
+			t.Fatalf("Len() = %d, want 0 after popping final list element", store.Len())
+		}
+	})
+
+	t.Run("List push notifies one waiter and unsubscribe stops notifications", func(t *testing.T) {
+		store := NewStore()
+		waiter := store.SubscribeListPush("events")
+
+		if _, err := store.RightPush("events", [][]byte{[]byte("first")}); err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+
+		select {
+		case <-waiter:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("waiter did not receive notification")
+		}
+
+		waiter = store.SubscribeListPush("events")
+		store.UnsubscribeListPush("events", waiter)
+		if _, err := store.RightPush("events", [][]byte{[]byte("second")}); err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+
+		select {
+		case <-waiter:
+			t.Fatal("received notification after unsubscribe")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+}
+
+func TestStoreSortedSetBehavior(t *testing.T) {
+	t.Run("ZAdd and ZRange order by score then member", func(t *testing.T) {
+		store := NewStore()
+
+		added, err := store.ZAdd("leaders", []ZSetEntry{
+			{Member: []byte("beta"), Score: 2},
+			{Member: []byte("alpha"), Score: 1},
+			{Member: []byte("aardvark"), Score: 2},
+		})
+		if err != nil {
+			t.Fatalf("ZAdd() error = %v", err)
+		}
+		if added != 3 {
+			t.Fatalf("ZAdd() added = %d, want 3", added)
+		}
+
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() error = %v", err)
+		}
+
+		wantMembers := []string{"alpha", "aardvark", "beta"}
+		wantScores := []float64{1, 2, 2}
+		if len(values) != len(wantMembers) {
+			t.Fatalf("len(ZRange()) = %d, want %d", len(values), len(wantMembers))
+		}
+		for i, got := range values {
+			if string(got.Member) != wantMembers[i] {
+				t.Fatalf("ZRange()[%d].Member = %q, want %q", i, string(got.Member), wantMembers[i])
+			}
+			if got.Score != wantScores[i] {
+				t.Fatalf("ZRange()[%d].Score = %v, want %v", i, got.Score, wantScores[i])
+			}
+		}
+	})
+
+	t.Run("ZAdd updates existing members without increasing added count", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("alpha"), Score: 1}, {Member: []byte("beta"), Score: 2}}); err != nil {
+			t.Fatalf("ZAdd() initial error = %v", err)
+		}
+
+		added, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("beta"), Score: 0.5}})
+		if err != nil {
+			t.Fatalf("ZAdd() update error = %v", err)
+		}
+		if added != 0 {
+			t.Fatalf("ZAdd() added = %d, want 0", added)
+		}
+
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() error = %v", err)
+		}
+		want := []string{"beta", "alpha"}
+		for i, got := range values {
+			if string(got.Member) != want[i] {
+				t.Fatalf("ZRange()[%d].Member = %q, want %q", i, string(got.Member), want[i])
+			}
+		}
+	})
+
+	t.Run("ZRange supports negative indexes", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.ZAdd("leaders", []ZSetEntry{
+			{Member: []byte("alpha"), Score: 1},
+			{Member: []byte("beta"), Score: 2},
+			{Member: []byte("charlie"), Score: 3},
+		}); err != nil {
+			t.Fatalf("ZAdd() error = %v", err)
+		}
+
+		values, err := store.ZRange("leaders", -2, -1)
+		if err != nil {
+			t.Fatalf("ZRange() error = %v", err)
+		}
+		want := []string{"beta", "charlie"}
+		for i, got := range values {
+			if string(got.Member) != want[i] {
+				t.Fatalf("ZRange()[%d].Member = %q, want %q", i, string(got.Member), want[i])
+			}
+		}
+	})
+
+	t.Run("ZRange rejects wrong value type", func(t *testing.T) {
+		store := NewStore()
+		store.Set("leaders", []byte("hello"), 0)
+
+		if _, err := store.ZRange("leaders", 0, -1); err != ErrWrongType {
+			t.Fatalf("ZRange() error = %v, want ErrWrongType", err)
+		}
+	})
+
+	t.Run("ZAdd recreates expired key", func(t *testing.T) {
+		store := NewStore()
+		store.Set("leaders", []byte("stale"), time.Now().Add(-time.Millisecond).UnixMilli())
+
+		added, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("fresh"), Score: 1}})
+		if err != nil {
+			t.Fatalf("ZAdd() error = %v", err)
+		}
+		if added != 1 {
+			t.Fatalf("ZAdd() added = %d, want 1", added)
+		}
+
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() error = %v", err)
+		}
+		if len(values) != 1 || string(values[0].Member) != "fresh" {
+			t.Fatalf("ZRange() = %#v, want fresh member", values)
+		}
+	})
+}
+
+func TestStoreStreamBehavior(t *testing.T) {
+	t.Run("XAdd and XRead preserve append order and field values", func(t *testing.T) {
+		store := NewStore()
+
+		firstID, err := store.XAdd("events", "1-0", [][]byte{[]byte("type"), []byte("start")})
+		if err != nil {
+			t.Fatalf("XAdd() first error = %v", err)
+		}
+		if firstID != "1-0" {
+			t.Fatalf("XAdd() first ID = %q, want %q", firstID, "1-0")
+		}
+
+		secondID, err := store.XAdd("events", "2-0", [][]byte{[]byte("type"), []byte("finish"), []byte("user"), []byte("42")})
+		if err != nil {
+			t.Fatalf("XAdd() second error = %v", err)
+		}
+		if secondID != "2-0" {
+			t.Fatalf("XAdd() second ID = %q, want %q", secondID, "2-0")
+		}
+
+		entries, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("len(XRead()) = %d, want 2", len(entries))
+		}
+		if entries[0].ID != "1-0" || entries[1].ID != "2-0" {
+			t.Fatalf("XRead() IDs = [%q, %q], want [%q, %q]", entries[0].ID, entries[1].ID, "1-0", "2-0")
+		}
+		if got := string(entries[1].Values[0]); got != "type" {
+			t.Fatalf("entries[1].Values[0] = %q, want %q", got, "type")
+		}
+		if got := string(entries[1].Values[1]); got != "finish" {
+			t.Fatalf("entries[1].Values[1] = %q, want %q", got, "finish")
+		}
+		if got := string(entries[1].Values[2]); got != "user" {
+			t.Fatalf("entries[1].Values[2] = %q, want %q", got, "user")
+		}
+		if got := string(entries[1].Values[3]); got != "42" {
+			t.Fatalf("entries[1].Values[3] = %q, want %q", got, "42")
+		}
+	})
+
+	t.Run("XAdd auto generated IDs increment sequence in same millisecond", func(t *testing.T) {
+		stream := newStream()
+
+		firstID, err := stream.add("*", [][]byte{[]byte("field"), []byte("one")}, 100)
+		if err != nil {
+			t.Fatalf("stream.add() first error = %v", err)
+		}
+		secondID, err := stream.add("*", [][]byte{[]byte("field"), []byte("two")}, 100)
+		if err != nil {
+			t.Fatalf("stream.add() second error = %v", err)
+		}
+		thirdID, err := stream.add("*", [][]byte{[]byte("field"), []byte("three")}, 101)
+		if err != nil {
+			t.Fatalf("stream.add() third error = %v", err)
+		}
+
+		if firstID != "100-0" {
+			t.Fatalf("first auto ID = %q, want %q", firstID, "100-0")
+		}
+		if secondID != "100-1" {
+			t.Fatalf("second auto ID = %q, want %q", secondID, "100-1")
+		}
+		if thirdID != "101-0" {
+			t.Fatalf("third auto ID = %q, want %q", thirdID, "101-0")
+		}
+	})
+
+	t.Run("XRead supports dollar special ID and bare millisecond IDs", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("one")}); err != nil {
+			t.Fatalf("XAdd() first error = %v", err)
+		}
+		if _, err := store.XAdd("events", "2-0", [][]byte{[]byte("field"), []byte("two")}); err != nil {
+			t.Fatalf("XAdd() second error = %v", err)
+		}
+
+		entries, err := store.XRead("events", "$")
+		if err != nil {
+			t.Fatalf("XRead($) error = %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("len(XRead($)) = %d, want 0", len(entries))
+		}
+
+		entries, err = store.XRead("events", "1")
+		if err != nil {
+			t.Fatalf("XRead(1) error = %v", err)
+		}
+		if len(entries) != 1 || entries[0].ID != "2-0" {
+			t.Fatalf("XRead(1) = %#v, want one entry with ID 2-0", entries)
+		}
+	})
+
+	t.Run("XAdd rejects malformed or non monotonic IDs", func(t *testing.T) {
+		store := NewStore()
+
+		if _, err := store.XAdd("events", "not-an-id", [][]byte{[]byte("field"), []byte("value")}); err != ErrInvalidStreamID {
+			t.Fatalf("XAdd() invalid ID error = %v, want ErrInvalidStreamID", err)
+		}
+		if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("value")}); err != nil {
+			t.Fatalf("XAdd() initial error = %v", err)
+		}
+		if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("value")}); err != ErrStreamIDTooSmall {
+			t.Fatalf("XAdd() non monotonic error = %v, want ErrStreamIDTooSmall", err)
+		}
+	})
+
+	t.Run("XRead rejects wrong value type", func(t *testing.T) {
+		store := NewStore()
+		store.Set("events", []byte("plain"), 0)
+
+		if _, err := store.XRead("events", "0-0"); err != ErrWrongType {
+			t.Fatalf("XRead() error = %v, want ErrWrongType", err)
+		}
+	})
+
+	t.Run("XAdd recreates expired stream key", func(t *testing.T) {
+		store := NewStore()
+		store.data["events"] = newStreamValue(newStream(), time.Now().Add(-time.Millisecond).UnixMilli())
+
+		id, err := store.XAdd("events", "5-0", [][]byte{[]byte("field"), []byte("value")})
+		if err != nil {
+			t.Fatalf("XAdd() error = %v", err)
+		}
+		if id != "5-0" {
+			t.Fatalf("XAdd() ID = %q, want %q", id, "5-0")
+		}
+
+		entries, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+		if len(entries) != 1 || entries[0].ID != "5-0" {
+			t.Fatalf("XRead() = %#v, want single fresh entry", entries)
+		}
+	})
+
+	t.Run("concurrent XAdd keeps stream IDs strictly increasing", func(t *testing.T) {
+		store := NewStore()
+
+		const writers = 32
+		var wg sync.WaitGroup
+		ids := make(chan string, writers)
+		errs := make(chan error, writers)
+
+		for i := 0; i < writers; i++ {
+			i := i
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				id, err := store.XAdd("events", "*", [][]byte{[]byte("writer"), []byte(strconv.Itoa(i))})
+				if err != nil {
+					errs <- err
+					return
+				}
+				ids <- id
+			}()
+		}
+
+		wg.Wait()
+		close(ids)
+		close(errs)
+
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent XAdd() error = %v", err)
+			}
+		}
+
+		seen := map[string]struct{}{}
+		for id := range ids {
+			if _, ok := seen[id]; ok {
+				t.Fatalf("duplicate ID generated: %q", id)
+			}
+			seen[id] = struct{}{}
+		}
+
+		entries, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+		if len(entries) != writers {
+			t.Fatalf("len(XRead()) = %d, want %d", len(entries), writers)
+		}
+
+		last := streamID{}
+		for i, entry := range entries {
+			current, err := parseStreamAddID(entry.ID)
+			if err != nil {
+				t.Fatalf("parseStreamAddID(%q) error = %v", entry.ID, err)
+			}
+			if i > 0 && compareStreamIDs(current, last) <= 0 {
+				t.Fatalf("entry ID %q is not greater than previous ID %q", entry.ID, last.String())
+			}
+			last = current
+		}
+	})
+
+	t.Run("concurrent XAdd and XRead do not race", func(t *testing.T) {
+		store := NewStore()
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		errCh := make(chan error, 2)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 128; i++ {
+				if _, err := store.XAdd("events", "*", [][]byte{[]byte("field"), []byte(strconv.Itoa(i))}); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 128; i++ {
+				if _, err := store.XRead("events", "0-0"); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			if err != nil {
+				t.Fatalf("concurrent stream access error = %v", err)
+			}
+		}
+	})
+
+	t.Run("XAdd copies caller provided values", func(t *testing.T) {
+		store := NewStore()
+		payload := [][]byte{[]byte("field"), []byte("value")}
+
+		if _, err := store.XAdd("events", "1-0", payload); err != nil {
+			t.Fatalf("XAdd() error = %v", err)
+		}
+		payload[0][0] = 'F'
+		payload[1][0] = 'V'
+
+		entries, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+		if got := string(entries[0].Values[0]); got != "field" {
+			t.Fatalf("entries[0].Values[0] = %q, want %q", got, "field")
+		}
+		if got := string(entries[0].Values[1]); got != "value" {
+			t.Fatalf("entries[0].Values[1] = %q, want %q", got, "value")
+		}
+	})
+
+	t.Run("XRead returns empty for missing stream", func(t *testing.T) {
+		store := NewStore()
+
+		entries, err := store.XRead("missing", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("len(XRead()) = %d, want 0", len(entries))
+		}
+	})
+
+	t.Run("XRead rejects malformed IDs", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("value")}); err != nil {
+			t.Fatalf("XAdd() error = %v", err)
+		}
+
+		_, err := store.XRead("events", "bad-id")
+		if err != ErrInvalidStreamID {
+			t.Fatalf("XRead() error = %v, want ErrInvalidStreamID", err)
+		}
+	})
+
+	t.Run("XAdd returns full millisecond sequence IDs", func(t *testing.T) {
+		store := NewStore()
+		id, err := store.XAdd("events", "*", [][]byte{[]byte("field"), []byte("value")})
+		if err != nil {
+			t.Fatalf("XAdd() error = %v", err)
+		}
+		if parts := strings.Split(id, "-"); len(parts) != 2 {
+			t.Fatalf("generated ID = %q, want <milliseconds>-<sequence>", id)
+		}
+	})
 }

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -1,0 +1,152 @@
+package storage
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type streamID struct {
+	milliseconds int64
+	sequence     int64
+}
+
+type streamRecord struct {
+	id     streamID
+	values [][]byte
+}
+
+type streamValue struct {
+	entries    []streamRecord
+	lastID     streamID
+	hasEntries bool
+}
+
+func newStream() *streamValue {
+	return &streamValue{}
+}
+
+func (s *streamValue) add(rawID string, values [][]byte, nowMillis int64) (string, error) {
+	var (
+		id  streamID
+		err error
+	)
+
+	if rawID == "*" {
+		id = s.nextAutoID(nowMillis)
+	} else {
+		id, err = parseStreamAddID(rawID)
+		if err != nil {
+			return "", err
+		}
+		if s.hasEntries && compareStreamIDs(id, s.lastID) <= 0 {
+			return "", ErrStreamIDTooSmall
+		}
+	}
+
+	s.entries = append(s.entries, streamRecord{id: id, values: cloneList(values)})
+	s.lastID = id
+	s.hasEntries = true
+
+	return id.String(), nil
+}
+
+func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
+	if len(s.entries) == 0 {
+		return []StreamEntry{}, nil
+	}
+
+	after, err := parseStreamReadID(rawID, s.lastID)
+	if err != nil {
+		return nil, err
+	}
+
+	start := sort.Search(len(s.entries), func(i int) bool {
+		return compareStreamIDs(s.entries[i].id, after) > 0
+	})
+
+	entries := make([]StreamEntry, 0, len(s.entries)-start)
+	for _, entry := range s.entries[start:] {
+		entries = append(entries, StreamEntry{ID: entry.id.String(), Values: cloneList(entry.values)})
+	}
+
+	return entries, nil
+}
+
+func (s *streamValue) nextAutoID(nowMillis int64) streamID {
+	if !s.hasEntries {
+		return streamID{milliseconds: nowMillis, sequence: 0}
+	}
+
+	if nowMillis < s.lastID.milliseconds {
+		return streamID{milliseconds: s.lastID.milliseconds, sequence: s.lastID.sequence + 1}
+	}
+	if nowMillis == s.lastID.milliseconds {
+		return streamID{milliseconds: nowMillis, sequence: s.lastID.sequence + 1}
+	}
+
+	return streamID{milliseconds: nowMillis, sequence: 0}
+}
+
+func (id streamID) String() string {
+	return strconv.FormatInt(id.milliseconds, 10) + "-" + strconv.FormatInt(id.sequence, 10)
+}
+
+func compareStreamIDs(left, right streamID) int {
+	if left.milliseconds < right.milliseconds {
+		return -1
+	}
+	if left.milliseconds > right.milliseconds {
+		return 1
+	}
+	if left.sequence < right.sequence {
+		return -1
+	}
+	if left.sequence > right.sequence {
+		return 1
+	}
+
+	return 0
+}
+
+func parseStreamAddID(raw string) (streamID, error) {
+	millisecondsPart, sequencePart, ok := strings.Cut(raw, "-")
+	if !ok || millisecondsPart == "" || sequencePart == "" || strings.Contains(sequencePart, "-") {
+		return streamID{}, ErrInvalidStreamID
+	}
+
+	milliseconds, err := parseNonNegativeStreamInt(millisecondsPart)
+	if err != nil {
+		return streamID{}, err
+	}
+	sequence, err := parseNonNegativeStreamInt(sequencePart)
+	if err != nil {
+		return streamID{}, err
+	}
+
+	return streamID{milliseconds: milliseconds, sequence: sequence}, nil
+}
+
+func parseStreamReadID(raw string, latest streamID) (streamID, error) {
+	if raw == "$" {
+		return latest, nil
+	}
+	if _, _, ok := strings.Cut(raw, "-"); !ok {
+		milliseconds, err := parseNonNegativeStreamInt(raw)
+		if err != nil {
+			return streamID{}, err
+		}
+		return streamID{milliseconds: milliseconds, sequence: 0}, nil
+	}
+
+	return parseStreamAddID(raw)
+}
+
+func parseNonNegativeStreamInt(raw string) (int64, error) {
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 0 {
+		return 0, ErrInvalidStreamID
+	}
+
+	return value, nil
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -6,14 +6,67 @@ type ValueKind string
 const (
 	// ValueKindString is the Phase 1 string storage type used by SET/GET.
 	ValueKindString ValueKind = "string"
+	// ValueKindList is the Phase 2 list storage type used by LPUSH/RPUSH/LRANGE.
+	ValueKindList ValueKind = "list"
+	// ValueKindZSet is the Phase 2 sorted-set storage type used by ZADD/ZRANGE.
+	ValueKindZSet ValueKind = "zset"
+	// ValueKindStream is the Phase 2 stream storage type used by XADD/XREAD.
+	ValueKindStream ValueKind = "stream"
 )
+
+// ZSetEntry represents a member/score pair in a sorted set.
+type ZSetEntry struct {
+	Member []byte
+	Score  float64
+}
+
+// StreamEntry represents a stream entry returned by XREAD.
+type StreamEntry struct {
+	ID     string
+	Values [][]byte
+}
 
 // StoredValue is the internal representation of an item stored in Godis.
 //
 // ExpiresAt is stored as a Unix timestamp in milliseconds. A value of 0 means
 // the key does not expire.
 type StoredValue struct {
-	Data      []byte
+	String    []byte
+	List      [][]byte
+	ZSet      *sortedSet
+	Stream    *streamValue
 	ExpiresAt int64
 	Kind      ValueKind
+}
+
+func newStringValue(data []byte, expiresAt int64) StoredValue {
+	return StoredValue{
+		String:    cloneBytes(data),
+		ExpiresAt: expiresAt,
+		Kind:      ValueKindString,
+	}
+}
+
+func newListValue(items [][]byte, expiresAt int64) StoredValue {
+	return StoredValue{
+		List:      cloneList(items),
+		ExpiresAt: expiresAt,
+		Kind:      ValueKindList,
+	}
+}
+
+func newZSetValue(set *sortedSet, expiresAt int64) StoredValue {
+	return StoredValue{
+		ZSet:      set,
+		ExpiresAt: expiresAt,
+		Kind:      ValueKindZSet,
+	}
+}
+
+func newStreamValue(stream *streamValue, expiresAt int64) StoredValue {
+	return StoredValue{
+		Stream:    stream,
+		ExpiresAt: expiresAt,
+		Kind:      ValueKindStream,
+	}
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -47,9 +47,12 @@ func newStringValue(data []byte, expiresAt int64) StoredValue {
 	}
 }
 
+// newListValue stores an already-owned list representation without cloning.
+// Callers must only pass slices whose element bytes are not aliased with caller-
+// controlled memory.
 func newListValue(items [][]byte, expiresAt int64) StoredValue {
 	return StoredValue{
-		List:      cloneList(items),
+		List:      items,
 		ExpiresAt: expiresAt,
 		Kind:      ValueKindList,
 	}

--- a/internal/storage/zset.go
+++ b/internal/storage/zset.go
@@ -1,0 +1,225 @@
+package storage
+
+import (
+	"math/rand"
+)
+
+const (
+	zsetMaxLevel = 16
+	zsetP        = 0.25
+)
+
+type sortedSet struct {
+	index map[string]float64
+	order *zsetSkipList
+}
+
+type zsetItem struct {
+	member string
+	score  float64
+}
+
+type zsetSkipList struct {
+	header *zsetNode
+	tail   *zsetNode
+	level  int
+	length int
+}
+
+type zsetNode struct {
+	member   string
+	score    float64
+	backward *zsetNode
+	levels   []zsetLevel
+}
+
+type zsetLevel struct {
+	forward *zsetNode
+	span    int
+}
+
+func newSortedSet() *sortedSet {
+	return &sortedSet{
+		index: make(map[string]float64),
+		order: newZSetSkipList(),
+	}
+}
+
+func newZSetSkipList() *zsetSkipList {
+	header := &zsetNode{levels: make([]zsetLevel, zsetMaxLevel)}
+	return &zsetSkipList{header: header, level: 1}
+}
+
+func (s *sortedSet) len() int {
+	return len(s.index)
+}
+
+func (s *sortedSet) add(member string, score float64) bool {
+	current, exists := s.index[member]
+	if exists {
+		if current == score {
+			return false
+		}
+		s.order.delete(current, member)
+	}
+
+	s.order.insert(score, member)
+	s.index[member] = score
+	return !exists
+}
+
+func (s *sortedSet) rangeByRank(start, stop int) []zsetItem {
+	if start < 0 || stop < start || start >= s.order.length {
+		return nil
+	}
+
+	node := s.order.getByRank(start + 1)
+	if node == nil {
+		return nil
+	}
+
+	items := make([]zsetItem, 0, stop-start+1)
+	for remaining := stop - start + 1; remaining > 0 && node != nil; remaining-- {
+		items = append(items, zsetItem{member: node.member, score: node.score})
+		node = node.levels[0].forward
+	}
+
+	return items
+}
+
+func (sl *zsetSkipList) insert(score float64, member string) *zsetNode {
+	var (
+		update [zsetMaxLevel]*zsetNode
+		rank   [zsetMaxLevel]int
+	)
+
+	x := sl.header
+	for i := sl.level - 1; i >= 0; i-- {
+		if i == sl.level-1 {
+			rank[i] = 0
+		} else {
+			rank[i] = rank[i+1]
+		}
+
+		for next := x.levels[i].forward; next != nil && zsetLess(next.score, next.member, score, member); next = x.levels[i].forward {
+			rank[i] += x.levels[i].span
+			x = next
+		}
+		update[i] = x
+	}
+
+	level := randomZSetLevel()
+	if level > sl.level {
+		for i := sl.level; i < level; i++ {
+			rank[i] = 0
+			update[i] = sl.header
+			update[i].levels[i].span = sl.length
+		}
+		sl.level = level
+	}
+
+	x = &zsetNode{member: member, score: score, levels: make([]zsetLevel, level)}
+	for i := 0; i < level; i++ {
+		x.levels[i].forward = update[i].levels[i].forward
+		update[i].levels[i].forward = x
+
+		x.levels[i].span = update[i].levels[i].span - (rank[0] - rank[i])
+		update[i].levels[i].span = (rank[0] - rank[i]) + 1
+	}
+
+	for i := level; i < sl.level; i++ {
+		update[i].levels[i].span++
+	}
+
+	if update[0] == sl.header {
+		x.backward = nil
+	} else {
+		x.backward = update[0]
+	}
+	if x.levels[0].forward != nil {
+		x.levels[0].forward.backward = x
+	} else {
+		sl.tail = x
+	}
+
+	sl.length++
+	return x
+}
+
+func (sl *zsetSkipList) delete(score float64, member string) bool {
+	var update [zsetMaxLevel]*zsetNode
+
+	x := sl.header
+	for i := sl.level - 1; i >= 0; i-- {
+		for next := x.levels[i].forward; next != nil && zsetLess(next.score, next.member, score, member); next = x.levels[i].forward {
+			x = next
+		}
+		update[i] = x
+	}
+
+	x = x.levels[0].forward
+	if x == nil || x.score != score || x.member != member {
+		return false
+	}
+
+	sl.deleteNode(x, update)
+	return true
+}
+
+func (sl *zsetSkipList) deleteNode(node *zsetNode, update [zsetMaxLevel]*zsetNode) {
+	for i := 0; i < sl.level; i++ {
+		if update[i].levels[i].forward == node {
+			update[i].levels[i].span += node.levels[i].span - 1
+			update[i].levels[i].forward = node.levels[i].forward
+		} else {
+			update[i].levels[i].span--
+		}
+	}
+
+	if node.levels[0].forward != nil {
+		node.levels[0].forward.backward = node.backward
+	} else {
+		sl.tail = node.backward
+	}
+
+	for sl.level > 1 && sl.header.levels[sl.level-1].forward == nil {
+		sl.level--
+	}
+	sl.length--
+}
+
+func (sl *zsetSkipList) getByRank(rank int) *zsetNode {
+	if rank <= 0 || rank > sl.length {
+		return nil
+	}
+
+	traversed := 0
+	x := sl.header
+	for i := sl.level - 1; i >= 0; i-- {
+		for next := x.levels[i].forward; next != nil && traversed+x.levels[i].span <= rank; next = x.levels[i].forward {
+			traversed += x.levels[i].span
+			x = next
+		}
+		if traversed == rank {
+			return x
+		}
+	}
+
+	return nil
+}
+
+func randomZSetLevel() int {
+	level := 1
+	for level < zsetMaxLevel && rand.Float64() < zsetP {
+		level++
+	}
+	return level
+}
+
+func zsetLess(leftScore float64, leftMember string, rightScore float64, rightMember string) bool {
+	if leftScore != rightScore {
+		return leftScore < rightScore
+	}
+
+	return leftMember < rightMember
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -74,6 +74,248 @@ func TestServerHandlesPhaseOneCommands(t *testing.T) {
 	}
 }
 
+func TestServerHandlesListCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "LPUSH", "letters", "a", "b")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 3}, "RPUSH", "letters", "c")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("b")},
+		protocol.BulkString{Data: []byte("a")},
+		protocol.BulkString{Data: []byte("c")},
+	}}, "LRANGE", "letters", "0", "-1")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "WRONGTYPE Operation against a key holding the wrong kind of value"}, "GET", "letters")
+
+	blockedConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) blocked client error = %v", addr, err)
+	}
+	defer func() { _ = blockedConn.Close() }()
+	blockedParser := protocol.NewParser(blockedConn)
+
+	if err := protocol.WriteValue(blockedConn, request("BLPOP", "jobs")); err != nil {
+		t.Fatalf("WriteValue(BLPOP) error = %v", err)
+	}
+
+	pushErrCh := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		if err := protocol.WriteValue(conn, request("RPUSH", "jobs", "build")); err != nil {
+			pushErrCh <- err
+			return
+		}
+
+		response, err := parser.Parse()
+		if err != nil {
+			pushErrCh <- err
+			return
+		}
+
+		if integer, ok := response.(protocol.Integer); !ok || integer.Value != 1 {
+			pushErrCh <- net.InvalidAddrError("unexpected RPUSH response")
+			return
+		}
+
+		pushErrCh <- nil
+	}()
+
+	got, err := blockedParser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() BLPOP error = %v", err)
+	}
+	assertValuesEqual(t, got, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("jobs")},
+		protocol.BulkString{Data: []byte("build")},
+	}})
+	if err := <-pushErrCh; err != nil {
+		t.Fatalf("RPUSH during BLPOP wake-up error = %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerHandlesSortedSetCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 3}, "ZADD", "leaders", "2", "beta", "1", "alpha", "2", "aardvark")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("alpha")},
+		protocol.BulkString{Data: []byte("aardvark")},
+		protocol.BulkString{Data: []byte("beta")},
+	}}, "ZRANGE", "leaders", "0", "-1")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("alpha")},
+		protocol.BulkString{Data: []byte("1")},
+		protocol.BulkString{Data: []byte("aardvark")},
+		protocol.BulkString{Data: []byte("2")},
+		protocol.BulkString{Data: []byte("beta")},
+		protocol.BulkString{Data: []byte("2")},
+	}}, "ZRANGE", "leaders", "0", "-1", "WITHSCORES")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 1}, "ZADD", "leaders", "0.5", "beta", "3", "gamma")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("beta")},
+		protocol.BulkString{Data: []byte("0.5")},
+		protocol.BulkString{Data: []byte("alpha")},
+		protocol.BulkString{Data: []byte("1")},
+		protocol.BulkString{Data: []byte("aardvark")},
+		protocol.BulkString{Data: []byte("2")},
+		protocol.BulkString{Data: []byte("gamma")},
+		protocol.BulkString{Data: []byte("3")},
+	}}, "ZRANGE", "leaders", "0", "-1", "WITHSCORES")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "plain", "hello")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "WRONGTYPE Operation against a key holding the wrong kind of value"}, "ZADD", "plain", "1", "alpha")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerHandlesStreamCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Data: []byte("1-0")}, "XADD", "events", "1-0", "type", "start")
+
+	if err := protocol.WriteValue(conn, request("XADD", "events", "*", "type", "finish", "user", "42")); err != nil {
+		t.Fatalf("WriteValue(XADD *) error = %v", err)
+	}
+	secondRaw, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() XADD * error = %v", err)
+	}
+	secondID, ok := secondRaw.(protocol.BulkString)
+	if !ok {
+		t.Fatalf("XADD * response type = %T, want protocol.BulkString", secondRaw)
+	}
+
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.Array{Elements: []protocol.Value{
+			protocol.BulkString{Data: []byte("events")},
+			protocol.Array{Elements: []protocol.Value{
+				protocol.Array{Elements: []protocol.Value{
+					protocol.BulkString{Data: []byte("1-0")},
+					protocol.Array{Elements: []protocol.Value{
+						protocol.BulkString{Data: []byte("type")},
+						protocol.BulkString{Data: []byte("start")},
+					}},
+				}},
+				protocol.Array{Elements: []protocol.Value{
+					protocol.BulkString{Data: secondID.Data},
+					protocol.Array{Elements: []protocol.Value{
+						protocol.BulkString{Data: []byte("type")},
+						protocol.BulkString{Data: []byte("finish")},
+						protocol.BulkString{Data: []byte("user")},
+						protocol.BulkString{Data: []byte("42")},
+					}},
+				}},
+			}},
+		}},
+	}}, "XREAD", "STREAMS", "events", "0-0")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{}}, "XREAD", "STREAMS", "events", "$")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR invalid stream ID specified as stream command argument"}, "XADD", "events", "bad-id", "field", "value")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
 func waitForAddr(t *testing.T, srv *server.Server) string {
 	t.Helper()
 
@@ -154,6 +396,20 @@ func assertValuesEqual(t *testing.T, got protocol.Value, want protocol.Value) {
 		}
 		if typedGot.Message != typedWant.Message {
 			t.Fatalf("error message = %q, want %q", typedGot.Message, typedWant.Message)
+		}
+	case protocol.Array:
+		typedGot, ok := got.(protocol.Array)
+		if !ok {
+			t.Fatalf("response type = %T, want %T", got, want)
+		}
+		if typedGot.Null != typedWant.Null {
+			t.Fatalf("array null = %v, want %v", typedGot.Null, typedWant.Null)
+		}
+		if len(typedGot.Elements) != len(typedWant.Elements) {
+			t.Fatalf("len(array) = %d, want %d", len(typedGot.Elements), len(typedWant.Elements))
+		}
+		for i := range typedWant.Elements {
+			assertValuesEqual(t, typedGot.Elements[i], typedWant.Elements[i])
 		}
 	default:
 		t.Fatalf("unsupported wanted type %T", want)

--- a/test/shutdown_test.go
+++ b/test/shutdown_test.go
@@ -80,3 +80,59 @@ func TestServerShutdownClosesMultipleClients(t *testing.T) {
 		}
 	}
 }
+
+func TestServerShutdownUnblocksBLPop(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		cancel()
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := protocol.WriteValue(conn, request("BLPOP", "jobs")); err != nil {
+		cancel()
+		t.Fatalf("WriteValue(BLPOP) error = %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+
+	buffer := make([]byte, 1)
+	_, err = conn.Read(buffer)
+	if err == nil {
+		t.Fatal("conn.Read() error = nil, want closed-connection error")
+	}
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatal("conn.Read() timed out, want closed-connection error")
+	}
+}


### PR DESCRIPTION
## Summary
- add Phase 2 list commands (LPUSH, RPUSH, LRANGE, BLPOP) with waiter-based blocking behavior
- add sorted set support (ZADD, ZRANGE) and stream support (XADD, minimal XREAD STREAMS key id) on top of typed storage
- expand unit, integration, benchmark, and shutdown coverage, including the stream concurrency audit fix for synchronized reads

## Verification
- go test ./...
- go test -race ./...
- go vet ./...
- golangci-lint run