### PR TITLE
feat: implement ACID transactions with optimistic locking and concurrency control

### DIFF
--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -2,13 +2,107 @@ package command
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
 
 	"github.com/maltemindedal/godis/internal/protocol"
+	"github.com/maltemindedal/godis/internal/server"
 	"github.com/maltemindedal/godis/internal/storage"
 )
+
+func (e *Executor) handleWatch(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) == 0 {
+		return nil, wrongNumberOfArgumentsError("WATCH")
+	}
+
+	state, err := clientStateFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if state.InTransactionActive() {
+		return nil, ErrWatchInsideMultiError()
+	}
+
+	keys := make([]string, 0, len(request.Args))
+	for _, arg := range request.Args {
+		keys = append(keys, string(arg))
+	}
+	state.WatchKeys(keys...)
+
+	return protocol.SimpleString{Value: "OK"}, nil
+}
+
+func (e *Executor) handleMulti(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 0 {
+		return nil, wrongNumberOfArgumentsError("MULTI")
+	}
+
+	state, err := clientStateFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !state.BeginTransaction() {
+		return nil, ErrMultiNestedError()
+	}
+
+	return protocol.SimpleString{Value: "OK"}, nil
+}
+
+func (e *Executor) handleExec(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 0 {
+		return nil, wrongNumberOfArgumentsError("EXEC")
+	}
+
+	state, err := clientStateFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !state.InTransactionActive() {
+		return nil, ErrExecWithoutMultiError()
+	}
+	if state.TransactionFailed() {
+		state.ResetTransaction()
+		state.UnwatchAll()
+		return protocol.Array{Null: true}, nil
+	}
+	state.UnwatchAll()
+
+	queued := state.DrainTransaction()
+	responses := make([]protocol.Value, 0, len(queued))
+	for _, queuedCommand := range queued {
+		response, execErr := e.executeRequest(ctx, &Request{Name: queuedCommand.Name, Args: queuedCommand.Args}, false)
+		if execErr != nil {
+			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
+				return nil, execErr
+			}
+			response = responseErrorValue(execErr)
+		}
+		responses = append(responses, response)
+	}
+
+	return protocol.Array{Elements: responses}, nil
+}
+
+func (e *Executor) handleDiscard(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 0 {
+		return nil, wrongNumberOfArgumentsError("DISCARD")
+	}
+
+	state, err := clientStateFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !state.InTransactionActive() {
+		return nil, ErrDiscardWithoutMultiError()
+	}
+
+	state.ResetTransaction()
+	state.UnwatchAll()
+	return protocol.SimpleString{Value: "OK"}, nil
+}
 
 func (e *Executor) handlePing(_ context.Context, request *Request) (protocol.Value, error) {
 	if len(request.Args) == 1 {
@@ -47,6 +141,7 @@ func (e *Executor) handleSet(_ context.Context, request *Request) (protocol.Valu
 	}
 
 	e.store.Set(string(request.Args[0]), request.Args[1], expiresAt)
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.SimpleString{Value: "OK"}, nil
 }
 
@@ -75,10 +170,15 @@ func (e *Executor) handleDel(_ context.Context, request *Request) (protocol.Valu
 	}
 
 	removed := int64(0)
+	touched := make([]string, 0, len(request.Args))
 	for _, arg := range request.Args {
 		if e.store.Delete(string(arg)) {
 			removed++
+			touched = append(touched, string(arg))
 		}
+	}
+	if len(touched) > 0 {
+		e.touchWatchKeys(touched...)
 	}
 
 	return protocol.Integer{Value: removed}, nil
@@ -101,6 +201,7 @@ func (e *Executor) handleIncr(_ context.Context, request *Request) (protocol.Val
 		}
 	}
 
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.Integer{Value: value}, nil
 }
 
@@ -117,6 +218,7 @@ func (e *Executor) handleLPush(_ context.Context, request *Request) (protocol.Va
 		return nil, err
 	}
 
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.Integer{Value: length}, nil
 }
 
@@ -133,6 +235,7 @@ func (e *Executor) handleRPush(_ context.Context, request *Request) (protocol.Va
 		return nil, err
 	}
 
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.Integer{Value: length}, nil
 }
 
@@ -180,6 +283,7 @@ func (e *Executor) handleBLPop(ctx context.Context, request *Request) (protocol.
 		}
 		if ok {
 			e.store.UnsubscribeListPush(key, waiter)
+			e.touchWatchKeys(key)
 			return protocol.Array{Elements: []protocol.Value{
 				protocol.BulkString{Data: clone(request.Args[0])},
 				protocol.BulkString{Data: value},
@@ -226,6 +330,7 @@ func (e *Executor) handleZAdd(_ context.Context, request *Request) (protocol.Val
 		}
 	}
 
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.Integer{Value: added}, nil
 }
 
@@ -283,6 +388,7 @@ func (e *Executor) handleXAdd(_ context.Context, request *Request) (protocol.Val
 		}
 	}
 
+	e.touchWatchKeys(string(request.Args[0]))
 	return protocol.BulkString{Data: []byte(id)}, nil
 }
 
@@ -384,4 +490,21 @@ func clone(value []byte) []byte {
 	copied := make([]byte, len(value))
 	copy(copied, value)
 	return copied
+}
+
+func clientStateFromContext(ctx context.Context) (*server.ClientState, error) {
+	state, ok := server.ClientStateFromContext(ctx)
+	if !ok || state == nil {
+		return nil, fmt.Errorf("client state unavailable")
+	}
+
+	return state, nil
+}
+
+func (e *Executor) touchWatchKeys(keys ...string) {
+	if e.watchRegistry == nil || len(keys) == 0 {
+		return
+	}
+
+	e.watchRegistry.Touch(keys...)
 }

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -63,6 +63,11 @@ func (e *Executor) handleExec(ctx context.Context, request *Request) (protocol.V
 	if !state.InTransactionActive() {
 		return nil, ErrExecWithoutMultiError()
 	}
+	if state.TransactionDirty() {
+		state.ResetTransaction()
+		state.UnwatchAll()
+		return nil, ErrExecAbortError()
+	}
 	if state.TransactionFailed() {
 		state.ResetTransaction()
 		state.UnwatchAll()

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/maltemindedal/godis/internal/protocol"
+	"github.com/maltemindedal/godis/internal/server"
 	"github.com/maltemindedal/godis/internal/storage"
 )
 
@@ -525,6 +526,125 @@ func TestExecutorBLPop(t *testing.T) {
 	}})
 }
 
+func TestExecutorTransactions(t *testing.T) {
+	t.Run("MULTI queues commands until EXEC", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		value, err := executor.Execute(ctx, requestValue("MULTI"))
+		if err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.SimpleString{Value: "OK"})
+
+		value, err = executor.Execute(ctx, requestValue("SET", "name", "godis"))
+		if err != nil {
+			t.Fatalf("queued SET error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.SimpleString{Value: "QUEUED"})
+
+		value, err = executor.Execute(ctx, requestValue("GET", "name"))
+		if err != nil {
+			t.Fatalf("queued GET error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.SimpleString{Value: "QUEUED"})
+
+		value, err = executor.Execute(ctx, requestValue("EXEC"))
+		if err != nil {
+			t.Fatalf("EXEC error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+			protocol.SimpleString{Value: "OK"},
+			protocol.BulkString{Data: []byte("godis")},
+		}})
+	})
+
+	t.Run("EXEC includes per-command errors", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("SET", "bad", "hello")); err != nil {
+			t.Fatalf("queued SET error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("INCR", "bad")); err != nil {
+			t.Fatalf("queued INCR error = %v", err)
+		}
+
+		value, err := executor.Execute(ctx, requestValue("EXEC"))
+		if err != nil {
+			t.Fatalf("EXEC error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.Array{Elements: []protocol.Value{
+			protocol.SimpleString{Value: "OK"},
+			protocol.ErrorValue{Message: "ERR value is not an integer or out of range"},
+		}})
+	})
+
+	t.Run("transaction state errors use Redis-compatible sentinels", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("EXEC")); !errors.Is(err, ErrExecWithoutMulti) {
+			t.Fatalf("EXEC error = %v, want ErrExecWithoutMulti", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("DISCARD")); !errors.Is(err, ErrDiscardWithoutMulti) {
+			t.Fatalf("DISCARD error = %v, want ErrDiscardWithoutMulti", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("first MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); !errors.Is(err, ErrMultiNested) {
+			t.Fatalf("nested MULTI error = %v, want ErrMultiNested", err)
+		}
+	})
+
+	t.Run("WATCH aborts EXEC after another client modifies a watched key", func(t *testing.T) {
+		executor := newTestExecutor()
+		watcherCtx := withClientStateForExecutor(context.Background(), executor, 1)
+		writerCtx := withClientStateForExecutor(context.Background(), executor, 2)
+
+		if _, err := executor.Execute(watcherCtx, requestValue("WATCH", "counter")); err != nil {
+			t.Fatalf("WATCH error = %v", err)
+		}
+		if _, err := executor.Execute(watcherCtx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(watcherCtx, requestValue("SET", "counter", "2")); err != nil {
+			t.Fatalf("queued SET error = %v", err)
+		}
+		if _, err := executor.Execute(writerCtx, requestValue("SET", "counter", "1")); err != nil {
+			t.Fatalf("writer SET error = %v", err)
+		}
+
+		value, err := executor.Execute(watcherCtx, requestValue("EXEC"))
+		if err != nil {
+			t.Fatalf("EXEC error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.Array{Null: true})
+
+		value, err = executor.Execute(watcherCtx, requestValue("GET", "counter"))
+		if err != nil {
+			t.Fatalf("GET after aborted EXEC error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.BulkString{Data: []byte("1")})
+	})
+
+	t.Run("WATCH is rejected inside MULTI", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("WATCH", "counter")); !errors.Is(err, ErrWatchInsideMulti) {
+			t.Fatalf("WATCH error = %v, want ErrWatchInsideMulti", err)
+		}
+	})
+}
+
 func TestDecodeRequest(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -613,6 +733,12 @@ func newTestExecutor() *Executor {
 	return NewExecutor(storage.NewStore(), logger)
 }
 
+func withClientStateForExecutor(ctx context.Context, executor *Executor, id uint64) context.Context {
+	state := &server.ClientState{ID: id, Authenticated: true}
+	state.SetWatchRegistry(executor.WatchRegistry())
+	return server.WithClientState(ctx, state)
+}
+
 func requestValue(parts ...string) protocol.Value {
 	elements := make([]protocol.Value, 0, len(parts))
 	for _, part := range parts {
@@ -665,6 +791,14 @@ func assertValueEqual(t *testing.T, got protocol.Value, want protocol.Value) {
 		}
 		for i := range typedWant.Elements {
 			assertValueEqual(t, typedGot.Elements[i], typedWant.Elements[i])
+		}
+	case protocol.ErrorValue:
+		typedGot, ok := got.(protocol.ErrorValue)
+		if !ok {
+			t.Fatalf("value type = %T, want %T", got, want)
+		}
+		if typedGot.Message != typedWant.Message {
+			t.Fatalf("error message = %q, want %q", typedGot.Message, typedWant.Message)
 		}
 	default:
 		t.Fatalf("unsupported wanted type %T", want)

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -643,6 +643,82 @@ func TestExecutorTransactions(t *testing.T) {
 			t.Fatalf("WATCH error = %v, want ErrWatchInsideMulti", err)
 		}
 	})
+
+	t.Run("queue-time validation errors abort EXEC", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("NOPE")); err == nil || err.Error() != "unknown command \"NOPE\"" {
+			t.Fatalf("unknown command error = %v, want unknown command \"NOPE\"", err)
+		}
+		value, err := executor.Execute(ctx, requestValue("SET", "name", "godis"))
+		if err != nil {
+			t.Fatalf("queued SET after invalid command error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.SimpleString{Value: "QUEUED"})
+
+		if _, err := executor.Execute(ctx, requestValue("EXEC")); !errors.Is(err, ErrExecAbort) {
+			t.Fatalf("EXEC error = %v, want ErrExecAbort", err)
+		}
+
+		value, err = executor.Execute(ctx, requestValue("GET", "name"))
+		if err != nil {
+			t.Fatalf("GET after EXECABORT error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.BulkString{Null: true})
+	})
+
+	t.Run("queue-time syntax errors are returned immediately", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("SET", "temp", "1", "NX", "10")); !errors.Is(err, ErrSyntax) {
+			t.Fatalf("queued SET syntax error = %v, want ErrSyntax", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("EXEC")); !errors.Is(err, ErrExecAbort) {
+			t.Fatalf("EXEC error = %v, want ErrExecAbort", err)
+		}
+	})
+
+	t.Run("queue-time malformed stream IDs abort EXEC", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			request protocol.Value
+		}{
+			{
+				name:    "XADD malformed ID",
+				request: requestValue("XADD", "events", "bad-id", "field", "value"),
+			},
+			{
+				name:    "XREAD malformed ID",
+				request: requestValue("XREAD", "STREAMS", "events", "bad-id"),
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				executor := newTestExecutor()
+				ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+				if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+					t.Fatalf("MULTI error = %v", err)
+				}
+				if _, err := executor.Execute(ctx, tt.request); !errors.Is(err, ErrInvalidStreamID) {
+					t.Fatalf("queued stream validation error = %v, want ErrInvalidStreamID", err)
+				}
+				if _, err := executor.Execute(ctx, requestValue("EXEC")); !errors.Is(err, ErrExecAbort) {
+					t.Fatalf("EXEC error = %v, want ErrExecAbort", err)
+				}
+			})
+		}
+	})
 }
 
 func TestDecodeRequest(t *testing.T) {

--- a/internal/command/executor.go
+++ b/internal/command/executor.go
@@ -8,6 +8,14 @@ import (
 var (
 	// ErrSyntax reports malformed command syntax.
 	ErrSyntax = errors.New("syntax error")
+	// ErrExecWithoutMulti reports that EXEC was called outside a transaction.
+	ErrExecWithoutMulti = errors.New("EXEC without MULTI")
+	// ErrDiscardWithoutMulti reports that DISCARD was called outside a transaction.
+	ErrDiscardWithoutMulti = errors.New("DISCARD without MULTI")
+	// ErrMultiNested reports that MULTI was called while already inside a transaction.
+	ErrMultiNested = errors.New("MULTI calls can not be nested")
+	// ErrWatchInsideMulti reports that WATCH was called inside a MULTI block.
+	ErrWatchInsideMulti = errors.New("WATCH inside MULTI is not allowed")
 	// ErrInvalidExpireTime reports an invalid EX/PX duration.
 	ErrInvalidExpireTime = errors.New("invalid expire time in 'SET' command")
 	// ErrInvalidStreamID reports that a stream ID could not be parsed.
@@ -75,6 +83,26 @@ func ErrUnknownCommand(name string) error {
 // ErrSyntaxError reports a Redis-style syntax error.
 func ErrSyntaxError() error {
 	return newRESPWrappedError("ERR", ErrSyntax)
+}
+
+// ErrExecWithoutMultiError reports that EXEC was called without MULTI.
+func ErrExecWithoutMultiError() error {
+	return newRESPWrappedError("ERR", ErrExecWithoutMulti)
+}
+
+// ErrDiscardWithoutMultiError reports that DISCARD was called without MULTI.
+func ErrDiscardWithoutMultiError() error {
+	return newRESPWrappedError("ERR", ErrDiscardWithoutMulti)
+}
+
+// ErrMultiNestedError reports that MULTI was called while already in MULTI mode.
+func ErrMultiNestedError() error {
+	return newRESPWrappedError("ERR", ErrMultiNested)
+}
+
+// ErrWatchInsideMultiError reports that WATCH cannot be called after MULTI.
+func ErrWatchInsideMultiError() error {
+	return newRESPWrappedError("ERR", ErrWatchInsideMulti)
 }
 
 // ErrInvalidExpireTimeError reports an invalid SET expiry argument.

--- a/internal/command/executor.go
+++ b/internal/command/executor.go
@@ -16,6 +16,8 @@ var (
 	ErrMultiNested = errors.New("MULTI calls can not be nested")
 	// ErrWatchInsideMulti reports that WATCH was called inside a MULTI block.
 	ErrWatchInsideMulti = errors.New("WATCH inside MULTI is not allowed")
+	// ErrExecAbort reports that EXEC aborted because queue-time validation failed.
+	ErrExecAbort = errors.New("transaction discarded because of previous errors")
 	// ErrInvalidExpireTime reports an invalid EX/PX duration.
 	ErrInvalidExpireTime = errors.New("invalid expire time in 'SET' command")
 	// ErrInvalidStreamID reports that a stream ID could not be parsed.
@@ -103,6 +105,11 @@ func ErrMultiNestedError() error {
 // ErrWatchInsideMultiError reports that WATCH cannot be called after MULTI.
 func ErrWatchInsideMultiError() error {
 	return newRESPWrappedError("ERR", ErrWatchInsideMulti)
+}
+
+// ErrExecAbortError reports that EXEC refused to run after queue-time validation errors.
+func ErrExecAbortError() error {
+	return newRESPError("EXECABORT", "Transaction discarded because of previous errors.", ErrExecAbort)
 }
 
 // ErrInvalidExpireTimeError reports an invalid SET expiry argument.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -2,10 +2,12 @@ package command
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 
 	"github.com/maltemindedal/godis/internal/protocol"
+	"github.com/maltemindedal/godis/internal/server"
 	"github.com/maltemindedal/godis/internal/storage"
 )
 
@@ -20,34 +22,45 @@ type Handler func(context.Context, *Request) (protocol.Value, error)
 
 // Executor routes protocol frames to concrete command handlers.
 type Executor struct {
-	store    *storage.Store
-	logger   *slog.Logger
-	handlers map[string]Handler
+	store         *storage.Store
+	logger        *slog.Logger
+	watchRegistry *server.WatchRegistry
+	handlers      map[string]Handler
 }
 
 // NewExecutor constructs a command executor with the Phase 1 command set.
 func NewExecutor(store *storage.Store, logger *slog.Logger) *Executor {
 	executor := &Executor{
-		store:  store,
-		logger: logger,
+		store:         store,
+		logger:        logger,
+		watchRegistry: server.NewWatchRegistry(),
 	}
 	executor.handlers = map[string]Handler{
-		"PING":   executor.handlePing,
-		"ECHO":   executor.handleEcho,
-		"SET":    executor.handleSet,
-		"GET":    executor.handleGet,
-		"DEL":    executor.handleDel,
-		"INCR":   executor.handleIncr,
-		"LPUSH":  executor.handleLPush,
-		"RPUSH":  executor.handleRPush,
-		"LRANGE": executor.handleLRange,
-		"BLPOP":  executor.handleBLPop,
-		"ZADD":   executor.handleZAdd,
-		"ZRANGE": executor.handleZRange,
-		"XADD":   executor.handleXAdd,
-		"XREAD":  executor.handleXRead,
+		"WATCH":   executor.handleWatch,
+		"MULTI":   executor.handleMulti,
+		"EXEC":    executor.handleExec,
+		"DISCARD": executor.handleDiscard,
+		"PING":    executor.handlePing,
+		"ECHO":    executor.handleEcho,
+		"SET":     executor.handleSet,
+		"GET":     executor.handleGet,
+		"DEL":     executor.handleDel,
+		"INCR":    executor.handleIncr,
+		"LPUSH":   executor.handleLPush,
+		"RPUSH":   executor.handleRPush,
+		"LRANGE":  executor.handleLRange,
+		"BLPOP":   executor.handleBLPop,
+		"ZADD":    executor.handleZAdd,
+		"ZRANGE":  executor.handleZRange,
+		"XADD":    executor.handleXAdd,
+		"XREAD":   executor.handleXRead,
 	}
 	return executor
+}
+
+// WatchRegistry exposes the shared optimistic-locking registry to the server.
+func (e *Executor) WatchRegistry() *server.WatchRegistry {
+	return e.watchRegistry
 }
 
 // Execute dispatches a parsed RESP frame to its command handler.
@@ -57,12 +70,52 @@ func (e *Executor) Execute(ctx context.Context, value protocol.Value) (protocol.
 		return nil, err
 	}
 
+	return e.executeRequest(ctx, request, true)
+}
+
+func (e *Executor) executeRequest(ctx context.Context, request *Request, allowQueue bool) (protocol.Value, error) {
+	if allowQueue {
+		if queued, response, err := e.maybeQueueRequest(ctx, request); queued || err != nil {
+			return response, err
+		}
+	}
+
 	handler, ok := e.handlers[request.Name]
 	if !ok {
 		return nil, ErrUnknownCommand(request.Name)
 	}
 
 	return handler(ctx, request)
+}
+
+func (e *Executor) maybeQueueRequest(ctx context.Context, request *Request) (bool, protocol.Value, error) {
+	state, ok := server.ClientStateFromContext(ctx)
+	if !ok || !state.InTransactionActive() || isTransactionControlCommand(request.Name) {
+		return false, nil, nil
+	}
+
+	state.EnqueueCommand(request.Name, request.Args)
+	return true, protocol.SimpleString{Value: "QUEUED"}, nil
+}
+
+func isTransactionControlCommand(name string) bool {
+	switch name {
+	case "WATCH", "MULTI", "EXEC", "DISCARD":
+		return true
+	default:
+		return false
+	}
+}
+
+func responseErrorValue(err error) protocol.ErrorValue {
+	prefix := "ERR"
+
+	var typed RESPError
+	if errors.As(err, &typed) {
+		prefix = typed.RESPErrorPrefix()
+	}
+
+	return protocol.ErrorValue{Message: prefix + " " + err.Error()}
 }
 
 // DecodeRequest converts a RESP array into a command request.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -28,7 +28,7 @@ type Executor struct {
 	handlers      map[string]Handler
 }
 
-// NewExecutor constructs a command executor with the Phase 1 command set.
+// NewExecutor constructs a command executor with the currently supported command set.
 func NewExecutor(store *storage.Store, logger *slog.Logger) *Executor {
 	executor := &Executor{
 		store:         store,
@@ -88,10 +88,145 @@ func (e *Executor) executeRequest(ctx context.Context, request *Request, allowQu
 	return handler(ctx, request)
 }
 
+func (e *Executor) validateQueueableRequest(request *Request) error {
+	if _, ok := e.handlers[request.Name]; !ok {
+		return ErrUnknownCommand(request.Name)
+	}
+
+	switch request.Name {
+	case "WATCH":
+		if len(request.Args) == 0 {
+			return wrongNumberOfArgumentsError("WATCH")
+		}
+	case "MULTI":
+		if len(request.Args) != 0 {
+			return wrongNumberOfArgumentsError("MULTI")
+		}
+	case "EXEC":
+		if len(request.Args) != 0 {
+			return wrongNumberOfArgumentsError("EXEC")
+		}
+	case "DISCARD":
+		if len(request.Args) != 0 {
+			return wrongNumberOfArgumentsError("DISCARD")
+		}
+	case "PING":
+		if len(request.Args) > 1 {
+			return wrongNumberOfArgumentsError("PING")
+		}
+	case "ECHO":
+		if len(request.Args) != 1 {
+			return wrongNumberOfArgumentsError("ECHO")
+		}
+	case "SET":
+		if len(request.Args) < 2 {
+			return wrongNumberOfArgumentsError("SET")
+		}
+		if _, err := storage.ParseExpiryMillis(request.Args[2:]); err != nil {
+			switch err {
+			case storage.ErrSyntax:
+				return ErrSyntaxError()
+			case storage.ErrInvalidExpireTime:
+				return ErrInvalidExpireTimeError()
+			default:
+				return err
+			}
+		}
+	case "GET":
+		if len(request.Args) != 1 {
+			return wrongNumberOfArgumentsError("GET")
+		}
+	case "DEL":
+		if len(request.Args) < 1 {
+			return wrongNumberOfArgumentsError("DEL")
+		}
+	case "INCR":
+		if len(request.Args) != 1 {
+			return wrongNumberOfArgumentsError("INCR")
+		}
+	case "LPUSH":
+		if len(request.Args) < 2 {
+			return wrongNumberOfArgumentsError("LPUSH")
+		}
+	case "RPUSH":
+		if len(request.Args) < 2 {
+			return wrongNumberOfArgumentsError("RPUSH")
+		}
+	case "LRANGE":
+		if len(request.Args) != 3 {
+			return wrongNumberOfArgumentsError("LRANGE")
+		}
+		if _, err := parseIntegerArgument(request.Args[1]); err != nil {
+			return err
+		}
+		if _, err := parseIntegerArgument(request.Args[2]); err != nil {
+			return err
+		}
+	case "BLPOP":
+		if len(request.Args) != 1 {
+			return wrongNumberOfArgumentsError("BLPOP")
+		}
+	case "ZADD":
+		if len(request.Args) < 3 || len(request.Args)%2 == 0 {
+			return wrongNumberOfArgumentsError("ZADD")
+		}
+		for i := 1; i < len(request.Args); i += 2 {
+			if _, err := parseFloatArgument(request.Args[i]); err != nil {
+				return err
+			}
+		}
+	case "ZRANGE":
+		if len(request.Args) != 3 && len(request.Args) != 4 {
+			return wrongNumberOfArgumentsError("ZRANGE")
+		}
+		if len(request.Args) == 4 && !strings.EqualFold(string(request.Args[3]), "WITHSCORES") {
+			return ErrSyntaxError()
+		}
+		if _, err := parseIntegerArgument(request.Args[1]); err != nil {
+			return err
+		}
+		if _, err := parseIntegerArgument(request.Args[2]); err != nil {
+			return err
+		}
+	case "XADD":
+		if len(request.Args) < 4 || len(request.Args)%2 != 0 {
+			return wrongNumberOfArgumentsError("XADD")
+		}
+		if err := storage.ValidateXAddID(string(request.Args[1])); err != nil {
+			if errors.Is(err, storage.ErrInvalidStreamID) {
+				return ErrInvalidStreamIDError()
+			}
+			return err
+		}
+	case "XREAD":
+		if len(request.Args) == 0 {
+			return wrongNumberOfArgumentsError("XREAD")
+		}
+		if !strings.EqualFold(string(request.Args[0]), "STREAMS") {
+			return ErrSyntaxError()
+		}
+		if len(request.Args) != 3 {
+			return ErrSyntaxError()
+		}
+		if err := storage.ValidateXReadID(string(request.Args[2])); err != nil {
+			if errors.Is(err, storage.ErrInvalidStreamID) {
+				return ErrInvalidStreamIDError()
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (e *Executor) maybeQueueRequest(ctx context.Context, request *Request) (bool, protocol.Value, error) {
 	state, ok := server.ClientStateFromContext(ctx)
 	if !ok || !state.InTransactionActive() || isTransactionControlCommand(request.Name) {
 		return false, nil, nil
+	}
+	if err := e.validateQueueableRequest(request); err != nil {
+		state.MarkTransactionDirty()
+		return false, nil, err
 	}
 
 	state.EnqueueCommand(request.Name, request.Args)

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-// QueuedCommand stores command metadata for future transaction support.
+// QueuedCommand stores command metadata queued for transactional EXEC.
 type QueuedCommand struct {
 	Name string
 	Args [][]byte
@@ -24,6 +24,7 @@ type ClientState struct {
 	Authenticated bool
 	InTransaction bool
 	TxFailed      bool
+	TxDirty       bool
 	TxQueue       []QueuedCommand
 }
 
@@ -59,6 +60,8 @@ func (s *ClientState) BeginTransaction() bool {
 	}
 
 	s.InTransaction = true
+	s.TxFailed = false
+	s.TxDirty = false
 	s.TxQueue = nil
 	return true
 }
@@ -148,6 +151,22 @@ func (s *ClientState) ClearTransactionFailure() {
 	s.TxFailed = false
 }
 
+// TransactionDirty reports whether queue-time validation has already failed.
+func (s *ClientState) TransactionDirty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.TxDirty
+}
+
+// MarkTransactionDirty marks the current transaction as invalid due to queue-time errors.
+func (s *ClientState) MarkTransactionDirty() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.TxDirty = true
+}
+
 func (s *ClientState) addWatchedKey(key string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -177,6 +196,7 @@ func (s *ClientState) DrainTransaction() []QueuedCommand {
 
 	queued := s.TxQueue
 	s.InTransaction = false
+	s.TxDirty = false
 	s.TxQueue = nil
 	return queued
 }
@@ -188,5 +208,6 @@ func (s *ClientState) ResetTransaction() {
 
 	s.InTransaction = false
 	s.TxFailed = false
+	s.TxDirty = false
 	s.TxQueue = nil
 }

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"sync"
 )
@@ -15,10 +16,14 @@ type QueuedCommand struct {
 type ClientState struct {
 	ID uint64
 
-	mu sync.Mutex
+	mu sync.RWMutex
+
+	watchRegistry *WatchRegistry
+	watchedKeys   map[string]struct{}
 
 	Authenticated bool
 	InTransaction bool
+	TxFailed      bool
 	TxQueue       []QueuedCommand
 }
 
@@ -37,10 +42,143 @@ func ClientStateFromContext(ctx context.Context) (*ClientState, bool) {
 
 // QueueLength returns the number of currently queued transaction commands.
 func (s *ClientState) QueueLength() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.TxQueue)
+}
+
+// BeginTransaction marks the client as inside a transaction.
+// It returns false when the client is already inside a transaction.
+func (s *ClientState) BeginTransaction() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return len(s.TxQueue)
+	if s.InTransaction {
+		return false
+	}
+
+	s.InTransaction = true
+	s.TxQueue = nil
+	return true
+}
+
+// SetWatchRegistry binds the shared watch registry to the client state.
+func (s *ClientState) SetWatchRegistry(registry *WatchRegistry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.watchRegistry = registry
+	if s.watchedKeys == nil {
+		s.watchedKeys = make(map[string]struct{})
+	}
+}
+
+// InTransactionActive reports whether the client is currently inside a transaction.
+func (s *ClientState) InTransactionActive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.InTransaction
+}
+
+// EnqueueCommand appends a command to the transaction queue.
+func (s *ClientState) EnqueueCommand(name string, args [][]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	queuedArgs := make([][]byte, 0, len(args))
+	for _, arg := range args {
+		queuedArgs = append(queuedArgs, bytes.Clone(arg))
+	}
+
+	s.TxQueue = append(s.TxQueue, QueuedCommand{
+		Name: name,
+		Args: queuedArgs,
+	})
+}
+
+// WatchKeys registers the supplied keys for optimistic locking.
+func (s *ClientState) WatchKeys(keys ...string) {
+	s.mu.RLock()
+	registry := s.watchRegistry
+	s.mu.RUnlock()
+
+	if registry == nil {
+		return
+	}
+
+	registry.Watch(s, keys...)
+}
+
+// UnwatchAll removes all watched keys for the client and clears failure state.
+func (s *ClientState) UnwatchAll() {
+	s.mu.RLock()
+	registry := s.watchRegistry
+	s.mu.RUnlock()
+
+	if registry != nil {
+		registry.UnwatchAll(s)
+	}
+
+	s.ClearTransactionFailure()
+}
+
+// TransactionFailed reports whether optimistic locking marked the transaction as aborted.
+func (s *ClientState) TransactionFailed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.TxFailed
+}
+
+// MarkTransactionFailed marks the transaction as invalidated by a watched-key mutation.
+func (s *ClientState) MarkTransactionFailed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.TxFailed = true
+}
+
+// ClearTransactionFailure resets the optimistic-locking failure flag.
+func (s *ClientState) ClearTransactionFailure() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.TxFailed = false
+}
+
+func (s *ClientState) addWatchedKey(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.watchedKeys == nil {
+		s.watchedKeys = make(map[string]struct{})
+	}
+	s.watchedKeys[key] = struct{}{}
+}
+
+func (s *ClientState) drainWatchedKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	keys := make([]string, 0, len(s.watchedKeys))
+	for key := range s.watchedKeys {
+		keys = append(keys, key)
+	}
+	clear(s.watchedKeys)
+	return keys
+}
+
+// DrainTransaction returns the queued commands and exits the transaction state.
+func (s *ClientState) DrainTransaction() []QueuedCommand {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	queued := s.TxQueue
+	s.InTransaction = false
+	s.TxQueue = nil
+	return queued
 }
 
 // ResetTransaction clears queued transaction state.
@@ -49,5 +187,6 @@ func (s *ClientState) ResetTransaction() {
 	defer s.mu.Unlock()
 
 	s.InTransaction = false
+	s.TxFailed = false
 	s.TxQueue = nil
 }

--- a/internal/server/client_state_test.go
+++ b/internal/server/client_state_test.go
@@ -18,6 +18,18 @@ func (stubExecutor) Execute(context.Context, protocol.Value) (protocol.Value, er
 	return protocol.SimpleString{Value: "OK"}, nil
 }
 
+type stubWatchExecutor struct {
+	registry *WatchRegistry
+}
+
+func (s stubWatchExecutor) Execute(context.Context, protocol.Value) (protocol.Value, error) {
+	return protocol.SimpleString{Value: "OK"}, nil
+}
+
+func (s stubWatchExecutor) WatchRegistry() *WatchRegistry {
+	return s.registry
+}
+
 func TestClientStateLifecycle(t *testing.T) {
 	cfg := config.Default()
 	cfg.RequirePass = "secret"
@@ -69,5 +81,30 @@ func TestClientStateLifecycle(t *testing.T) {
 	srv.clearClientStates()
 	if got := srv.getClientState(2); got != nil {
 		t.Fatalf("getClientState(2) after clear = %p, want nil", got)
+	}
+}
+
+func TestServerClientStateCleanupUnwatchesKeys(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := NewWatchRegistry()
+	srv := New(config.Default(), logger, storage.NewStore(), stubWatchExecutor{registry: registry})
+
+	state := srv.createClientState(1)
+	state.WatchKeys("alpha")
+
+	srv.removeClientState(1)
+	registry.Touch("alpha")
+
+	if state.TransactionFailed() {
+		t.Fatal("TransactionFailed() = true, want false after cleanup removed all watchers")
+	}
+
+	other := srv.createClientState(2)
+	other.WatchKeys("beta")
+	srv.clearClientStates()
+	registry.Touch("beta")
+
+	if other.TransactionFailed() {
+		t.Fatal("TransactionFailed() for cleared state = true, want false after clearClientStates cleanup")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,13 +17,18 @@ type executor interface {
 	Execute(context.Context, protocol.Value) (protocol.Value, error)
 }
 
+type watchRegistryProvider interface {
+	WatchRegistry() *WatchRegistry
+}
+
 // Server owns the TCP listener, active clients, and command execution pipeline.
 type Server struct {
-	cfg      config.Config
-	logger   *slog.Logger
-	store    *storage.Store
-	executor executor
-	registry *Registry
+	cfg           config.Config
+	logger        *slog.Logger
+	store         *storage.Store
+	executor      executor
+	registry      *Registry
+	watchRegistry *WatchRegistry
 
 	clientStates   map[uint64]*ClientState
 	clientStatesMu sync.RWMutex
@@ -36,7 +41,7 @@ type Server struct {
 
 // New constructs a server ready to listen for TCP clients.
 func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor executor) *Server {
-	return &Server{
+	srv := &Server{
 		cfg:          cfg,
 		logger:       logger,
 		store:        store,
@@ -44,6 +49,11 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 		registry:     NewRegistry(),
 		clientStates: make(map[uint64]*ClientState),
 	}
+	if provider, ok := executor.(watchRegistryProvider); ok {
+		srv.watchRegistry = provider.WatchRegistry()
+	}
+
+	return srv
 }
 
 // ListenAndServe starts the TCP listener and blocks until shutdown.
@@ -126,6 +136,7 @@ func (s *Server) createClientState(clientID uint64) *ClientState {
 		ID:            clientID,
 		Authenticated: s.cfg.RequirePass == "",
 	}
+	state.SetWatchRegistry(s.watchRegistry)
 
 	s.clientStatesMu.Lock()
 	defer s.clientStatesMu.Unlock()
@@ -143,14 +154,25 @@ func (s *Server) getClientState(clientID uint64) *ClientState {
 
 func (s *Server) removeClientState(clientID uint64) {
 	s.clientStatesMu.Lock()
-	defer s.clientStatesMu.Unlock()
-
+	state := s.clientStates[clientID]
 	delete(s.clientStates, clientID)
+	s.clientStatesMu.Unlock()
+
+	if state != nil {
+		state.UnwatchAll()
+	}
 }
 
 func (s *Server) clearClientStates() {
 	s.clientStatesMu.Lock()
-	defer s.clientStatesMu.Unlock()
-
+	states := make([]*ClientState, 0, len(s.clientStates))
+	for _, state := range s.clientStates {
+		states = append(states, state)
+	}
 	clear(s.clientStates)
+	s.clientStatesMu.Unlock()
+
+	for _, state := range states {
+		state.UnwatchAll()
+	}
 }

--- a/internal/server/watch_registry.go
+++ b/internal/server/watch_registry.go
@@ -1,0 +1,86 @@
+package server
+
+import "sync"
+
+// WatchRegistry tracks optimistic-lock watchers for keys across all client states.
+type WatchRegistry struct {
+	mu       sync.RWMutex
+	watchers map[string]map[uint64]*ClientState
+}
+
+// NewWatchRegistry constructs an empty optimistic-lock watch registry.
+func NewWatchRegistry() *WatchRegistry {
+	return &WatchRegistry{watchers: make(map[string]map[uint64]*ClientState)}
+}
+
+// Watch records that state should be invalidated when any of the supplied keys changes.
+func (r *WatchRegistry) Watch(state *ClientState, keys ...string) {
+	if r == nil || state == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+
+		watchers := r.watchers[key]
+		if watchers == nil {
+			watchers = make(map[uint64]*ClientState)
+			r.watchers[key] = watchers
+		}
+
+		watchers[state.ID] = state
+		state.addWatchedKey(key)
+	}
+}
+
+// UnwatchAll removes all watched keys for a client state.
+func (r *WatchRegistry) UnwatchAll(state *ClientState) {
+	if r == nil || state == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	keys := state.drainWatchedKeys()
+
+	for _, key := range keys {
+		watchers := r.watchers[key]
+		if watchers == nil {
+			continue
+		}
+
+		delete(watchers, state.ID)
+		if len(watchers) == 0 {
+			delete(r.watchers, key)
+		}
+	}
+
+}
+
+// Touch marks transactions as failed for any clients watching the supplied keys.
+func (r *WatchRegistry) Touch(keys ...string) {
+	if r == nil {
+		return
+	}
+
+	states := make(map[uint64]*ClientState)
+
+	r.mu.RLock()
+	for _, key := range keys {
+		watchers := r.watchers[key]
+		for id, state := range watchers {
+			states[id] = state
+		}
+	}
+	r.mu.RUnlock()
+
+	for _, state := range states {
+		state.MarkTransactionFailed()
+	}
+}

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -26,6 +26,30 @@ func newStream() *streamValue {
 	return &streamValue{}
 }
 
+// ValidateXAddID reports whether raw is a syntactically valid XADD ID.
+func ValidateXAddID(raw string) error {
+	if raw == "*" {
+		return nil
+	}
+
+	_, err := parseStreamAddID(raw)
+	return err
+}
+
+// ValidateXReadID reports whether raw is a syntactically valid XREAD ID.
+func ValidateXReadID(raw string) error {
+	if raw == "$" {
+		return nil
+	}
+	if _, _, ok := strings.Cut(raw, "-"); !ok {
+		_, err := parseNonNegativeStreamInt(raw)
+		return err
+	}
+
+	_, err := parseStreamAddID(raw)
+	return err
+}
+
 func (s *streamValue) add(rawID string, values [][]byte, nowMillis int64) (string, error) {
 	var (
 		id  streamID

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -316,6 +316,127 @@ func TestServerHandlesStreamCommands(t *testing.T) {
 	}
 }
 
+func TestServerHandlesTransactionCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	otherConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) second client error = %v", addr, err)
+	}
+	defer func() { _ = otherConn.Close() }()
+	otherParser := protocol.NewParser(otherConn)
+
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "QUEUED"}, "SET", "name", "1")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "QUEUED"}, "INCR", "name")
+	assertCommandResponse(t, otherConn, otherParser, protocol.BulkString{Null: true}, "GET", "name")
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.SimpleString{Value: "OK"},
+		protocol.Integer{Value: 2},
+	}}, "EXEC")
+	assertCommandResponse(t, otherConn, otherParser, protocol.BulkString{Data: []byte("2")}, "GET", "name")
+
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "QUEUED"}, "SET", "temp", "discarded")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "DISCARD")
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Null: true}, "GET", "temp")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR EXEC without MULTI"}, "EXEC")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerHandlesWatchOptimisticLocking(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := godislogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	watcherConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) watcher error = %v", addr, err)
+	}
+	defer func() { _ = watcherConn.Close() }()
+	watcherParser := protocol.NewParser(watcherConn)
+
+	writerConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) writer error = %v", addr, err)
+	}
+	defer func() { _ = writerConn.Close() }()
+	writerParser := protocol.NewParser(writerConn)
+
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "OK"}, "WATCH", "balance")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "QUEUED"}, "SET", "balance", "2")
+	assertCommandResponse(t, writerConn, writerParser, protocol.SimpleString{Value: "OK"}, "SET", "balance", "1")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.Array{Null: true}, "EXEC")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.BulkString{Data: []byte("1")}, "GET", "balance")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "OK"}, "WATCH", "balance")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.ErrorValue{Message: "ERR WATCH inside MULTI is not allowed"}, "WATCH", "balance")
+	assertCommandResponse(t, watcherConn, watcherParser, protocol.SimpleString{Value: "OK"}, "DISCARD")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
 func waitForAddr(t *testing.T, srv *server.Server) string {
 	t.Helper()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -367,6 +367,14 @@ func TestServerHandlesTransactionCommands(t *testing.T) {
 	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "DISCARD")
 	assertCommandResponse(t, conn, parser, protocol.BulkString{Null: true}, "GET", "temp")
 	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR EXEC without MULTI"}, "EXEC")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR unknown command \"NOPE\""}, "NOPE")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "QUEUED"}, "SET", "after-abort", "1")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "EXECABORT Transaction discarded because of previous errors."}, "EXEC")
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Null: true}, "GET", "after-abort")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR invalid stream ID specified as stream command argument"}, "XADD", "events", "bad-id", "field", "value")
+	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "EXECABORT Transaction discarded because of previous errors."}, "EXEC")
 
 	cancel()
 	select {


### PR DESCRIPTION
This pull request introduces support for Redis-style transactions and optimistic locking (WATCH/MULTI/EXEC/DISCARD) in the command executor. It adds the necessary command handlers, updates the executor and client state to track transaction and watch state, ensures watched keys are invalidated on mutation, and provides comprehensive tests for transaction behaviors and edge cases.

**Transaction & Optimistic Locking Support:**

* Added handlers for `WATCH`, `MULTI`, `EXEC`, and `DISCARD` commands, enabling Redis-style transactions and optimistic locking. These handlers manage transaction state, command queuing, and abort execution if watched keys are modified by other clients. [[1]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R5-R106) [[2]](diffhunk://#diff-a99c4b2d3bcd537cd647689acfc1ddb3c75cb5e4641a56bd2ada52003daf499cR36-R42)
* Updated the `Executor` and `ClientState` to track transaction state, watched keys, and a shared `WatchRegistry` for key change notifications. [[1]](diffhunk://#diff-a99c4b2d3bcd537cd647689acfc1ddb3c75cb5e4641a56bd2ada52003daf499cR27) [[2]](diffhunk://#diff-0f079d4a572317c66b73149021c4fe0675fecd9375937a56b8065b56f7c8410cL18-R26)

**Key Mutation & Watch Integration:**

* Modified all mutating command handlers (e.g., `SET`, `DEL`, `INCR`, `LPUSH`, `RPUSH`, `BLPOP`, `ZADD`, `XADD`) to notify the watch registry when a key is changed, ensuring that transactions are properly invalidated if watched keys are modified. [[1]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R144) [[2]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R173-R181) [[3]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R204) [[4]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R221) [[5]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R238) [[6]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R286) [[7]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R333) [[8]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4R391)

**Error Handling Improvements:**

* Introduced Redis-compatible error sentinel values and error-wrapping functions for transaction-related errors (e.g., EXEC without MULTI, nested MULTI, WATCH inside MULTI), ensuring client-facing error messages match Redis behavior. [[1]](diffhunk://#diff-fae83202abea2eea657a6406a18a7c6f69cb4abf1a4ef3c41c13b4e0ea7e07dcR11-R18) [[2]](diffhunk://#diff-fae83202abea2eea657a6406a18a7c6f69cb4abf1a4ef3c41c13b4e0ea7e07dcR88-R107)

**Testing Enhancements:**

* Added comprehensive tests for transaction and watch behaviors, including command queuing, error handling, aborting transactions when watched keys are modified, and correct error responses for invalid transaction operations.
* Improved test utilities to support client state and watch registry setup, and enhanced value equality assertions to handle error values. [[1]](diffhunk://#diff-048ea080c5d31fb5a7113aeafa0bdf2091759d4a77e4f3615962e039fda2c351R736-R741) [[2]](diffhunk://#diff-048ea080c5d31fb5a7113aeafa0bdf2091759d4a77e4f3615962e039fda2c351R795-R802)

**Internal Refactoring:**

* Refactored command execution flow to support command queuing during transactions, centralized transaction control command detection, and improved error value generation for command responses. [[1]](diffhunk://#diff-a99c4b2d3bcd537cd647689acfc1ddb3c75cb5e4641a56bd2ada52003daf499cR61-R82) [[2]](diffhunk://#diff-a99c4b2d3bcd537cd647689acfc1ddb3c75cb5e4641a56bd2ada52003daf499cR91-R120)

These changes collectively bring robust transaction and optimistic locking support to the command executor, closely mirroring Redis semantics and ensuring correctness in concurrent scenarios.