### PR TITLE
Feat/distributed systems and availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Then try:
 - Startup-time RDB loading is available via `--rdb`, currently for DB `0` string keys only.
 - The server is still intentionally RESP2-centric at the command-behavior level, even though RESP3 boolean/null support exists in the protocol layer.
 - `Config.RequirePass` and per-connection client state are scaffolding for future auth/transaction work; full `AUTH`, `MULTI`, `EXEC`, `DISCARD`, and related behavior are not implemented yet.
-- Replication, broader persistence coverage, richer data structures, pub/sub, and full security features remain future milestones.
+- Core replication protocol support exists (`REPLCONF`, `PSYNC`, and `WAIT`), but broader replication completeness, broader persistence coverage, richer data structures, pub/sub, and full security features remain future milestones.
 
 ## Related docs
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ Then try:
 
 - The store currently uses a single `sync.RWMutex` for correctness and simplicity.
 - TTLs are normalized to Unix milliseconds internally.
+- Startup-time RDB loading is available via `--rdb`, currently for DB `0` string keys only.
 - The server is still intentionally RESP2-centric at the command-behavior level, even though RESP3 boolean/null support exists in the protocol layer.
 - `Config.RequirePass` and per-connection client state are scaffolding for future auth/transaction work; full `AUTH`, `MULTI`, `EXEC`, `DISCARD`, and related behavior are not implemented yet.
-- Replication, persistence, richer data structures, pub/sub, and full security features remain future milestones.
+- Replication, broader persistence coverage, richer data structures, pub/sub, and full security features remain future milestones.
 
 ## Related docs
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -142,11 +142,11 @@ Handle complex, multi-step operations safely.
 - [x] If a watching client is found, mark their connection state `TxFailed = true`
 - [x] When a client calls `EXEC`, if `TxFailed` is `true`, abort the transaction and return a Null Array: `*-1\r\n`
 
-### Phase 4: Distributed Systems & High Availability — **Partial**
+### Phase 4: Distributed Systems & High Availability — **Done**
 
 Implement the Redis replication protocol.
 
-#### RDB Persistence (Disk I/O) — **Done for startup loading scope**
+#### RDB Persistence (Disk I/O) — **Done**
 
 - [x] Parse the `.rdb` binary format on server startup
 - [x] Read the 9-byte magic string `REDIS0011`
@@ -155,27 +155,27 @@ Implement the Redis replication protocol.
 
 Current implementation scope: startup-time loading via `--rdb`, DB `0` only, and string values only. Unsupported databases or value types fail fast during startup.
 
-#### Master / Replica Handshake — **Not done**
+#### Master / Replica Handshake — **Done**
 
-- [ ] When acting as a **Replica**:
-  - [ ] Connect to the Master's TCP port
-  - [ ] Send `PING`, `REPLCONF listening-port <port>`, and `PSYNC ? -1`
-- [ ] When acting as a **Master**:
-  - [ ] Respond to `PSYNC` with `+FULLRESYNC <master_replid> 0\r\n`
-  - [ ] Send an empty RDB file over the socket as a heavily formatted Bulk String
+- [x] When acting as a **Replica**:
+  - [x] Connect to the Master's TCP port
+  - [x] Send `PING`, `REPLCONF listening-port <port>`, and `PSYNC ? -1`
+- [x] When acting as a **Master**:
+  - [x] Respond to `PSYNC` with `+FULLRESYNC <master_replid> 0\r\n`
+  - [x] Send an empty RDB file over the socket as a heavily formatted Bulk String
 
-#### Command Propagation — **Not done**
+#### Command Propagation — **Done**
 
-- [ ] The Master must maintain a list of active Replica TCP connections
-- [ ] Whenever a state-mutating command (`SET`, `DEL`) is executed successfully, the Master encodes it back into RESP and writes it to every Replica's network socket
+- [x] The Master must maintain a list of active Replica TCP connections
+- [x] Whenever a state-mutating command (`SET`, `DEL`) is executed successfully, the Master encodes it back into RESP and writes it to every Replica's network socket
 
-#### Synchronization (`WAIT <numreplicas> <timeout>`) — **Not done**
+#### Synchronization (`WAIT <numreplicas> <timeout>`) — **Done**
 
-- [ ] Master must track the replication offset (number of bytes of commands sent)
-- [ ] Master pauses the client's goroutine
-- [ ] Master sends `REPLCONF GETACK *` to replicas
-- [ ] Replicas reply with `REPLCONF ACK <offset>`
-- [ ] Master resumes the client when `<numreplicas>` have reported an offset greater than or equal to the Master's offset, or when `<timeout>` is reached
+- [x] Master must track the replication offset (number of bytes of commands sent)
+- [x] Master pauses the client's goroutine
+- [x] Master sends `REPLCONF GETACK *` to replicas
+- [x] Replicas reply with `REPLCONF ACK <offset>`
+- [x] Master resumes the client when `<numreplicas>` have reported an offset greater than or equal to the Master's offset, or when `<timeout>` is reached
 
 ### Phase 5: Pub/Sub & Security — **Partial**
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -5,6 +5,16 @@
 - **Primary Focus:** Concurrency, low-level networking (TCP), custom protocols (RESP), and distributed systems
 - **Description:** A high-performance, concurrent Redis-compatible key-value store built from scratch
 
+### Current Implementation Status
+
+Legend: `[x]` done, `[~]` partially done, `[ ]` not done.
+
+- **Phase 1:** Done
+- **Phase 2:** Done
+- **Phase 3:** Done
+- **Phase 4:** Partial (`RDB` startup loading is implemented for DB 0 string keys; replication remains not implemented)
+- **Phase 5:** Partial (`--requirepass` / client auth state scaffold exists, but pub/sub and full AUTH flow are not implemented)
+
 ## 1. Executive Summary
 
 This project aims to build **RuneDB**, a production-ready, highly concurrent, in-memory key-value data store from scratch, fully compliant with the **Redis Serialization Protocol (RESP)**.
@@ -27,167 +37,169 @@ To ensure this project accurately reflects senior-level engineering, the followi
 
 ## 3. Scope & Milestones (Epics)
 
-### Phase 1: Foundation & The Network Layer
+### Phase 1: Foundation & The Network Layer — **Done**
 
 Establish the core TCP loop, memory store, and parser.
 
-#### Networking (TCP Loop)
+#### Networking (TCP Loop) — **Done**
 
-- Implement `net.Listen("tcp", ":6379")`
-- Use an infinite `for` loop calling `Accept()`
-- For each incoming connection, spawn a new goroutine: `go handleConnection(conn)`
-- Maintain a thread-safe registry of active client connections to handle clean disconnects
+- [x] Implement `net.Listen("tcp", ":6379")`
+- [x] Use an infinite `for` loop calling `Accept()`
+- [x] For each incoming connection, spawn a new goroutine: `go handleConnection(conn)`
+- [x] Maintain a thread-safe registry of active client connections to handle clean disconnects
 
-#### Protocol Parsing (RESP)
+#### Protocol Parsing (RESP) — **Done**
 
-- Implement a parser that reads from the TCP socket using `bufio.Reader`
-- Parse RESP data types:
-  - Simple Strings (`+`)
-  - Errors (`-`)
-  - Integers (`:`)
-  - Bulk Strings (`$`)
-  - Arrays (`*`)
-- Crucial: Handle fragmented TCP packets (e.g., a bulk string might arrive in multiple TCP segments)
-- Rely on the lengths specified in the RESP protocol (`$<length>\r\n`), not network frame sizes
+- [x] Implement a parser that reads from the TCP socket using `bufio.Reader`
+- [x] Parse RESP data types:
+  - [x] Simple Strings (`+`)
+  - [x] Errors (`-`)
+  - [x] Integers (`:`)
+  - [x] Bulk Strings (`$`)
+  - [x] Arrays (`*`)
+- [x] Handle fragmented TCP packets (e.g., a bulk string might arrive in multiple TCP segments)
+- [x] Rely on the lengths specified in the RESP protocol (`$<length>\r\n`), not network frame sizes
 
-#### Basic Commands (`PING`, `ECHO`)
+#### Basic Commands (`PING`, `ECHO`) — **Done**
 
-- `PING`: Return `+PONG\r\n` (Simple String)
-- `ECHO <msg>`: Return the exact argument as a Bulk String: `$<len>\r\n<msg>\r\n`
+- [x] `PING`: Return `+PONG\r\n` (Simple String)
+- [x] `ECHO <msg>`: Return the exact argument as a Bulk String: `$<len>\r\n<msg>\r\n`
 
-#### Core Storage Engine (`SET`, `GET`)
+#### Core Storage Engine (`SET`, `GET`) — **Done**
 
-- Create a global state struct containing a `map[string]Value` and a `sync.RWMutex`
-- `Value` should be a struct containing:
-  - `Data ([]byte)`
-  - `ExpiresAt (int64)`
-- `GET`:
-  - Acquire `RLock()`
-  - Read map
-  - Release `RUnlock()`
-- `SET`:
-  - Acquire `Lock()`
-  - Write map
-  - Release `Unlock()`
+- [x] Create a global state struct containing a `map[string]Value` and a `sync.RWMutex`
+- [x] `Value` should be a struct containing:
+  - [x] `Data ([]byte)` *(implemented as the string payload field on the stored value type)*
+  - [x] `ExpiresAt (int64)`
+- [x] `GET`:
+  - [x] Acquire `RLock()`
+  - [x] Read map
+  - [x] Release `RUnlock()`
+- [x] `SET`:
+  - [x] Acquire `Lock()`
+  - [x] Write map
+  - [x] Release `Unlock()`
 
-#### State Management (Key Expiry / TTL)
+#### State Management (Key Expiry / TTL) — **Done**
 
-- Implement `PX` (milliseconds) and `EX` (seconds) arguments for `SET`
-- **Passive eviction:** On `GET`, check if `time.Now().UnixMilli() > ExpiresAt`; if true, delete the key and return `nil`
-- **Active eviction:** Create a background goroutine that wakes up every `100ms`, samples a batch of keys with TTLs, and deletes expired keys to prevent memory bloat from unread keys
+- [x] Implement `PX` (milliseconds) and `EX` (seconds) arguments for `SET`
+- [x] **Passive eviction:** On `GET`, check if `time.Now().UnixMilli() > ExpiresAt`; if true, delete the key and return `nil`
+- [x] **Active eviction:** Create a background goroutine that wakes up every `100ms`, samples a batch of keys with TTLs, and deletes expired keys to prevent memory bloat from unread keys
 
-### Phase 2: Advanced Data Structures
+### Phase 2: Advanced Data Structures — **Done**
 
 Expand the data model, requiring specific memory layouts for performance.
 
-#### Lists (`LPUSH`, `RPUSH`, `LRANGE`)
+#### Lists (`LPUSH`, `RPUSH`, `LRANGE`) — **Done**
 
-- Values in the store must support different types (`interface{}` or tagged unions)
-- Use a Go slice `[][]byte` for the list
-- For blocking commands (`BLPOP`), implement a pub/sub-like channel system where the client's goroutine pauses (`select` on a Go channel) until a background process or another client `PUSH`es to that key
+- [x] Values in the store must support different types (`interface{}` or tagged unions)
+- [x] Use a Go slice `[][]byte` for the list
+- [x] For blocking commands (`BLPOP`), implement a pub/sub-like channel system where the client's goroutine pauses (`select` on a Go channel) until a background process or another client `PUSH`es to that key
 
-#### Sorted Sets (`ZADD`, `ZRANGE`)
+#### Sorted Sets (`ZADD`, `ZRANGE`) — **Done**
 
 Implementing this efficiently is complex. You need a composite data structure:
 
-- A `map[string]float64` for $O(1)$ lookups of a member's score
-- A Skip List (or a balanced Binary Search Tree) for $O(\log N)$ insertions and range queries based on scores
+- [x] A `map[string]float64` for $O(1)$ lookups of a member's score
+- [x] A Skip List (or a balanced Binary Search Tree) for $O(\log N)$ insertions and range queries based on scores
 
-#### Streams (`XADD`, `XREAD`)
+#### Streams (`XADD`, `XREAD`) — **Done**
 
-- IDs are formatted as `<millisecondsTime>-<sequenceNumber>`
-- Implement auto-generation of IDs (e.g., `XADD mystream * value`)
-- Handle the edge case where multiple commands arrive in the same millisecond by incrementing the sequence number
-- Store stream entries in an append-only slice or Radix tree
+- [x] IDs are formatted as `<millisecondsTime>-<sequenceNumber>`
+- [x] Implement auto-generation of IDs (e.g., `XADD mystream * value`)
+- [x] Handle the edge case where multiple commands arrive in the same millisecond by incrementing the sequence number
+- [x] Store stream entries in an append-only slice or Radix tree
 
-### Phase 3: ACID Transactions & Concurrency Control
+### Phase 3: ACID Transactions & Concurrency Control — **Done**
 
 Handle complex, multi-step operations safely.
 
-#### Basic Atomicity (`INCR`)
+#### Basic Atomicity (`INCR`) — **Done**
 
-- Read the value, parse it as a base-10 integer, increment, convert back to bytes, and save
-- Wrap this entire read-modify-write cycle in a single write `Lock()` to prevent race conditions
+- [x] Read the value, parse it as a base-10 integer, increment, convert back to bytes, and save
+- [x] Wrap this entire read-modify-write cycle in a single write `Lock()` to prevent race conditions
 
-#### Transaction Queueing (`MULTI`, `EXEC`, `DISCARD`)
+#### Transaction Queueing (`MULTI`, `EXEC`, `DISCARD`) — **Done**
 
-- Add state to the client connection struct:
-  - `InTransaction (bool)`
-  - `TxQueue ([]Command)`
-- When `MULTI` is received:
-  - Set `InTransaction = true`
-  - Return `+OK\r\n`
-- Subsequent commands are parsed but **not** executed:
-  - Append them to `TxQueue`
-  - Return `+QUEUED\r\n`
-- On `EXEC`:
-  - Iterate through `TxQueue`
-  - Execute all commands sequentially
-  - Return a RESP Array of their results
+- [x] Add state to the client connection struct:
+  - [x] `InTransaction (bool)`
+  - [x] `TxQueue ([]Command)`
+- [x] When `MULTI` is received:
+  - [x] Set `InTransaction = true`
+  - [x] Return `+OK\r\n`
+- [x] Subsequent commands are parsed but **not** executed:
+  - [x] Append them to `TxQueue`
+  - [x] Return `+QUEUED\r\n`
+- [x] On `EXEC`:
+  - [x] Iterate through `TxQueue`
+  - [x] Execute all commands sequentially
+  - [x] Return a RESP Array of their results
 
-#### Optimistic Locking (`WATCH`)
+#### Optimistic Locking (`WATCH`) — **Done**
 
-- Create a global `map[string][]net.Conn` mapping keys to watching clients
-- Whenever a key is modified (e.g., via `SET`), check this map
-- If a watching client is found, mark their connection state `TxFailed = true`
-- When a client calls `EXEC`, if `TxFailed` is `true`, abort the transaction and return a Null Array: `*-1\r\n`
+- [x] Create a global `map[string][]net.Conn` mapping keys to watching clients *(implemented with a shared watch registry keyed by key and client state)*
+- [x] Whenever a key is modified (e.g., via `SET`), check this map
+- [x] If a watching client is found, mark their connection state `TxFailed = true`
+- [x] When a client calls `EXEC`, if `TxFailed` is `true`, abort the transaction and return a Null Array: `*-1\r\n`
 
-### Phase 4: Distributed Systems & High Availability
+### Phase 4: Distributed Systems & High Availability — **Partial**
 
 Implement the Redis replication protocol.
 
-#### RDB Persistence (Disk I/O)
+#### RDB Persistence (Disk I/O) — **Done for startup loading scope**
 
-- Parse the `.rdb` binary format on server startup
-- Read the 9-byte magic string `REDIS0011`
-- Handle database selectors (`0xFE`) and expiry metadata opcodes (`0xFD`, `0xFC`)
-- Load the keys into the in-memory map before accepting TCP connections
+- [x] Parse the `.rdb` binary format on server startup
+- [x] Read the 9-byte magic string `REDIS0011`
+- [x] Handle database selectors (`0xFE`) and expiry metadata opcodes (`0xFD`, `0xFC`)
+- [x] Load the keys into the in-memory map before accepting TCP connections
 
-#### Master / Replica Handshake
+Current implementation scope: startup-time loading via `--rdb`, DB `0` only, and string values only. Unsupported databases or value types fail fast during startup.
 
-- When acting as a **Replica**:
-  - Connect to the Master's TCP port
-  - Send `PING`, `REPLCONF listening-port <port>`, and `PSYNC ? -1`
-- When acting as a **Master**:
-  - Respond to `PSYNC` with `+FULLRESYNC <master_replid> 0\r\n`
-  - Send an empty RDB file over the socket as a heavily formatted Bulk String
+#### Master / Replica Handshake — **Not done**
 
-#### Command Propagation
+- [ ] When acting as a **Replica**:
+  - [ ] Connect to the Master's TCP port
+  - [ ] Send `PING`, `REPLCONF listening-port <port>`, and `PSYNC ? -1`
+- [ ] When acting as a **Master**:
+  - [ ] Respond to `PSYNC` with `+FULLRESYNC <master_replid> 0\r\n`
+  - [ ] Send an empty RDB file over the socket as a heavily formatted Bulk String
 
-- The Master must maintain a list of active Replica TCP connections
-- Whenever a state-mutating command (`SET`, `DEL`) is executed successfully, the Master encodes it back into RESP and writes it to every Replica's network socket
+#### Command Propagation — **Not done**
 
-#### Synchronization (`WAIT <numreplicas> <timeout>`)
+- [ ] The Master must maintain a list of active Replica TCP connections
+- [ ] Whenever a state-mutating command (`SET`, `DEL`) is executed successfully, the Master encodes it back into RESP and writes it to every Replica's network socket
 
-- Master must track the replication offset (number of bytes of commands sent)
-- Master pauses the client's goroutine
-- Master sends `REPLCONF GETACK *` to replicas
-- Replicas reply with `REPLCONF ACK <offset>`
-- Master resumes the client when `<numreplicas>` have reported an offset greater than or equal to the Master's offset, or when `<timeout>` is reached
+#### Synchronization (`WAIT <numreplicas> <timeout>`) — **Not done**
 
-### Phase 5: Pub/Sub & Security
+- [ ] Master must track the replication offset (number of bytes of commands sent)
+- [ ] Master pauses the client's goroutine
+- [ ] Master sends `REPLCONF GETACK *` to replicas
+- [ ] Replicas reply with `REPLCONF ACK <offset>`
+- [ ] Master resumes the client when `<numreplicas>` have reported an offset greater than or equal to the Master's offset, or when `<timeout>` is reached
 
-#### Pub/Sub Engine (`SUBSCRIBE`, `PUBLISH`)
+### Phase 5: Pub/Sub & Security — **Partial**
 
-- Maintain a global `map[string][]net.Conn` mapping channel names to active client sockets
-- When a client issues `SUBSCRIBE`, flag their connection
-- They can now only issue `PING`, `SUBSCRIBE`, and `UNSUBSCRIBE` commands
-- `PUBLISH <channel> <msg>`:
-  - Look up the channel in the map
-  - Format a RESP Array (e.g., `*3\r\n$7\r\nmessage\r\n...`)
-  - Write it to all matching client sockets
+#### Pub/Sub Engine (`SUBSCRIBE`, `PUBLISH`) — **Not done**
 
-#### Authentication (`AUTH <password>`)
+- [ ] Maintain a global `map[string][]net.Conn` mapping channel names to active client sockets
+- [ ] When a client issues `SUBSCRIBE`, flag their connection
+- [ ] They can now only issue `PING`, `SUBSCRIBE`, and `UNSUBSCRIBE` commands
+- [ ] `PUBLISH <channel> <msg>`:
+  - [ ] Look up the channel in the map
+  - [ ] Format a RESP Array (e.g., `*3\r\n$7\r\nmessage\r\n...`)
+  - [ ] Write it to all matching client sockets
 
-- Allow passing a `--requirepass` flag on server startup
-- If set, all client connections initialize with `Authenticated = false`
-- Reject all commands (return `-NOAUTH Authentication required.\r\n`) except `AUTH` and `PING` until `AUTH` is successfully called
+#### Authentication (`AUTH <password>`) — **Partial**
+
+- [x] Allow passing a `--requirepass` flag on server startup
+- [x] If set, all client connections initialize with `Authenticated = false`
+- [ ] Reject all commands (return `-NOAUTH Authentication required.\r\n`) except `AUTH` and `PING` until `AUTH` is successfully called
 
 ## 4. Non-Functional Requirements (Production Readiness)
 
-- **High concurrency performance:** Avoid blocking the main accept loop. Lock contention must be minimized. Use `RLock()` instead of `Lock()` for `GET` operations
-- **Graceful shutdown:** Use `os/signal.Notify(chan, syscall.SIGINT, syscall.SIGTERM)`. Upon signal, stop accepting new connections, wait for active `TxQueue`s to finish `EXEC`, flush the state to `dump.rdb` (if persistence is enabled), and exit
-- **Observability:** Use `log/slog` for structured logging. Log connection drops, replication syncs, and parsing errors
+- [x] **High concurrency performance:** Avoid blocking the main accept loop. Lock contention is minimized, and `GET` uses `RLock()` / `RUnlock()` paths.
+- [~] **Graceful shutdown:** Signal-driven shutdown, listener stop, client cleanup, and handler waiting are implemented; flushing state to `dump.rdb` is not.
+- [~] **Observability:** `log/slog` structured logging is in place and logs connection / parser / response issues; replication-specific observability is not implemented because replication is not implemented.
 
 ## 5. Out of Scope (For V1)
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -12,7 +12,7 @@ Legend: `[x]` done, `[~]` partially done, `[ ]` not done.
 - **Phase 1:** Done
 - **Phase 2:** Done
 - **Phase 3:** Done
-- **Phase 4:** Partial (`RDB` startup loading is implemented for DB 0 string keys; replication remains not implemented)
+- **Phase 4:** Done (`RDB` startup loading is implemented for DB 0 string keys, and replication handshake/propagation/`WAIT` support is implemented)
 - **Phase 5:** Partial (`--requirepass` / client auth state scaffold exists, but pub/sub and full AUTH flow are not implemented)
 
 ## 1. Executive Summary
@@ -199,7 +199,7 @@ Current implementation scope: startup-time loading via `--rdb`, DB `0` only, and
 
 - [x] **High concurrency performance:** Avoid blocking the main accept loop. Lock contention is minimized, and `GET` uses `RLock()` / `RUnlock()` paths.
 - [~] **Graceful shutdown:** Signal-driven shutdown, listener stop, client cleanup, and handler waiting are implemented; flushing state to `dump.rdb` is not.
-- [~] **Observability:** `log/slog` structured logging is in place and logs connection / parser / response issues; replication-specific observability is not implemented because replication is not implemented.
+- [~] **Observability:** `log/slog` structured logging is in place and logs connection / parser / response issues; replication is implemented, but dedicated replication-specific metrics/logging are still limited.
 
 ## 5. Out of Scope (For V1)
 

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -7,8 +7,10 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
 	"github.com/maltemindedal/runedb/internal/server"
 	"github.com/maltemindedal/runedb/internal/storage"
 )
@@ -51,44 +53,175 @@ func (e *Executor) handleMulti(ctx context.Context, request *Request) (protocol.
 	return protocol.SimpleString{Value: "OK"}, nil
 }
 
-func (e *Executor) handleExec(ctx context.Context, request *Request) (protocol.Value, error) {
+func (e *Executor) handleExec(ctx context.Context, request *Request) (server.ExecuteResult, error) {
 	if len(request.Args) != 0 {
-		return nil, wrongNumberOfArgumentsError("EXEC")
+		return server.ExecuteResult{}, wrongNumberOfArgumentsError("EXEC")
 	}
 
 	state, err := clientStateFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return server.ExecuteResult{}, err
 	}
 	if !state.InTransactionActive() {
-		return nil, ErrExecWithoutMultiError()
+		return server.ExecuteResult{}, ErrExecWithoutMultiError()
 	}
 	if state.TransactionDirty() {
 		state.ResetTransaction()
 		state.UnwatchAll()
-		return nil, ErrExecAbortError()
+		return server.ExecuteResult{}, ErrExecAbortError()
 	}
 	if state.TransactionFailed() {
 		state.ResetTransaction()
 		state.UnwatchAll()
-		return protocol.Array{Null: true}, nil
+		return server.SingleResponse(protocol.Array{Null: true}), nil
 	}
 	state.UnwatchAll()
 
 	queued := state.DrainTransaction()
 	responses := make([]protocol.Value, 0, len(queued))
+	propagation := make([]protocol.Value, 0, len(queued))
 	for _, queuedCommand := range queued {
-		response, execErr := e.executeRequest(ctx, &Request{Name: queuedCommand.Name, Args: queuedCommand.Args}, false)
+		result, execErr := e.executeRequestDetailed(ctx, &Request{Name: queuedCommand.Name, Args: queuedCommand.Args}, false)
 		if execErr != nil {
 			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
-				return nil, execErr
+				return server.ExecuteResult{}, execErr
 			}
-			response = responseErrorValue(execErr)
+			responses = append(responses, responseErrorValue(execErr))
+			continue
 		}
-		responses = append(responses, response)
+		if len(result.Responses) != 1 {
+			responses = append(responses, protocol.ErrorValue{Message: "ERR queued command returned an invalid response"})
+			continue
+		}
+		responses = append(responses, result.Responses[0])
+		propagation = append(propagation, result.Propagation...)
 	}
 
-	return protocol.Array{Elements: responses}, nil
+	result := server.SingleResponse(protocol.Array{Elements: responses})
+	result.Propagation = propagation
+	return result, nil
+}
+
+func (e *Executor) handleReplConf(ctx context.Context, request *Request) (server.ExecuteResult, error) {
+	if len(request.Args) != 2 {
+		return server.ExecuteResult{}, wrongNumberOfArgumentsError("REPLCONF")
+	}
+	subcommand := strings.ToUpper(string(request.Args[0]))
+
+	switch subcommand {
+	case "LISTENING-PORT":
+		port, err := parseReplicationPortArgument(request.Args[1])
+		if err != nil {
+			return server.ExecuteResult{}, ErrSyntaxError()
+		}
+
+		if state, ok := server.ClientStateFromContext(ctx); ok && state != nil {
+			state.SetReplicaListeningPort(port)
+		}
+
+		return server.SingleResponse(protocol.SimpleString{Value: "OK"}), nil
+	case "GETACK":
+		if !server.IsReplicationOrigin(ctx) || string(request.Args[1]) != "*" {
+			return server.ExecuteResult{}, ErrSyntaxError()
+		}
+
+		ackOffset := int64(0)
+		if e.replication != nil {
+			ackOffset = e.replication.ReplicaOffset()
+		}
+
+		result := server.ExecuteResult{}
+		result.UpstreamReplies = []protocol.Value{propagationFrame(&Request{
+			Name: "REPLCONF",
+			Args: [][]byte{[]byte("ACK"), []byte(strconv.FormatInt(ackOffset, 10))},
+		})}
+		return result, nil
+	case "ACK":
+		ackOffset, err := parseIntegerArgument(request.Args[1])
+		if err != nil || ackOffset < 0 {
+			return server.ExecuteResult{}, ErrSyntaxError()
+		}
+
+		if state, ok := server.ClientStateFromContext(ctx); ok && state != nil && state.IsReplica() && e.replicaPeers != nil {
+			e.replicaPeers.UpdateAck(state.ID, ackOffset)
+		}
+
+		return server.ExecuteResult{}, nil
+	default:
+		return server.ExecuteResult{}, ErrSyntaxError()
+	}
+}
+
+func (e *Executor) handlePSync(ctx context.Context, request *Request) (server.ExecuteResult, error) {
+	if len(request.Args) != 2 {
+		return server.ExecuteResult{}, wrongNumberOfArgumentsError("PSYNC")
+	}
+	if string(request.Args[0]) != "?" || string(request.Args[1]) != "-1" {
+		return server.ExecuteResult{}, ErrSyntaxError()
+	}
+	if e.replication == nil || e.replication.MasterReplicationID == "" {
+		return server.ExecuteResult{}, fmt.Errorf("replication state unavailable")
+	}
+
+	if state, ok := server.ClientStateFromContext(ctx); ok && state != nil {
+		state.PromoteToReplica()
+	}
+
+	result := server.MultiResponse(
+		protocol.SimpleString{Value: fmt.Sprintf("FULLRESYNC %s 0", e.replication.MasterReplicationID)},
+		protocol.BulkString{Data: rdb.EmptySnapshot()},
+	)
+	result.RegisterReplica = true
+	return result, nil
+}
+
+func (e *Executor) handleWait(ctx context.Context, request *Request) (server.ExecuteResult, error) {
+	if len(request.Args) != 2 {
+		return server.ExecuteResult{}, wrongNumberOfArgumentsError("WAIT")
+	}
+
+	replicas, err := parseIntegerArgument(request.Args[0])
+	if err != nil || replicas < 0 {
+		return server.ExecuteResult{}, ErrValueNotIntegerError()
+	}
+	timeoutMillis, err := parseIntegerArgument(request.Args[1])
+	if err != nil || timeoutMillis < 0 {
+		return server.ExecuteResult{}, ErrValueNotIntegerError()
+	}
+
+	targetOffset := int64(0)
+	if state, ok := server.ClientStateFromContext(ctx); ok && state != nil {
+		targetOffset = state.LastWriteReplicationOffset()
+	} else if e.replication != nil {
+		targetOffset = e.replication.MasterOffset()
+	}
+
+	ackedReplicas := e.countReplicasAtOrAbove(targetOffset)
+	if ackedReplicas >= int(replicas) || timeoutMillis == 0 {
+		return server.SingleResponse(protocol.Integer{Value: int64(ackedReplicas)}), nil
+	}
+
+	if err := e.requestReplicaAcknowledgements(); err != nil {
+		return server.ExecuteResult{}, err
+	}
+
+	timer := time.NewTimer(time.Duration(timeoutMillis) * time.Millisecond)
+	defer timer.Stop()
+
+	for {
+		ackedReplicas, notified := e.countReplicasAtOrAboveWithNotify(targetOffset)
+		if ackedReplicas >= int(replicas) {
+			return server.SingleResponse(protocol.Integer{Value: int64(ackedReplicas)}), nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return server.ExecuteResult{}, ctx.Err()
+		case <-timer.C:
+			return server.SingleResponse(protocol.Integer{Value: int64(e.countReplicasAtOrAbove(targetOffset))}), nil
+		case <-notified:
+		}
+	}
 }
 
 func (e *Executor) handleDiscard(ctx context.Context, request *Request) (protocol.Value, error) {
@@ -491,6 +624,18 @@ func formatFloatScore(score float64) string {
 	return strconv.FormatFloat(score, 'g', -1, 64)
 }
 
+func parseReplicationPortArgument(raw []byte) (int, error) {
+	port, err := strconv.Atoi(string(raw))
+	if err != nil {
+		return 0, err
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("invalid port %d", port)
+	}
+
+	return port, nil
+}
+
 func clone(value []byte) []byte {
 	copied := make([]byte, len(value))
 	copy(copied, value)
@@ -512,4 +657,46 @@ func (e *Executor) touchWatchKeys(keys ...string) {
 	}
 
 	e.watchRegistry.Touch(keys...)
+}
+
+func (e *Executor) countReplicasAtOrAbove(targetOffset int64) int {
+	if e.replicaPeers == nil {
+		return 0
+	}
+
+	return e.replicaPeers.CountReplicasAtOrAbove(targetOffset)
+}
+
+func (e *Executor) countReplicasAtOrAboveWithNotify(targetOffset int64) (int, <-chan struct{}) {
+	if e.replicaPeers == nil {
+		return 0, nil
+	}
+
+	return e.replicaPeers.CountReplicasAtOrAboveWithNotify(targetOffset)
+}
+
+func (e *Executor) requestReplicaAcknowledgements() error {
+	if e.replicaPeers == nil {
+		return nil
+	}
+
+	request := propagationFrame(&Request{Name: "REPLCONF", Args: [][]byte{[]byte("GETACK"), []byte("*")}})
+	encoded, err := protocol.Encode(request)
+	if err != nil {
+		return fmt.Errorf("encode REPLCONF GETACK: %w", err)
+	}
+	if e.replication != nil {
+		e.replication.AdvanceMasterOffset(int64(len(encoded)))
+	}
+
+	for _, peer := range e.replicaPeers.Snapshot() {
+		if err := peer.WriteEncoded(encoded); err != nil {
+			e.logger.Warn("failed to request replica ACK", "replica_id", peer.ID, "error", err)
+			if closeErr := e.replicaPeers.RemoveAndClose(peer.ID); closeErr != nil {
+				e.logger.Debug("failed to close replica after ACK request failure", "replica_id", peer.ID, "error", closeErr)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -394,7 +394,7 @@ func (e *Executor) handleXAdd(_ context.Context, request *Request) (protocol.Val
 	}
 
 	e.touchWatchKeys(string(request.Args[0]))
-	return protocol.BulkString{Data: []byte(id)}, nil
+	return protocol.TextBulkString{Value: id}, nil
 }
 
 func (e *Executor) handleXRead(_ context.Context, request *Request) (protocol.Value, error) {
@@ -426,22 +426,22 @@ func (e *Executor) handleXRead(_ context.Context, request *Request) (protocol.Va
 func listResponse(values [][]byte) protocol.Array {
 	elements := make([]protocol.Value, 0, len(values))
 	for _, value := range values {
-		elements = append(elements, protocol.BulkString{Data: clone(value)})
+		elements = append(elements, protocol.BulkString{Data: value})
 	}
 
 	return protocol.Array{Elements: elements}
 }
 
-func zsetResponse(entries []storage.ZSetEntry, withScores bool) protocol.Array {
+func zsetResponse(entries []storage.ZSetRangeEntry, withScores bool) protocol.Array {
 	elements := make([]protocol.Value, 0, len(entries))
 	if withScores {
 		elements = make([]protocol.Value, 0, len(entries)*2)
 	}
 
 	for _, entry := range entries {
-		elements = append(elements, protocol.BulkString{Data: clone(entry.Member)})
+		elements = append(elements, protocol.TextBulkString{Value: entry.Member})
 		if withScores {
-			elements = append(elements, protocol.BulkString{Data: formatFloatScore(entry.Score)})
+			elements = append(elements, protocol.TextBulkString{Value: formatFloatScore(entry.Score)})
 		}
 	}
 
@@ -456,14 +456,14 @@ func streamReadResponse(key []byte, entries []storage.StreamEntry) protocol.Arra
 	streamEntries := make([]protocol.Value, 0, len(entries))
 	for _, entry := range entries {
 		streamEntries = append(streamEntries, protocol.Array{Elements: []protocol.Value{
-			protocol.BulkString{Data: []byte(entry.ID)},
+			protocol.TextBulkString{Value: entry.ID},
 			listResponse(entry.Values),
 		}})
 	}
 
 	return protocol.Array{Elements: []protocol.Value{
 		protocol.Array{Elements: []protocol.Value{
-			protocol.BulkString{Data: clone(key)},
+			protocol.BulkString{Data: key},
 			protocol.Array{Elements: streamEntries},
 		}},
 	}}
@@ -487,8 +487,8 @@ func parseFloatArgument(raw []byte) (float64, error) {
 	return value, nil
 }
 
-func formatFloatScore(score float64) []byte {
-	return []byte(strconv.FormatFloat(score, 'g', -1, 64))
+func formatFloatScore(score float64) string {
+	return strconv.FormatFloat(score, 'g', -1, 64)
 }
 
 func clone(value []byte) []byte {

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
@@ -447,6 +448,249 @@ func TestExecutorExecute(t *testing.T) {
 			tt.assert(t, value, err)
 		})
 	}
+}
+
+func TestExecutorDetailedPropagation(t *testing.T) {
+	t.Run("SET returns propagation frame", func(t *testing.T) {
+		executor := newTestExecutor()
+
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("SET", "name", "RuneDB"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+
+		assertValueEqual(t, result.Responses[0], protocol.SimpleString{Value: "OK"})
+		assertPropagationFrames(t, result.Propagation, requestValue("SET", "name", "RuneDB"))
+	})
+
+	t.Run("INCR returns propagation frame", func(t *testing.T) {
+		executor := newTestExecutor()
+
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("INCR", "counter"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 1})
+		assertPropagationFrames(t, result.Propagation, requestValue("INCR", "counter"))
+	})
+
+	t.Run("DEL propagates even when it removes no keys", func(t *testing.T) {
+		executor := newTestExecutor()
+
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("DEL", "missing"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 0})
+		assertPropagationFrames(t, result.Propagation, requestValue("DEL", "missing"))
+	})
+
+	t.Run("replication-origin commands do not re-propagate", func(t *testing.T) {
+		executor := newTestExecutor()
+
+		result, err := executor.ExecuteDetailed(server.WithReplicationOrigin(context.Background()), requestValue("SET", "name", "replica"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Propagation) != 0 {
+			t.Fatalf("len(result.Propagation) = %d, want 0", len(result.Propagation))
+		}
+	})
+
+	t.Run("EXEC aggregates child SET and DEL propagation", func(t *testing.T) {
+		executor := newTestExecutor()
+		ctx := withClientStateForExecutor(context.Background(), executor, 1)
+
+		if _, err := executor.Execute(ctx, requestValue("MULTI")); err != nil {
+			t.Fatalf("MULTI error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("SET", "name", "RuneDB")); err != nil {
+			t.Fatalf("queued SET error = %v", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("DEL", "missing")); err != nil {
+			t.Fatalf("queued DEL error = %v", err)
+		}
+
+		result, err := executor.ExecuteDetailed(ctx, requestValue("EXEC"))
+		if err != nil {
+			t.Fatalf("EXEC error = %v", err)
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+
+		assertValueEqual(t, result.Responses[0], protocol.Array{Elements: []protocol.Value{
+			protocol.SimpleString{Value: "OK"},
+			protocol.Integer{Value: 0},
+		}})
+		assertPropagationFrames(t, result.Propagation,
+			requestValue("SET", "name", "RuneDB"),
+			requestValue("DEL", "missing"),
+		)
+	})
+}
+
+func TestExecutorReplicationAcknowledgements(t *testing.T) {
+	t.Run("replica-origin GETACK emits upstream ACK reply", func(t *testing.T) {
+		executor := newTestExecutor()
+		replication := &server.ReplicationState{}
+		replication.AdvanceReplicaOffset(123)
+		executor.SetReplicationState(replication)
+
+		result, err := executor.ExecuteDetailed(server.WithReplicationOrigin(context.Background()), requestValue("REPLCONF", "GETACK", "*"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 0 {
+			t.Fatalf("len(result.Responses) = %d, want 0", len(result.Responses))
+		}
+		if len(result.UpstreamReplies) != 1 {
+			t.Fatalf("len(result.UpstreamReplies) = %d, want 1", len(result.UpstreamReplies))
+		}
+
+		assertValueEqual(t, result.UpstreamReplies[0], requestValue("REPLCONF", "ACK", "123"))
+	})
+
+	t.Run("ACK updates tracked replica offset", func(t *testing.T) {
+		executor := newTestExecutor()
+		registry := server.NewReplicaRegistry()
+		serverConn, replicaConn := net.Pipe()
+		defer func() { _ = serverConn.Close() }()
+		defer func() { _ = replicaConn.Close() }()
+
+		registry.Add(7, serverConn, 6380)
+		executor.SetReplicaRegistry(registry)
+
+		state := &server.ClientState{ID: 7, Authenticated: true}
+		state.PromoteToReplica()
+		ctx := server.WithClientState(context.Background(), state)
+
+		result, err := executor.ExecuteDetailed(ctx, requestValue("REPLCONF", "ACK", "42"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 0 {
+			t.Fatalf("len(result.Responses) = %d, want 0", len(result.Responses))
+		}
+		if got := registry.CountReplicasAtOrAbove(42); got != 1 {
+			t.Fatalf("CountReplicasAtOrAbove(42) = %d, want 1", got)
+		}
+		if got := registry.CountReplicasAtOrAbove(43); got != 0 {
+			t.Fatalf("CountReplicasAtOrAbove(43) = %d, want 0", got)
+		}
+	})
+}
+
+func TestExecutorWait(t *testing.T) {
+	t.Run("WAIT requests ACKs and returns once enough replicas catch up", func(t *testing.T) {
+		executor := newTestExecutor()
+		replication := &server.ReplicationState{}
+		replication.AdvanceMasterOffset(50)
+		executor.SetReplicationState(replication)
+
+		registry := server.NewReplicaRegistry()
+		serverConn, replicaConn := net.Pipe()
+		defer func() { _ = serverConn.Close() }()
+		defer func() { _ = replicaConn.Close() }()
+
+		registry.Add(11, serverConn, 6380)
+		executor.SetReplicaRegistry(registry)
+
+		requestSeen := make(chan struct{})
+		go func() {
+			defer close(requestSeen)
+
+			parser := protocol.NewParser(replicaConn)
+			value, err := parser.Parse()
+			if err != nil {
+				return
+			}
+			request, err := DecodeRequest(value)
+			if err != nil {
+				return
+			}
+			if request.Name != "REPLCONF" || len(request.Args) != 2 || string(request.Args[0]) != "GETACK" || string(request.Args[1]) != "*" {
+				return
+			}
+
+			time.Sleep(20 * time.Millisecond)
+			registry.UpdateAck(11, 50)
+		}()
+
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("WAIT", "1", "200"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		<-requestSeen
+
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 1})
+	})
+
+	t.Run("WAIT times out when replicas do not acknowledge", func(t *testing.T) {
+		executor := newTestExecutor()
+		replication := &server.ReplicationState{}
+		replication.AdvanceMasterOffset(5)
+		executor.SetReplicationState(replication)
+
+		startedAt := time.Now()
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("WAIT", "1", "25"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if time.Since(startedAt) < 20*time.Millisecond {
+			t.Fatalf("WAIT returned too quickly: %v", time.Since(startedAt))
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 0})
+	})
+
+	t.Run("WAIT uses the calling client's last write offset", func(t *testing.T) {
+		executor := newTestExecutor()
+		replication := &server.ReplicationState{}
+		replication.AdvanceMasterOffset(50)
+		executor.SetReplicationState(replication)
+
+		registry := server.NewReplicaRegistry()
+		serverConn, replicaConn := net.Pipe()
+		defer func() { _ = serverConn.Close() }()
+		defer func() { _ = replicaConn.Close() }()
+
+		registry.Add(12, serverConn, 6380)
+		executor.SetReplicaRegistry(registry)
+
+		state := &server.ClientState{ID: 99, Authenticated: true}
+		state.SetLastWriteReplicationOffset(0)
+		ctx := server.WithClientState(context.Background(), state)
+
+		startedAt := time.Now()
+		result, err := executor.ExecuteDetailed(ctx, requestValue("WAIT", "1", "50"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if time.Since(startedAt) > 20*time.Millisecond {
+			t.Fatalf("WAIT took too long for a client with no pending replicated writes: %v", time.Since(startedAt))
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 1})
+	})
 }
 
 func TestExecutorXAddAutoGeneratesIDs(t *testing.T) {
@@ -897,5 +1141,16 @@ func bulkStringContent(value protocol.Value) (string, bool, bool) {
 		return typed.Value, typed.Null, true
 	default:
 		return "", false, false
+	}
+}
+
+func assertPropagationFrames(t *testing.T, got []protocol.Value, want ...protocol.Value) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(propagation) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		assertValueEqual(t, got[i], want[i])
 	}
 }

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -461,25 +461,19 @@ func TestExecutorXAddAutoGeneratesIDs(t *testing.T) {
 		t.Fatalf("second XADD error = %v", err)
 	}
 
-	firstBulk, ok := first.(protocol.BulkString)
-	if !ok {
-		t.Fatalf("first response type = %T, want protocol.BulkString", first)
-	}
-	secondBulk, ok := second.(protocol.BulkString)
-	if !ok {
-		t.Fatalf("second response type = %T, want protocol.BulkString", second)
-	}
+	firstIDText := mustBulkStringText(t, first)
+	secondIDText := mustBulkStringText(t, second)
 
-	firstID, err := storageParseStreamIDForTest(string(firstBulk.Data))
+	firstID, err := storageParseStreamIDForTest(firstIDText)
 	if err != nil {
 		t.Fatalf("parse first ID error = %v", err)
 	}
-	secondID, err := storageParseStreamIDForTest(string(secondBulk.Data))
+	secondID, err := storageParseStreamIDForTest(secondIDText)
 	if err != nil {
 		t.Fatalf("parse second ID error = %v", err)
 	}
 	if secondID.milliseconds < firstID.milliseconds || (secondID.milliseconds == firstID.milliseconds && secondID.sequence <= firstID.sequence) {
-		t.Fatalf("second auto-generated ID %q is not greater than first ID %q", string(secondBulk.Data), string(firstBulk.Data))
+		t.Fatalf("second auto-generated ID %q is not greater than first ID %q", secondIDText, firstIDText)
 	}
 }
 
@@ -836,15 +830,15 @@ func assertValueEqual(t *testing.T, got protocol.Value, want protocol.Value) {
 			t.Fatalf("simple string = %q, want %q", typedGot.Value, typedWant.Value)
 		}
 	case protocol.BulkString:
-		typedGot, ok := got.(protocol.BulkString)
+		gotText, gotNull, ok := bulkStringContent(got)
 		if !ok {
-			t.Fatalf("value type = %T, want %T", got, want)
+			t.Fatalf("value type = %T, want bulk-string-compatible type", got)
 		}
-		if typedGot.Null != typedWant.Null {
-			t.Fatalf("bulk string null = %v, want %v", typedGot.Null, typedWant.Null)
+		if gotNull != typedWant.Null {
+			t.Fatalf("bulk string null = %v, want %v", gotNull, typedWant.Null)
 		}
-		if string(typedGot.Data) != string(typedWant.Data) {
-			t.Fatalf("bulk string = %q, want %q", string(typedGot.Data), string(typedWant.Data))
+		if gotText != string(typedWant.Data) {
+			t.Fatalf("bulk string = %q, want %q", gotText, string(typedWant.Data))
 		}
 	case protocol.Integer:
 		typedGot, ok := got.(protocol.Integer)
@@ -878,5 +872,30 @@ func assertValueEqual(t *testing.T, got protocol.Value, want protocol.Value) {
 		}
 	default:
 		t.Fatalf("unsupported wanted type %T", want)
+	}
+}
+
+func mustBulkStringText(t *testing.T, value protocol.Value) string {
+	t.Helper()
+
+	text, isNull, ok := bulkStringContent(value)
+	if !ok {
+		t.Fatalf("value type = %T, want bulk-string-compatible type", value)
+	}
+	if isNull {
+		t.Fatal("bulk string unexpectedly null")
+	}
+
+	return text
+}
+
+func bulkStringContent(value protocol.Value) (string, bool, bool) {
+	switch typed := value.(type) {
+	case protocol.BulkString:
+		return string(typed.Data), typed.Null, true
+	case protocol.TextBulkString:
+		return typed.Value, typed.Null, true
+	default:
+		return "", false, false
 	}
 }

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -20,12 +21,27 @@ type Request struct {
 // Handler executes a command against the current server state.
 type Handler func(context.Context, *Request) (protocol.Value, error)
 
+// DetailedHandler executes a command that may emit multiple RESP frames.
+type DetailedHandler func(context.Context, *Request) (server.ExecuteResult, error)
+
+type commandValidator func(*Request) error
+
+type commandSpec struct {
+	handler            Handler
+	detailed           DetailedHandler
+	validate           commandValidator
+	transactionControl bool
+	propagates         bool
+}
+
 // Executor routes protocol frames to concrete command handlers.
 type Executor struct {
 	store         *storage.Store
 	logger        *slog.Logger
 	watchRegistry *server.WatchRegistry
-	handlers      map[string]Handler
+	commands      map[string]commandSpec
+	replication   *server.ReplicationState
+	replicaPeers  *server.ReplicaRegistry
 }
 
 // NewExecutor constructs a command executor with the currently supported command set.
@@ -35,26 +51,7 @@ func NewExecutor(store *storage.Store, logger *slog.Logger) *Executor {
 		logger:        logger,
 		watchRegistry: server.NewWatchRegistry(),
 	}
-	executor.handlers = map[string]Handler{
-		"WATCH":   executor.handleWatch,
-		"MULTI":   executor.handleMulti,
-		"EXEC":    executor.handleExec,
-		"DISCARD": executor.handleDiscard,
-		"PING":    executor.handlePing,
-		"ECHO":    executor.handleEcho,
-		"SET":     executor.handleSet,
-		"GET":     executor.handleGet,
-		"DEL":     executor.handleDel,
-		"INCR":    executor.handleIncr,
-		"LPUSH":   executor.handleLPush,
-		"RPUSH":   executor.handleRPush,
-		"LRANGE":  executor.handleLRange,
-		"BLPOP":   executor.handleBLPop,
-		"ZADD":    executor.handleZAdd,
-		"ZRANGE":  executor.handleZRange,
-		"XADD":    executor.handleXAdd,
-		"XREAD":   executor.handleXRead,
-	}
+	executor.commands = executor.commandSpecs()
 	return executor
 }
 
@@ -63,14 +60,65 @@ func (e *Executor) WatchRegistry() *server.WatchRegistry {
 	return e.watchRegistry
 }
 
+// SetReplicationState injects shared replication metadata from the server.
+func (e *Executor) SetReplicationState(state *server.ReplicationState) {
+	e.replication = state
+}
+
+// SetReplicaRegistry injects the server's live replica registry.
+func (e *Executor) SetReplicaRegistry(registry *server.ReplicaRegistry) {
+	e.replicaPeers = registry
+}
+
 // Execute dispatches a parsed RESP frame to its command handler.
 func (e *Executor) Execute(ctx context.Context, value protocol.Value) (protocol.Value, error) {
-	request, err := DecodeRequest(value)
+	result, err := e.ExecuteDetailed(ctx, value)
 	if err != nil {
 		return nil, err
 	}
+	if len(result.Responses) == 1 {
+		return result.Responses[0], nil
+	}
 
-	return e.executeRequest(ctx, request, true)
+	return nil, fmt.Errorf("command: expected single response, got %d", len(result.Responses))
+}
+
+// ExecuteDetailed dispatches a parsed RESP frame to a handler that may emit multiple responses.
+func (e *Executor) ExecuteDetailed(ctx context.Context, value protocol.Value) (server.ExecuteResult, error) {
+	request, err := DecodeRequest(value)
+	if err != nil {
+		return server.ExecuteResult{}, err
+	}
+
+	return e.executeRequestDetailed(ctx, request, true)
+}
+
+func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request, allowQueue bool) (server.ExecuteResult, error) {
+	if allowQueue {
+		if queued, response, err := e.maybeQueueRequest(ctx, request); queued || err != nil {
+			if response == nil {
+				return server.ExecuteResult{}, err
+			}
+			return server.SingleResponse(response), err
+		}
+	}
+
+	spec, ok := e.command(request.Name)
+	if !ok {
+		return server.ExecuteResult{}, ErrUnknownCommand(request.Name)
+	}
+	if spec.detailed != nil {
+		return spec.detailed(ctx, request)
+	}
+
+	response, err := e.executeRequest(ctx, request, false)
+	if err != nil {
+		return server.ExecuteResult{}, err
+	}
+
+	result := server.SingleResponse(response)
+	result.Propagation = e.propagationFrames(ctx, request)
+	return result, nil
 }
 
 func (e *Executor) executeRequest(ctx context.Context, request *Request, allowQueue bool) (protocol.Value, error) {
@@ -80,148 +128,32 @@ func (e *Executor) executeRequest(ctx context.Context, request *Request, allowQu
 		}
 	}
 
-	handler, ok := e.handlers[request.Name]
+	spec, ok := e.command(request.Name)
 	if !ok {
 		return nil, ErrUnknownCommand(request.Name)
 	}
+	if spec.handler == nil {
+		return nil, fmt.Errorf("command: %s does not support single-response execution", request.Name)
+	}
 
-	return handler(ctx, request)
+	return spec.handler(ctx, request)
 }
 
 func (e *Executor) validateQueueableRequest(request *Request) error {
-	if _, ok := e.handlers[request.Name]; !ok {
+	spec, ok := e.command(request.Name)
+	if !ok {
 		return ErrUnknownCommand(request.Name)
 	}
-
-	switch request.Name {
-	case "WATCH":
-		if len(request.Args) == 0 {
-			return wrongNumberOfArgumentsError("WATCH")
-		}
-	case "MULTI":
-		if len(request.Args) != 0 {
-			return wrongNumberOfArgumentsError("MULTI")
-		}
-	case "EXEC":
-		if len(request.Args) != 0 {
-			return wrongNumberOfArgumentsError("EXEC")
-		}
-	case "DISCARD":
-		if len(request.Args) != 0 {
-			return wrongNumberOfArgumentsError("DISCARD")
-		}
-	case "PING":
-		if len(request.Args) > 1 {
-			return wrongNumberOfArgumentsError("PING")
-		}
-	case "ECHO":
-		if len(request.Args) != 1 {
-			return wrongNumberOfArgumentsError("ECHO")
-		}
-	case "SET":
-		if len(request.Args) < 2 {
-			return wrongNumberOfArgumentsError("SET")
-		}
-		if _, err := storage.ParseExpiryMillis(request.Args[2:]); err != nil {
-			switch err {
-			case storage.ErrSyntax:
-				return ErrSyntaxError()
-			case storage.ErrInvalidExpireTime:
-				return ErrInvalidExpireTimeError()
-			default:
-				return err
-			}
-		}
-	case "GET":
-		if len(request.Args) != 1 {
-			return wrongNumberOfArgumentsError("GET")
-		}
-	case "DEL":
-		if len(request.Args) < 1 {
-			return wrongNumberOfArgumentsError("DEL")
-		}
-	case "INCR":
-		if len(request.Args) != 1 {
-			return wrongNumberOfArgumentsError("INCR")
-		}
-	case "LPUSH":
-		if len(request.Args) < 2 {
-			return wrongNumberOfArgumentsError("LPUSH")
-		}
-	case "RPUSH":
-		if len(request.Args) < 2 {
-			return wrongNumberOfArgumentsError("RPUSH")
-		}
-	case "LRANGE":
-		if len(request.Args) != 3 {
-			return wrongNumberOfArgumentsError("LRANGE")
-		}
-		if _, err := parseIntegerArgument(request.Args[1]); err != nil {
-			return err
-		}
-		if _, err := parseIntegerArgument(request.Args[2]); err != nil {
-			return err
-		}
-	case "BLPOP":
-		if len(request.Args) != 1 {
-			return wrongNumberOfArgumentsError("BLPOP")
-		}
-	case "ZADD":
-		if len(request.Args) < 3 || len(request.Args)%2 == 0 {
-			return wrongNumberOfArgumentsError("ZADD")
-		}
-		for i := 1; i < len(request.Args); i += 2 {
-			if _, err := parseFloatArgument(request.Args[i]); err != nil {
-				return err
-			}
-		}
-	case "ZRANGE":
-		if len(request.Args) != 3 && len(request.Args) != 4 {
-			return wrongNumberOfArgumentsError("ZRANGE")
-		}
-		if len(request.Args) == 4 && !strings.EqualFold(string(request.Args[3]), "WITHSCORES") {
-			return ErrSyntaxError()
-		}
-		if _, err := parseIntegerArgument(request.Args[1]); err != nil {
-			return err
-		}
-		if _, err := parseIntegerArgument(request.Args[2]); err != nil {
-			return err
-		}
-	case "XADD":
-		if len(request.Args) < 4 || len(request.Args)%2 != 0 {
-			return wrongNumberOfArgumentsError("XADD")
-		}
-		if err := storage.ValidateXAddID(string(request.Args[1])); err != nil {
-			if errors.Is(err, storage.ErrInvalidStreamID) {
-				return ErrInvalidStreamIDError()
-			}
-			return err
-		}
-	case "XREAD":
-		if len(request.Args) == 0 {
-			return wrongNumberOfArgumentsError("XREAD")
-		}
-		if !strings.EqualFold(string(request.Args[0]), "STREAMS") {
-			return ErrSyntaxError()
-		}
-		if len(request.Args) != 3 {
-			return ErrSyntaxError()
-		}
-		if err := storage.ValidateXReadID(string(request.Args[2])); err != nil {
-			if errors.Is(err, storage.ErrInvalidStreamID) {
-				return ErrInvalidStreamIDError()
-			}
-			return err
-		}
+	if spec.validate == nil {
+		return nil
 	}
 
-	return nil
+	return spec.validate(request)
 }
 
 func (e *Executor) maybeQueueRequest(ctx context.Context, request *Request) (bool, protocol.Value, error) {
 	state, ok := server.ClientStateFromContext(ctx)
-	if !ok || !state.InTransactionActive() || isTransactionControlCommand(request.Name) {
+	if !ok || !state.InTransactionActive() || e.isTransactionControlCommand(request.Name) {
 		return false, nil, nil
 	}
 	if err := e.validateQueueableRequest(request); err != nil {
@@ -233,15 +165,6 @@ func (e *Executor) maybeQueueRequest(ctx context.Context, request *Request) (boo
 	return true, protocol.SimpleString{Value: "QUEUED"}, nil
 }
 
-func isTransactionControlCommand(name string) bool {
-	switch name {
-	case "WATCH", "MULTI", "EXEC", "DISCARD":
-		return true
-	default:
-		return false
-	}
-}
-
 func responseErrorValue(err error) protocol.ErrorValue {
 	prefix := "ERR"
 
@@ -251,6 +174,29 @@ func responseErrorValue(err error) protocol.ErrorValue {
 	}
 
 	return protocol.ErrorValue{Message: prefix + " " + err.Error()}
+}
+
+func (e *Executor) propagationFrames(ctx context.Context, request *Request) []protocol.Value {
+	if server.IsReplicationOrigin(ctx) {
+		return nil
+	}
+
+	spec, ok := e.command(request.Name)
+	if !ok || !spec.propagates {
+		return nil
+	}
+
+	return []protocol.Value{propagationFrame(request)}
+}
+
+func propagationFrame(request *Request) protocol.Array {
+	elements := make([]protocol.Value, 0, len(request.Args)+1)
+	elements = append(elements, protocol.BulkString{Data: []byte(request.Name)})
+	for _, arg := range request.Args {
+		elements = append(elements, protocol.BulkString{Data: clone(arg)})
+	}
+
+	return protocol.Array{Elements: elements}
 }
 
 // DecodeRequest converts a RESP array into a command request.
@@ -276,4 +222,290 @@ func DecodeRequest(value protocol.Value) (*Request, error) {
 		Name: strings.ToUpper(string(parts[0])),
 		Args: parts[1:],
 	}, nil
+}
+
+func (e *Executor) command(name string) (commandSpec, bool) {
+	spec, ok := e.commands[name]
+	return spec, ok
+}
+
+func (e *Executor) isTransactionControlCommand(name string) bool {
+	spec, ok := e.command(name)
+	return ok && spec.transactionControl
+}
+
+func (e *Executor) commandSpecs() map[string]commandSpec {
+	return map[string]commandSpec{
+		"WATCH": {
+			handler:            e.handleWatch,
+			validate:           validateWatchRequest,
+			transactionControl: true,
+		},
+		"MULTI": {
+			handler:            e.handleMulti,
+			validate:           exactArgsValidator("MULTI", 0),
+			transactionControl: true,
+		},
+		"EXEC": {
+			detailed:           e.handleExec,
+			validate:           exactArgsValidator("EXEC", 0),
+			transactionControl: true,
+		},
+		"DISCARD": {
+			handler:            e.handleDiscard,
+			validate:           exactArgsValidator("DISCARD", 0),
+			transactionControl: true,
+		},
+		"PING": {
+			handler:  e.handlePing,
+			validate: maxArgsValidator("PING", 1),
+		},
+		"ECHO": {
+			handler:  e.handleEcho,
+			validate: exactArgsValidator("ECHO", 1),
+		},
+		"SET": {
+			handler:    e.handleSet,
+			validate:   validateSetRequest,
+			propagates: true,
+		},
+		"GET": {
+			handler:  e.handleGet,
+			validate: exactArgsValidator("GET", 1),
+		},
+		"DEL": {
+			handler:    e.handleDel,
+			validate:   minArgsValidator("DEL", 1),
+			propagates: true,
+		},
+		"INCR": {
+			handler:    e.handleIncr,
+			validate:   exactArgsValidator("INCR", 1),
+			propagates: true,
+		},
+		"LPUSH": {
+			handler:    e.handleLPush,
+			validate:   minArgsValidator("LPUSH", 2),
+			propagates: true,
+		},
+		"RPUSH": {
+			handler:    e.handleRPush,
+			validate:   minArgsValidator("RPUSH", 2),
+			propagates: true,
+		},
+		"LRANGE": {
+			handler:  e.handleLRange,
+			validate: validateLRangeRequest,
+		},
+		"BLPOP": {
+			handler:  e.handleBLPop,
+			validate: exactArgsValidator("BLPOP", 1),
+		},
+		"ZADD": {
+			handler:    e.handleZAdd,
+			validate:   validateZAddRequest,
+			propagates: true,
+		},
+		"ZRANGE": {
+			handler:  e.handleZRange,
+			validate: validateZRangeRequest,
+		},
+		"XADD": {
+			handler:  e.handleXAdd,
+			validate: validateXAddRequest,
+		},
+		"XREAD": {
+			handler:  e.handleXRead,
+			validate: validateXReadRequest,
+		},
+		"REPLCONF": {
+			detailed: e.handleReplConf,
+			validate: validateReplConfRequest,
+		},
+		"PSYNC": {
+			detailed: e.handlePSync,
+			validate: validatePSyncRequest,
+		},
+		"WAIT": {
+			detailed: e.handleWait,
+			validate: validateWaitRequest,
+		},
+	}
+}
+
+func exactArgsValidator(name string, count int) commandValidator {
+	return func(request *Request) error {
+		if len(request.Args) != count {
+			return wrongNumberOfArgumentsError(name)
+		}
+		return nil
+	}
+}
+
+func maxArgsValidator(name string, max int) commandValidator {
+	return func(request *Request) error {
+		if len(request.Args) > max {
+			return wrongNumberOfArgumentsError(name)
+		}
+		return nil
+	}
+}
+
+func minArgsValidator(name string, min int) commandValidator {
+	return func(request *Request) error {
+		if len(request.Args) < min {
+			return wrongNumberOfArgumentsError(name)
+		}
+		return nil
+	}
+}
+
+func validateWatchRequest(request *Request) error {
+	if len(request.Args) == 0 {
+		return wrongNumberOfArgumentsError("WATCH")
+	}
+	return nil
+}
+
+func validateSetRequest(request *Request) error {
+	if len(request.Args) < 2 {
+		return wrongNumberOfArgumentsError("SET")
+	}
+	if _, err := storage.ParseExpiryMillis(request.Args[2:]); err != nil {
+		switch err {
+		case storage.ErrSyntax:
+			return ErrSyntaxError()
+		case storage.ErrInvalidExpireTime:
+			return ErrInvalidExpireTimeError()
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLRangeRequest(request *Request) error {
+	if len(request.Args) != 3 {
+		return wrongNumberOfArgumentsError("LRANGE")
+	}
+	if _, err := parseIntegerArgument(request.Args[1]); err != nil {
+		return err
+	}
+	if _, err := parseIntegerArgument(request.Args[2]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateZAddRequest(request *Request) error {
+	if len(request.Args) < 3 || len(request.Args)%2 == 0 {
+		return wrongNumberOfArgumentsError("ZADD")
+	}
+	for i := 1; i < len(request.Args); i += 2 {
+		if _, err := parseFloatArgument(request.Args[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateZRangeRequest(request *Request) error {
+	if len(request.Args) != 3 && len(request.Args) != 4 {
+		return wrongNumberOfArgumentsError("ZRANGE")
+	}
+	if len(request.Args) == 4 && !strings.EqualFold(string(request.Args[3]), "WITHSCORES") {
+		return ErrSyntaxError()
+	}
+	if _, err := parseIntegerArgument(request.Args[1]); err != nil {
+		return err
+	}
+	if _, err := parseIntegerArgument(request.Args[2]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateXAddRequest(request *Request) error {
+	if len(request.Args) < 4 || len(request.Args)%2 != 0 {
+		return wrongNumberOfArgumentsError("XADD")
+	}
+	if err := storage.ValidateXAddID(string(request.Args[1])); err != nil {
+		if errors.Is(err, storage.ErrInvalidStreamID) {
+			return ErrInvalidStreamIDError()
+		}
+		return err
+	}
+	return nil
+}
+
+func validateXReadRequest(request *Request) error {
+	if len(request.Args) == 0 {
+		return wrongNumberOfArgumentsError("XREAD")
+	}
+	if !strings.EqualFold(string(request.Args[0]), "STREAMS") {
+		return ErrSyntaxError()
+	}
+	if len(request.Args) != 3 {
+		return ErrSyntaxError()
+	}
+	if err := storage.ValidateXReadID(string(request.Args[2])); err != nil {
+		if errors.Is(err, storage.ErrInvalidStreamID) {
+			return ErrInvalidStreamIDError()
+		}
+		return err
+	}
+	return nil
+}
+
+func validateReplConfRequest(request *Request) error {
+	if len(request.Args) != 2 {
+		return wrongNumberOfArgumentsError("REPLCONF")
+	}
+
+	subcommand := strings.ToUpper(string(request.Args[0]))
+	switch subcommand {
+	case "LISTENING-PORT":
+		if _, err := parseReplicationPortArgument(request.Args[1]); err != nil {
+			return ErrSyntaxError()
+		}
+	case "GETACK":
+		if string(request.Args[1]) != "*" {
+			return ErrSyntaxError()
+		}
+	case "ACK":
+		value, err := parseIntegerArgument(request.Args[1])
+		if err != nil || value < 0 {
+			return ErrSyntaxError()
+		}
+	default:
+		return ErrSyntaxError()
+	}
+
+	return nil
+}
+
+func validatePSyncRequest(request *Request) error {
+	if len(request.Args) != 2 {
+		return wrongNumberOfArgumentsError("PSYNC")
+	}
+	if string(request.Args[0]) != "?" || string(request.Args[1]) != "-1" {
+		return ErrSyntaxError()
+	}
+	return nil
+}
+
+func validateWaitRequest(request *Request) error {
+	if len(request.Args) != 2 {
+		return wrongNumberOfArgumentsError("WAIT")
+	}
+	for _, arg := range request.Args {
+		value, err := parseIntegerArgument(arg)
+		if err != nil {
+			return err
+		}
+		if value < 0 {
+			return ErrValueNotIntegerError()
+		}
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"flag"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 )
 
@@ -14,6 +16,7 @@ type Config struct {
 	EvictionInterval   time.Duration
 	EvictionSampleSize int
 	RDBPath            string
+	ReplicaOf          string
 	RequirePass        string
 }
 
@@ -26,6 +29,7 @@ func Default() Config {
 		EvictionInterval:   100 * time.Millisecond,
 		EvictionSampleSize: 20,
 		RDBPath:            "",
+		ReplicaOf:          "",
 	}
 }
 
@@ -39,6 +43,7 @@ func ParseFlags() Config {
 	flag.DurationVar(&cfg.EvictionInterval, "eviction-interval", cfg.EvictionInterval, "interval for active TTL eviction")
 	flag.IntVar(&cfg.EvictionSampleSize, "eviction-sample-size", cfg.EvictionSampleSize, "number of keys to sample on each eviction pass")
 	flag.StringVar(&cfg.RDBPath, "rdb", cfg.RDBPath, "optional path to an RDB file to load before accepting TCP connections")
+	flag.StringVar(&cfg.ReplicaOf, "replicaof", cfg.ReplicaOf, "optional master address in host:port form for replica mode")
 	flag.StringVar(&cfg.RequirePass, "requirepass", cfg.RequirePass, "optional password requirement placeholder for future AUTH support")
 	flag.Parse()
 
@@ -52,4 +57,27 @@ func (c Config) Address() string {
 	}
 
 	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+}
+
+// IsReplica reports whether the server should connect to an upstream master.
+func (c Config) IsReplica() bool {
+	return strings.TrimSpace(c.ReplicaOf) != ""
+}
+
+// ReplicaAddress validates and normalizes the configured upstream master address.
+func (c Config) ReplicaAddress() (string, error) {
+	address := strings.TrimSpace(c.ReplicaOf)
+	if address == "" {
+		return "", nil
+	}
+
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", fmt.Errorf("invalid replicaof address %q: %w", address, err)
+	}
+	if host == "" || port == "" {
+		return "", fmt.Errorf("invalid replicaof address %q: expected host:port", address)
+	}
+
+	return net.JoinHostPort(host, port), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	LogLevel           string
 	EvictionInterval   time.Duration
 	EvictionSampleSize int
+	RDBPath            string
 	RequirePass        string
 }
 
@@ -24,6 +25,7 @@ func Default() Config {
 		LogLevel:           "info",
 		EvictionInterval:   100 * time.Millisecond,
 		EvictionSampleSize: 20,
+		RDBPath:            "",
 	}
 }
 
@@ -36,6 +38,7 @@ func ParseFlags() Config {
 	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "log level: debug, info, warn, error")
 	flag.DurationVar(&cfg.EvictionInterval, "eviction-interval", cfg.EvictionInterval, "interval for active TTL eviction")
 	flag.IntVar(&cfg.EvictionSampleSize, "eviction-sample-size", cfg.EvictionSampleSize, "number of keys to sample on each eviction pass")
+	flag.StringVar(&cfg.RDBPath, "rdb", cfg.RDBPath, "optional path to an RDB file to load before accepting TCP connections")
 	flag.StringVar(&cfg.RequirePass, "requirepass", cfg.RequirePass, "optional password requirement placeholder for future AUTH support")
 	flag.Parse()
 

--- a/internal/protocol/coerce.go
+++ b/internal/protocol/coerce.go
@@ -12,9 +12,12 @@ func Bytes(value Value) ([]byte, error) {
 		if typed.Null {
 			return nil, fmt.Errorf("protocol: null bulk string cannot be coerced to bytes")
 		}
-		copied := make([]byte, len(typed.Data))
-		copy(copied, typed.Data)
-		return copied, nil
+		return typed.Data, nil
+	case TextBulkString:
+		if typed.Null {
+			return nil, fmt.Errorf("protocol: null bulk string cannot be coerced to bytes")
+		}
+		return []byte(typed.Value), nil
 	case SimpleString:
 		return []byte(typed.Value), nil
 	case Integer:

--- a/internal/protocol/parser.go
+++ b/internal/protocol/parser.go
@@ -2,10 +2,10 @@ package protocol
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 )
 
 // Parser reads RESP values from an io.Reader.
@@ -84,12 +84,12 @@ func (p *Parser) Parse() (Value, error) {
 }
 
 func (p *Parser) parseBulkString() (Value, error) {
-	line, err := p.readLine()
+	line, err := p.readLineBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	length, err := strconv.Atoi(line)
+	length, err := parseDecimalInt(line)
 	if err != nil {
 		return nil, fmt.Errorf("protocol: parse bulk string length: %w", err)
 	}
@@ -100,26 +100,24 @@ func (p *Parser) parseBulkString() (Value, error) {
 		return nil, fmt.Errorf("protocol: invalid bulk string length %d", length)
 	}
 
-	buffer := make([]byte, length+2)
-	if _, err := io.ReadFull(p.reader, buffer); err != nil {
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(p.reader, payload); err != nil {
 		return nil, fmt.Errorf("protocol: read bulk string payload: %w", err)
 	}
-	if len(buffer) < 2 || buffer[len(buffer)-2] != '\r' || buffer[len(buffer)-1] != '\n' {
+	if err := p.expectCRLF(); err != nil {
 		return nil, fmt.Errorf("protocol: bulk string payload missing CRLF terminator")
 	}
 
-	payload := make([]byte, length)
-	copy(payload, buffer[:length])
 	return BulkString{Data: payload}, nil
 }
 
 func (p *Parser) parseArray() (Value, error) {
-	line, err := p.readLine()
+	line, err := p.readLineBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	count, err := strconv.Atoi(line)
+	count, err := parseDecimalInt(line)
 	if err != nil {
 		return nil, fmt.Errorf("protocol: parse array length: %w", err)
 	}
@@ -143,13 +141,71 @@ func (p *Parser) parseArray() (Value, error) {
 }
 
 func (p *Parser) readLine() (string, error) {
-	line, err := p.reader.ReadString('\n')
+	line, err := p.readLineBytes()
 	if err != nil {
 		return "", err
 	}
-	if !strings.HasSuffix(line, "\r\n") {
-		return "", fmt.Errorf("protocol: line missing CRLF terminator")
+
+	return string(line), nil
+}
+
+func (p *Parser) readLineBytes() ([]byte, error) {
+	line, err := p.reader.ReadSlice('\n')
+	if err == nil {
+		return trimCRLF(line)
+	}
+	if !errors.Is(err, bufio.ErrBufferFull) {
+		return nil, err
 	}
 
-	return strings.TrimSuffix(line, "\r\n"), nil
+	combined := append([]byte(nil), line...)
+	for {
+		fragment, readErr := p.reader.ReadSlice('\n')
+		combined = append(combined, fragment...)
+		if readErr == nil {
+			return trimCRLF(combined)
+		}
+		if !errors.Is(readErr, bufio.ErrBufferFull) {
+			return nil, readErr
+		}
+	}
+}
+
+func (p *Parser) expectCRLF() error {
+	carriage, err := p.reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	newline, err := p.reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	if carriage != '\r' || newline != '\n' {
+		return fmt.Errorf("protocol: line missing CRLF terminator")
+	}
+
+	return nil
+}
+
+func trimCRLF(line []byte) ([]byte, error) {
+	if len(line) < 2 || line[len(line)-2] != '\r' || line[len(line)-1] != '\n' {
+		return nil, fmt.Errorf("protocol: line missing CRLF terminator")
+	}
+
+	return line[:len(line)-2], nil
+}
+
+func parseDecimalInt(raw []byte) (int, error) {
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	if value < minInt || value > maxInt {
+		return 0, fmt.Errorf("value %d out of int range", value)
+	}
+
+	return int(value), nil
 }

--- a/internal/protocol/parser_test.go
+++ b/internal/protocol/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -91,6 +92,25 @@ func TestParserParse(t *testing.T) {
 				}
 				if _, ok := value.(Null); !ok {
 					t.Fatalf("Parse() type = %T, want Null", value)
+				}
+			},
+		},
+		{
+			name: "long line over buffered reader capacity",
+			reader: func() io.Reader {
+				return bufio.NewReaderSize(strings.NewReader("+"+strings.Repeat("a", 64)+"\r\n"), 8)
+			},
+			assert: func(t *testing.T, value Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Parse() error = %v", err)
+				}
+				simple, ok := value.(SimpleString)
+				if !ok {
+					t.Fatalf("Parse() type = %T, want SimpleString", value)
+				}
+				if simple.Value != strings.Repeat("a", 64) {
+					t.Fatalf("simple string = %q, want %q", simple.Value, strings.Repeat("a", 64))
 				}
 			},
 		},

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -26,6 +26,12 @@ type BulkString struct {
 	Null bool
 }
 
+// TextBulkString encodes a RESP bulk string backed by an immutable Go string.
+type TextBulkString struct {
+	Value string
+	Null  bool
+}
+
 // Array encodes a RESP array value.
 type Array struct {
 	Elements []Value
@@ -40,10 +46,11 @@ type Boolean struct {
 // Null is a RESP3 placeholder/value for future protocol expansion.
 type Null struct{}
 
-func (SimpleString) value() {}
-func (ErrorValue) value()   {}
-func (Integer) value()      {}
-func (BulkString) value()   {}
-func (Array) value()        {}
-func (Boolean) value()      {}
-func (Null) value()         {}
+func (SimpleString) value()   {}
+func (ErrorValue) value()     {}
+func (Integer) value()        {}
+func (BulkString) value()     {}
+func (TextBulkString) value() {}
+func (Array) value()          {}
+func (Boolean) value()        {}
+func (Null) value()           {}

--- a/internal/protocol/writer.go
+++ b/internal/protocol/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 // Encode serializes a RESP value into its wire representation.
@@ -20,24 +21,35 @@ func Encode(value Value) ([]byte, error) {
 func WriteValue(writer io.Writer, value Value) error {
 	switch typed := value.(type) {
 	case SimpleString:
-		_, err := fmt.Fprintf(writer, "+%s\r\n", typed.Value)
-		return err
+		return writePrefixedStringLine(writer, '+', typed.Value)
 	case ErrorValue:
-		_, err := fmt.Fprintf(writer, "-%s\r\n", typed.Message)
-		return err
+		return writePrefixedStringLine(writer, '-', typed.Message)
 	case Integer:
-		_, err := fmt.Fprintf(writer, ":%d\r\n", typed.Value)
-		return err
+		return writePrefixedIntLine(writer, ':', typed.Value)
 	case BulkString:
 		if typed.Null {
 			_, err := io.WriteString(writer, "$-1\r\n")
 			return err
 		}
 
-		if _, err := fmt.Fprintf(writer, "$%d\r\n", len(typed.Data)); err != nil {
+		if err := writePrefixedIntLine(writer, '$', int64(len(typed.Data))); err != nil {
 			return err
 		}
 		if _, err := writer.Write(typed.Data); err != nil {
+			return err
+		}
+		_, err := io.WriteString(writer, "\r\n")
+		return err
+	case TextBulkString:
+		if typed.Null {
+			_, err := io.WriteString(writer, "$-1\r\n")
+			return err
+		}
+
+		if err := writePrefixedIntLine(writer, '$', int64(len(typed.Value))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(writer, typed.Value); err != nil {
 			return err
 		}
 		_, err := io.WriteString(writer, "\r\n")
@@ -48,7 +60,7 @@ func WriteValue(writer io.Writer, value Value) error {
 			return err
 		}
 
-		if _, err := fmt.Fprintf(writer, "*%d\r\n", len(typed.Elements)); err != nil {
+		if err := writePrefixedIntLine(writer, '*', int64(len(typed.Elements))); err != nil {
 			return err
 		}
 		for _, element := range typed.Elements {
@@ -70,4 +82,28 @@ func WriteValue(writer io.Writer, value Value) error {
 	default:
 		return fmt.Errorf("protocol: unsupported value type %T", value)
 	}
+}
+
+func writePrefixedStringLine(writer io.Writer, prefix byte, value string) error {
+	if _, err := writer.Write([]byte{prefix}); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(writer, value); err != nil {
+		return err
+	}
+	_, err := io.WriteString(writer, "\r\n")
+	return err
+}
+
+func writePrefixedIntLine(writer io.Writer, prefix byte, value int64) error {
+	var buf [32]byte
+	encoded := strconv.AppendInt(buf[:0], value, 10)
+	if _, err := writer.Write([]byte{prefix}); err != nil {
+		return err
+	}
+	if _, err := writer.Write(encoded); err != nil {
+		return err
+	}
+	_, err := io.WriteString(writer, "\r\n")
+	return err
 }

--- a/internal/protocol/writer.go
+++ b/internal/protocol/writer.go
@@ -17,6 +17,18 @@ func Encode(value Value) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// EncodeValues serializes multiple RESP values into a single wire payload.
+func EncodeValues(values []Value) ([]byte, error) {
+	var buffer bytes.Buffer
+	for _, value := range values {
+		if err := WriteValue(&buffer, value); err != nil {
+			return nil, err
+		}
+	}
+
+	return buffer.Bytes(), nil
+}
+
 // WriteValue writes a RESP value to the provided writer.
 func WriteValue(writer io.Writer, value Value) error {
 	switch typed := value.(type) {

--- a/internal/rdb/doc.go
+++ b/internal/rdb/doc.go
@@ -1,0 +1,2 @@
+// Package rdb loads Redis RDB snapshots into the RuneDB in-memory store.
+package rdb

--- a/internal/rdb/loader.go
+++ b/internal/rdb/loader.go
@@ -1,0 +1,440 @@
+package rdb
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+const (
+	fileHeader = "REDIS0011"
+
+	opcodeAux           = 0xFA
+	opcodeResizeDB      = 0xFB
+	opcodeExpireTimeMS  = 0xFC
+	opcodeExpireTimeSec = 0xFD
+	opcodeSelectDB      = 0xFE
+	opcodeEOF           = 0xFF
+
+	valueTypeString = 0x00
+
+	lengthEncoding6Bit  = 0x00
+	lengthEncoding14Bit = 0x01
+	lengthEncoding32Bit = 0x02
+	lengthEncodingEnc   = 0x03
+
+	stringEncodingInt8  = 0x00
+	stringEncodingInt16 = 0x01
+	stringEncodingInt32 = 0x02
+	stringEncodingLZF   = 0x03
+)
+
+var (
+	// ErrInvalidHeader reports that the RDB file does not start with REDIS0011.
+	ErrInvalidHeader = errors.New("rdb: invalid file header")
+	// ErrUnsupportedDB reports that the loader encountered a non-zero database selector.
+	ErrUnsupportedDB = errors.New("rdb: unsupported database selector")
+	// ErrUnsupportedValueType reports that the loader encountered a non-string value type.
+	ErrUnsupportedValueType = errors.New("rdb: unsupported value type")
+	// ErrUnsupportedOpcode reports that the loader encountered an opcode it does not implement.
+	ErrUnsupportedOpcode = errors.New("rdb: unsupported opcode")
+)
+
+// Stats summarizes the results of loading an RDB snapshot.
+type Stats struct {
+	LoadedKeys         int
+	SkippedExpiredKeys int
+}
+
+// LoadFile opens an RDB file from disk and loads its supported contents into the store.
+func LoadFile(path string, store *storage.Store) (stats Stats, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Stats{}, fmt.Errorf("rdb: open %q: %w", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			wrapped := fmt.Errorf("rdb: close %q: %w", path, closeErr)
+			if err == nil {
+				err = wrapped
+				return
+			}
+
+			err = errors.Join(err, wrapped)
+		}
+	}()
+
+	stats, err = LoadReader(file, store)
+	if err != nil {
+		return Stats{}, fmt.Errorf("rdb: load %q: %w", path, err)
+	}
+
+	return stats, nil
+}
+
+// LoadReader loads an RDB payload from the provided reader into the store.
+func LoadReader(reader io.Reader, store *storage.Store) (Stats, error) {
+	return loadReaderAt(reader, store, func() int64 { return time.Now().UnixMilli() })
+}
+
+type loader struct {
+	reader   *bufio.Reader
+	store    *storage.Store
+	nowMilli func() int64
+	stats    Stats
+	seenEOF  bool
+}
+
+func loadReaderAt(reader io.Reader, store *storage.Store, nowMilli func() int64) (Stats, error) {
+	if store == nil {
+		return Stats{}, errors.New("rdb: nil store")
+	}
+	if reader == nil {
+		return Stats{}, errors.New("rdb: nil reader")
+	}
+
+	loader := &loader{
+		reader:   bufio.NewReader(reader),
+		store:    store,
+		nowMilli: nowMilli,
+	}
+
+	if err := loader.load(); err != nil {
+		return Stats{}, err
+	}
+
+	return loader.stats, nil
+}
+
+func (l *loader) load() error {
+	header := make([]byte, len(fileHeader))
+	if _, err := io.ReadFull(l.reader, header); err != nil {
+		return fmt.Errorf("read header: %w", err)
+	}
+	if string(header) != fileHeader {
+		return fmt.Errorf("%w: got %q want %q", ErrInvalidHeader, string(header), fileHeader)
+	}
+
+	for !l.seenEOF {
+		marker, err := l.readByte()
+		if err != nil {
+			return fmt.Errorf("read marker: %w", err)
+		}
+
+		switch marker {
+		case opcodeAux:
+			if _, err := l.readString(); err != nil {
+				return fmt.Errorf("read AUX key: %w", err)
+			}
+			if _, err := l.readString(); err != nil {
+				return fmt.Errorf("read AUX value: %w", err)
+			}
+		case opcodeResizeDB:
+			if _, _, err := l.readLength(); err != nil {
+				return fmt.Errorf("read RESIZEDB main hash size: %w", err)
+			}
+			if _, _, err := l.readLength(); err != nil {
+				return fmt.Errorf("read RESIZEDB expiry hash size: %w", err)
+			}
+		case opcodeSelectDB:
+			dbIndex, _, err := l.readLength()
+			if err != nil {
+				return fmt.Errorf("read SELECTDB: %w", err)
+			}
+			if dbIndex != 0 {
+				return fmt.Errorf("%w: %d", ErrUnsupportedDB, dbIndex)
+			}
+		case opcodeExpireTimeSec:
+			expiresAtSeconds, err := l.readUint32LE()
+			if err != nil {
+				return fmt.Errorf("read EXPIRETIME: %w", err)
+			}
+			valueType, err := l.readByte()
+			if err != nil {
+				return fmt.Errorf("read value type after EXPIRETIME: %w", err)
+			}
+			if err := l.readEntry(valueType, int64(expiresAtSeconds)*1000); err != nil {
+				return err
+			}
+		case opcodeExpireTimeMS:
+			expiresAtMillis, err := l.readUint64LE()
+			if err != nil {
+				return fmt.Errorf("read EXPIRETIMEMS: %w", err)
+			}
+			if expiresAtMillis > uint64(^uint64(0)>>1) {
+				return fmt.Errorf("rdb: expiry milliseconds overflow: %d", expiresAtMillis)
+			}
+			valueType, err := l.readByte()
+			if err != nil {
+				return fmt.Errorf("read value type after EXPIRETIMEMS: %w", err)
+			}
+			if err := l.readEntry(valueType, int64(expiresAtMillis)); err != nil {
+				return err
+			}
+		case opcodeEOF:
+			if err := l.consumeChecksum(); err != nil {
+				return err
+			}
+			l.seenEOF = true
+		default:
+			if !isValueType(marker) {
+				return fmt.Errorf("%w: 0x%X", ErrUnsupportedOpcode, marker)
+			}
+
+			if err := l.readEntry(marker, 0); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (l *loader) readEntry(valueType byte, expiresAt int64) error {
+	if valueType != valueTypeString {
+		return fmt.Errorf("%w: %d", ErrUnsupportedValueType, valueType)
+	}
+
+	key, err := l.readString()
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	value, err := l.readString()
+	if err != nil {
+		return fmt.Errorf("read string value: %w", err)
+	}
+
+	if expiresAt > 0 && expiresAt <= l.nowMilli() {
+		l.stats.SkippedExpiredKeys++
+		return nil
+	}
+
+	l.store.Set(string(key), value, expiresAt)
+	l.stats.LoadedKeys++
+	return nil
+}
+
+func (l *loader) readByte() (byte, error) {
+	value, err := l.reader.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+func (l *loader) readLength() (uint64, bool, error) {
+	first, err := l.readByte()
+	if err != nil {
+		return 0, false, err
+	}
+
+	switch first >> 6 {
+	case lengthEncoding6Bit:
+		return uint64(first & 0x3F), false, nil
+	case lengthEncoding14Bit:
+		second, err := l.readByte()
+		if err != nil {
+			return 0, false, err
+		}
+		return (uint64(first&0x3F) << 8) | uint64(second), false, nil
+	case lengthEncoding32Bit:
+		raw := make([]byte, 4)
+		if _, err := io.ReadFull(l.reader, raw); err != nil {
+			return 0, false, err
+		}
+		return uint64(binary.BigEndian.Uint32(raw)), false, nil
+	case lengthEncodingEnc:
+		return uint64(first & 0x3F), true, nil
+	default:
+		return 0, false, fmt.Errorf("rdb: invalid length prefix %d", first)
+	}
+}
+
+func (l *loader) readString() ([]byte, error) {
+	length, encoded, err := l.readLength()
+	if err != nil {
+		return nil, err
+	}
+	if !encoded {
+		return l.readBytes(length)
+	}
+
+	switch byte(length) {
+	case stringEncodingInt8:
+		value, err := l.readByte()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(strconv.FormatInt(int64(int8(value)), 10)), nil
+	case stringEncodingInt16:
+		value, err := l.readUint16LE()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(strconv.FormatInt(int64(int16(value)), 10)), nil
+	case stringEncodingInt32:
+		value, err := l.readUint32LE()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(strconv.FormatInt(int64(int32(value)), 10)), nil
+	case stringEncodingLZF:
+		compressedLength, compressedEncoded, err := l.readLength()
+		if err != nil {
+			return nil, fmt.Errorf("read LZF compressed length: %w", err)
+		}
+		if compressedEncoded {
+			return nil, errors.New("rdb: invalid encoded compressed length")
+		}
+
+		uncompressedLength, uncompressedEncoded, err := l.readLength()
+		if err != nil {
+			return nil, fmt.Errorf("read LZF uncompressed length: %w", err)
+		}
+		if uncompressedEncoded {
+			return nil, errors.New("rdb: invalid encoded uncompressed length")
+		}
+
+		compressed, err := l.readBytes(compressedLength)
+		if err != nil {
+			return nil, fmt.Errorf("read LZF payload: %w", err)
+		}
+
+		return decompressLZF(compressed, int(uncompressedLength))
+	default:
+		return nil, fmt.Errorf("rdb: unsupported string encoding %d", length)
+	}
+}
+
+func (l *loader) readBytes(length uint64) ([]byte, error) {
+	if length == 0 {
+		return []byte{}, nil
+	}
+	if length > uint64(^uint(0)>>1) {
+		return nil, fmt.Errorf("rdb: length overflow %d", length)
+	}
+
+	buffer := make([]byte, int(length))
+	if _, err := io.ReadFull(l.reader, buffer); err != nil {
+		return nil, err
+	}
+
+	return buffer, nil
+}
+
+func (l *loader) readUint16LE() (uint16, error) {
+	raw := make([]byte, 2)
+	if _, err := io.ReadFull(l.reader, raw); err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint16(raw), nil
+}
+
+func (l *loader) readUint32LE() (uint32, error) {
+	raw := make([]byte, 4)
+	if _, err := io.ReadFull(l.reader, raw); err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint32(raw), nil
+}
+
+func (l *loader) readUint64LE() (uint64, error) {
+	raw := make([]byte, 8)
+	if _, err := io.ReadFull(l.reader, raw); err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint64(raw), nil
+}
+
+func (l *loader) consumeChecksum() error {
+	rest, err := io.ReadAll(l.reader)
+	if err != nil {
+		return fmt.Errorf("read trailing checksum: %w", err)
+	}
+
+	if len(rest) != 0 && len(rest) != 8 {
+		return fmt.Errorf("rdb: invalid trailing checksum length %d", len(rest))
+	}
+
+	return nil
+}
+
+func isValueType(marker byte) bool {
+	switch marker {
+	case 0, 1, 2, 3, 4, 9, 10, 11, 12, 13, 14:
+		return true
+	default:
+		return false
+	}
+}
+
+func decompressLZF(input []byte, outputLength int) ([]byte, error) {
+	output := make([]byte, outputLength)
+	ip := 0
+	op := 0
+
+	for ip < len(input) {
+		control := int(input[ip])
+		ip++
+
+		if control < 32 {
+			literalLength := control + 1
+			if ip+literalLength > len(input) {
+				return nil, errors.New("rdb: truncated LZF literal")
+			}
+			if op+literalLength > len(output) {
+				return nil, errors.New("rdb: LZF literal exceeds output length")
+			}
+
+			copy(output[op:op+literalLength], input[ip:ip+literalLength])
+			ip += literalLength
+			op += literalLength
+			continue
+		}
+
+		matchLength := control >> 5
+		if matchLength == 7 {
+			if ip >= len(input) {
+				return nil, errors.New("rdb: truncated LZF match length")
+			}
+			matchLength += int(input[ip])
+			ip++
+		}
+		if ip >= len(input) {
+			return nil, errors.New("rdb: truncated LZF match offset")
+		}
+
+		reference := op - ((control & 0x1F) << 8) - int(input[ip]) - 1
+		ip++
+		matchLength += 2
+
+		if reference < 0 {
+			return nil, errors.New("rdb: invalid LZF back-reference")
+		}
+		if op+matchLength > len(output) {
+			return nil, errors.New("rdb: LZF match exceeds output length")
+		}
+
+		for i := 0; i < matchLength; i++ {
+			output[op] = output[reference+i]
+			op++
+		}
+	}
+
+	if op != len(output) {
+		return nil, fmt.Errorf("rdb: LZF output length mismatch got %d want %d", op, len(output))
+	}
+
+	return output, nil
+}

--- a/internal/rdb/loader_test.go
+++ b/internal/rdb/loader_test.go
@@ -1,0 +1,262 @@
+package rdb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestLoadReader(t *testing.T) {
+	now := time.Now().UnixMilli()
+
+	tests := []struct {
+		name    string
+		payload []byte
+		now     int64
+		assert  func(*testing.T, *storage.Store, Stats)
+		wantErr error
+	}{
+		{
+			name: "loads DB0 string keys with AUX and RESIZEDB metadata",
+			payload: buildRDBPayload(
+				auxField([]byte("redis-ver"), []byte("7.2.0")),
+				selectDB(0),
+				resizeDB(2, 1),
+				stringEntry(rawString([]byte("name")), rawString([]byte("RuneDB"))),
+			),
+			now: 1,
+			assert: func(t *testing.T, store *storage.Store, stats Stats) {
+				t.Helper()
+				if stats.LoadedKeys != 1 || stats.SkippedExpiredKeys != 0 {
+					t.Fatalf("stats = %#v, want 1 loaded and 0 skipped", stats)
+				}
+				assertStoredString(t, store, "name", "RuneDB")
+			},
+		},
+		{
+			name: "supports integer and LZF string encodings",
+			payload: buildRDBPayload(
+				selectDB(0),
+				stringEntry(rawString([]byte("answer")), int32String(42)),
+				stringEntry(rawString([]byte("compressed")), lzfString([]byte("hello"))),
+			),
+			now: 1,
+			assert: func(t *testing.T, store *storage.Store, stats Stats) {
+				t.Helper()
+				if stats.LoadedKeys != 2 || stats.SkippedExpiredKeys != 0 {
+					t.Fatalf("stats = %#v, want 2 loaded and 0 skipped", stats)
+				}
+				assertStoredString(t, store, "answer", "42")
+				assertStoredString(t, store, "compressed", "hello")
+			},
+		},
+		{
+			name: "loads EXPIRETIME and EXPIRETIMEMS entries and skips stale keys",
+			payload: buildRDBPayload(
+				selectDB(0),
+				expiringStringEntrySeconds(uint32((now/1000)+10), rawString([]byte("future-seconds")), rawString([]byte("alive"))),
+				expiringStringEntryMillis(uint64(now+15000), rawString([]byte("future-millis")), rawString([]byte("alive-too"))),
+				expiringStringEntryMillis(uint64(now-10000), rawString([]byte("stale")), rawString([]byte("gone"))),
+			),
+			now: now,
+			assert: func(t *testing.T, store *storage.Store, stats Stats) {
+				t.Helper()
+				if stats.LoadedKeys != 2 || stats.SkippedExpiredKeys != 1 {
+					t.Fatalf("stats = %#v, want 2 loaded and 1 skipped", stats)
+				}
+				assertStoredString(t, store, "future-seconds", "alive")
+				assertStoredString(t, store, "future-millis", "alive-too")
+				if _, ok, err := store.Get("stale"); err != nil {
+					t.Fatalf("Get(stale) error = %v", err)
+				} else if ok {
+					t.Fatal("Get(stale) ok = true, want false")
+				}
+			},
+		},
+		{
+			name: "rejects non zero database selectors",
+			payload: buildRDBPayload(
+				selectDB(1),
+			),
+			wantErr: ErrUnsupportedDB,
+		},
+		{
+			name: "rejects unsupported value types",
+			payload: buildRDBPayload(
+				selectDB(0),
+				[]byte{0x01},
+				rawString([]byte("letters")),
+				encodeLength(1),
+				rawString([]byte("a")),
+			),
+			wantErr: ErrUnsupportedValueType,
+		},
+		{
+			name: "rejects unsupported opcodes",
+			payload: buildRDBPayload(
+				selectDB(0),
+				[]byte{0xAB},
+			),
+			wantErr: ErrUnsupportedOpcode,
+		},
+		{
+			name:    "rejects invalid header",
+			payload: append([]byte("NOTREDIS11"), opcodeEOF),
+			wantErr: ErrInvalidHeader,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			store := storage.NewStore()
+			stats, err := loadReaderAt(bytes.NewReader(tt.payload), store, func() int64 { return tt.now })
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("loadReaderAt() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadReaderAt() error = %v", err)
+			}
+
+			tt.assert(t, store, stats)
+		})
+	}
+}
+
+func TestDecompressLZFRejectsCorruptPayload(t *testing.T) {
+	_, err := decompressLZF([]byte{0x20}, 3)
+	if err == nil {
+		t.Fatal("decompressLZF() error = nil, want corruption error")
+	}
+}
+
+func assertStoredString(t *testing.T, store *storage.Store, key, want string) {
+	t.Helper()
+	got, ok, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get(%q) error = %v", key, err)
+	}
+	if !ok {
+		t.Fatalf("Get(%q) ok = false, want true", key)
+	}
+	if string(got) != want {
+		t.Fatalf("Get(%q) = %q, want %q", key, string(got), want)
+	}
+}
+
+func buildRDBPayload(parts ...[]byte) []byte {
+	payload := append([]byte{}, []byte(fileHeader)...)
+	for _, part := range parts {
+		payload = append(payload, part...)
+	}
+	payload = append(payload, opcodeEOF)
+	payload = append(payload, make([]byte, 8)...)
+	return payload
+}
+
+func auxField(key, value []byte) []byte {
+	payload := []byte{opcodeAux}
+	payload = append(payload, rawString(key)...)
+	payload = append(payload, rawString(value)...)
+	return payload
+}
+
+func selectDB(index uint64) []byte {
+	payload := []byte{opcodeSelectDB}
+	payload = append(payload, encodeLength(index)...)
+	return payload
+}
+
+func resizeDB(mainSize, expirySize uint64) []byte {
+	payload := []byte{opcodeResizeDB}
+	payload = append(payload, encodeLength(mainSize)...)
+	payload = append(payload, encodeLength(expirySize)...)
+	return payload
+}
+
+func stringEntry(key, value []byte) []byte {
+	payload := []byte{valueTypeString}
+	payload = append(payload, key...)
+	payload = append(payload, value...)
+	return payload
+}
+
+func expiringStringEntrySeconds(expiresAtSeconds uint32, key, value []byte) []byte {
+	payload := []byte{opcodeExpireTimeSec}
+	raw := make([]byte, 4)
+	binary.LittleEndian.PutUint32(raw, expiresAtSeconds)
+	payload = append(payload, raw...)
+	payload = append(payload, stringEntry(key, value)...)
+	return payload
+}
+
+func expiringStringEntryMillis(expiresAtMillis uint64, key, value []byte) []byte {
+	payload := []byte{opcodeExpireTimeMS}
+	raw := make([]byte, 8)
+	binary.LittleEndian.PutUint64(raw, expiresAtMillis)
+	payload = append(payload, raw...)
+	payload = append(payload, stringEntry(key, value)...)
+	return payload
+}
+
+func rawString(value []byte) []byte {
+	payload := encodeLength(uint64(len(value)))
+	payload = append(payload, value...)
+	return payload
+}
+
+func int32String(value int32) []byte {
+	payload := []byte{0xC2}
+	raw := make([]byte, 4)
+	binary.LittleEndian.PutUint32(raw, uint32(value))
+	payload = append(payload, raw...)
+	return payload
+}
+
+func lzfString(value []byte) []byte {
+	compressed := append([]byte{byte(len(value) - 1)}, value...)
+	payload := []byte{0xC3}
+	payload = append(payload, encodeLength(uint64(len(compressed)))...)
+	payload = append(payload, encodeLength(uint64(len(value)))...)
+	payload = append(payload, compressed...)
+	return payload
+}
+
+func encodeLength(length uint64) []byte {
+	switch {
+	case length < 1<<6:
+		return []byte{byte(length)}
+	case length < 1<<14:
+		return []byte{byte((length>>8)&0x3F) | 0x40, byte(length)}
+	default:
+		raw := make([]byte, 5)
+		raw[0] = 0x80
+		binary.BigEndian.PutUint32(raw[1:], uint32(length))
+		return raw
+	}
+}
+
+func TestLoadReaderWithRealisticAbsoluteExpiry(t *testing.T) {
+	store := storage.NewStore()
+	now := time.Now().UnixMilli()
+	payload := buildRDBPayload(
+		selectDB(0),
+		expiringStringEntryMillis(uint64(now+5000), rawString([]byte("ttl")), rawString([]byte("fresh"))),
+	)
+
+	stats, err := loadReaderAt(bytes.NewReader(payload), store, func() int64 { return now })
+	if err != nil {
+		t.Fatalf("loadReaderAt() error = %v", err)
+	}
+	if stats.LoadedKeys != 1 {
+		t.Fatalf("LoadedKeys = %d, want 1", stats.LoadedKeys)
+	}
+	assertStoredString(t, store, "ttl", "fresh")
+}

--- a/internal/rdb/snapshot.go
+++ b/internal/rdb/snapshot.go
@@ -1,0 +1,16 @@
+package rdb
+
+import "bytes"
+
+var emptySnapshot = func() []byte {
+	payload := make([]byte, 0, len(fileHeader)+1+8)
+	payload = append(payload, fileHeader...)
+	payload = append(payload, opcodeEOF)
+	payload = append(payload, make([]byte, 8)...)
+	return payload
+}()
+
+// EmptySnapshot returns the canonical empty RDB payload used for FULLRESYNC.
+func EmptySnapshot() []byte {
+	return bytes.Clone(emptySnapshot)
+}

--- a/internal/rdb/snapshot_test.go
+++ b/internal/rdb/snapshot_test.go
@@ -1,0 +1,28 @@
+package rdb
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEmptySnapshotReturnsIndependentCopies(t *testing.T) {
+	first := EmptySnapshot()
+	second := EmptySnapshot()
+
+	if !bytes.Equal(first, second) {
+		t.Fatal("EmptySnapshot() payloads differ before mutation")
+	}
+	if len(first) == 0 {
+		t.Fatal("EmptySnapshot() returned empty payload")
+	}
+
+	baseline := append([]byte(nil), second...)
+	first[0] ^= 0xff
+
+	if !bytes.Equal(second, baseline) {
+		t.Fatal("mutating one EmptySnapshot() result changed another result")
+	}
+	if got := EmptySnapshot(); !bytes.Equal(got, baseline) {
+		t.Fatal("subsequent EmptySnapshot() call returned mutated cached payload")
+	}
+}

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -21,11 +21,14 @@ type ClientState struct {
 	watchRegistry *WatchRegistry
 	watchedKeys   map[string]struct{}
 
-	Authenticated bool
-	InTransaction bool
-	TxFailed      bool
-	TxDirty       bool
-	TxQueue       []QueuedCommand
+	Authenticated     bool
+	Replica           bool
+	ReplicaListenPort int
+	LastWriteOffset   int64
+	InTransaction     bool
+	TxFailed          bool
+	TxDirty           bool
+	TxQueue           []QueuedCommand
 }
 
 type clientStateContextKey struct{}
@@ -75,6 +78,56 @@ func (s *ClientState) SetWatchRegistry(registry *WatchRegistry) {
 	if s.watchedKeys == nil {
 		s.watchedKeys = make(map[string]struct{})
 	}
+}
+
+// SetReplicaListeningPort records the port announced during REPLCONF listening-port.
+func (s *ClientState) SetReplicaListeningPort(port int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ReplicaListenPort = port
+}
+
+// ReplicaListeningPort returns the port announced by the replica, if any.
+func (s *ClientState) ReplicaListeningPort() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.ReplicaListenPort
+}
+
+// PromoteToReplica marks the connection as a replica peer.
+func (s *ClientState) PromoteToReplica() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Replica = true
+}
+
+// IsReplica reports whether the connection has completed replica handshake setup.
+func (s *ClientState) IsReplica() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Replica
+}
+
+// SetLastWriteReplicationOffset records the replication offset produced by the
+// most recent write command issued by this client.
+func (s *ClientState) SetLastWriteReplicationOffset(offset int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.LastWriteOffset = offset
+}
+
+// LastWriteReplicationOffset returns the replication offset produced by the
+// client's most recent write command.
+func (s *ClientState) LastWriteReplicationOffset() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.LastWriteOffset
 }
 
 // InTransactionActive reports whether the client is currently inside a transaction.

--- a/internal/server/client_state_test.go
+++ b/internal/server/client_state_test.go
@@ -18,12 +18,20 @@ func (stubExecutor) Execute(context.Context, protocol.Value) (protocol.Value, er
 	return protocol.SimpleString{Value: "OK"}, nil
 }
 
+func (stubExecutor) ExecuteDetailed(context.Context, protocol.Value) (ExecuteResult, error) {
+	return SingleResponse(protocol.SimpleString{Value: "OK"}), nil
+}
+
 type stubWatchExecutor struct {
 	registry *WatchRegistry
 }
 
 func (s stubWatchExecutor) Execute(context.Context, protocol.Value) (protocol.Value, error) {
 	return protocol.SimpleString{Value: "OK"}, nil
+}
+
+func (s stubWatchExecutor) ExecuteDetailed(context.Context, protocol.Value) (ExecuteResult, error) {
+	return SingleResponse(protocol.SimpleString{Value: "OK"}), nil
 }
 
 func (s stubWatchExecutor) WatchRegistry() *WatchRegistry {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -13,6 +13,7 @@ import (
 func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net.Conn) {
 	defer s.handlerWG.Done()
 	defer s.registry.Remove(clientID)
+	defer s.replicaPeers.Remove(clientID)
 	defer s.removeClientState(clientID)
 
 	if state := s.getClientState(clientID); state != nil {
@@ -46,32 +47,45 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			}
 
 			logger.Warn("failed to parse request", "error", err)
-			if writeErr := s.writeResponse(writer, protocol.ErrorValue{Message: "ERR " + err.Error()}); writeErr != nil {
-				logger.Warn("failed to write parser error", "error", writeErr)
+			if writeErr := s.writeResponses(writer, []protocol.Value{protocol.ErrorValue{Message: "ERR " + err.Error()}}); writeErr != nil {
+				logger.Warn("failed to write parser error", "parse_error", err, "write_error", writeErr)
 				return
 			}
 			continue
 		}
 
-		response, execErr := s.executor.Execute(ctx, value)
+		result, execErr := s.executor.ExecuteDetailed(ctx, value)
 		if execErr != nil {
 			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
 				return
 			}
 			logger.Debug("command execution failed", "error", execErr)
-			response = responseError(execErr)
+			result = SingleResponse(responseError(execErr))
 		}
 
-		if err := s.writeResponse(writer, response); err != nil {
-			logger.Warn("failed to write response", "error", err)
+		if err := s.writeResponses(writer, result.Responses); err != nil {
+			if len(result.Propagation) > 0 {
+				report := s.propagateToReplicas(result.Propagation)
+				s.recordClientWriteOffset(ctx, report.endOffset)
+			}
+			logger.Warn("failed to write response", "error", err, "propagation_frames", len(result.Propagation))
 			return
+		}
+		if result.RegisterReplica {
+			s.registerReplicaPeer(clientID, conn)
+		}
+		if len(result.Propagation) > 0 {
+			report := s.propagateToReplicas(result.Propagation)
+			s.recordClientWriteOffset(ctx, report.endOffset)
 		}
 	}
 }
 
-func (s *Server) writeResponse(writer *bufio.Writer, value protocol.Value) error {
-	if err := protocol.WriteValue(writer, value); err != nil {
-		return err
+func (s *Server) writeResponses(writer *bufio.Writer, values []protocol.Value) error {
+	for _, value := range values {
+		if err := protocol.WriteValue(writer, value); err != nil {
+			return err
+		}
 	}
 
 	return writer.Flush()

--- a/internal/server/registry.go
+++ b/internal/server/registry.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net"
 	"sync"
 )
@@ -44,7 +45,7 @@ func (r *Registry) Count() int {
 }
 
 // CloseAll closes every tracked client connection.
-func (r *Registry) CloseAll() {
+func (r *Registry) CloseAll() error {
 	r.mu.Lock()
 	clients := make([]net.Conn, 0, len(r.clients))
 	for id, conn := range r.clients {
@@ -53,7 +54,12 @@ func (r *Registry) CloseAll() {
 	}
 	r.mu.Unlock()
 
+	var closeErr error
 	for _, conn := range clients {
-		_ = conn.Close()
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			closeErr = errors.Join(closeErr, err)
+		}
 	}
+
+	return closeErr
 }

--- a/internal/server/registry_test.go
+++ b/internal/server/registry_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRegistryCloseAllReturnsJoinedErrors(t *testing.T) {
+	registry := NewRegistry()
+	registry.Add(&stubConn{closeErr: errors.New("close one")})
+	registry.Add(&stubConn{closeErr: errors.New("close two")})
+
+	err := registry.CloseAll()
+	if err == nil {
+		t.Fatal("CloseAll() error = nil, want joined close errors")
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "close one") || !strings.Contains(message, "close two") {
+		t.Fatalf("CloseAll() error = %q, want both close errors joined", message)
+	}
+}

--- a/internal/server/replication.go
+++ b/internal/server/replication.go
@@ -1,0 +1,554 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+// ExecuteResult describes the full set of RESP frames emitted by a command.
+type ExecuteResult struct {
+	Responses       []protocol.Value
+	UpstreamReplies []protocol.Value
+	Propagation     []protocol.Value
+	RegisterReplica bool
+}
+
+// SingleResponse wraps a standard single RESP value as an execution result.
+func SingleResponse(value protocol.Value) ExecuteResult {
+	return MultiResponse(value)
+}
+
+// MultiResponse wraps multiple RESP values to be written in order.
+func MultiResponse(values ...protocol.Value) ExecuteResult {
+	responses := make([]protocol.Value, len(values))
+	copy(responses, values)
+	return ExecuteResult{Responses: responses}
+}
+
+type replicationOriginContextKey struct{}
+
+// WithReplicationOrigin marks a command as originating from the upstream replication stream.
+func WithReplicationOrigin(ctx context.Context) context.Context {
+	return context.WithValue(ctx, replicationOriginContextKey{}, true)
+}
+
+// IsReplicationOrigin reports whether the current command came from the upstream replication stream.
+func IsReplicationOrigin(ctx context.Context) bool {
+	origin, _ := ctx.Value(replicationOriginContextKey{}).(bool)
+	return origin
+}
+
+// ReplicationState stores process-wide replication metadata.
+type ReplicationState struct {
+	MasterReplicationID string
+	masterOffset        atomic.Int64
+	replicaOffset       atomic.Int64
+}
+
+// ReplicaPeer describes a replica connection attached to a master.
+type ReplicaPeer struct {
+	ID            uint64
+	Conn          net.Conn
+	ListeningPort int
+	AckOffset     int64
+
+	writer *bufio.Writer
+	mu     sync.Mutex
+}
+
+type propagationReport struct {
+	attempted   int
+	succeeded   int
+	failed      int
+	payloadSize int
+	endOffset   int64
+}
+
+// WriteEncoded writes a pre-encoded RESP payload to the replica socket.
+func (p *ReplicaPeer) WriteEncoded(payload []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.writer == nil {
+		p.writer = bufio.NewWriter(p.Conn)
+	}
+	if _, err := p.writer.Write(payload); err != nil {
+		return err
+	}
+
+	return p.writer.Flush()
+}
+
+// ReplicaRegistry tracks replica peers connected to a master server.
+type ReplicaRegistry struct {
+	mu       sync.RWMutex
+	replicas map[uint64]*ReplicaPeer
+	changed  chan struct{}
+}
+
+func newReplicationState() *ReplicationState {
+	return &ReplicationState{MasterReplicationID: randomReplicationID()}
+}
+
+// MasterOffset reports the master's current logical replication offset.
+func (s *ReplicationState) MasterOffset() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return s.masterOffset.Load()
+}
+
+// AdvanceMasterOffset increments the master's logical replication offset.
+func (s *ReplicationState) AdvanceMasterOffset(delta int64) int64 {
+	if s == nil || delta <= 0 {
+		return s.MasterOffset()
+	}
+
+	return s.masterOffset.Add(delta)
+}
+
+// ReplicaOffset reports the replica's processed upstream replication offset.
+func (s *ReplicationState) ReplicaOffset() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return s.replicaOffset.Load()
+}
+
+// AdvanceReplicaOffset increments the replica's processed upstream replication offset.
+func (s *ReplicationState) AdvanceReplicaOffset(delta int64) int64 {
+	if s == nil || delta <= 0 {
+		return s.ReplicaOffset()
+	}
+
+	return s.replicaOffset.Add(delta)
+}
+
+// NewReplicaRegistry creates an empty registry of replica peers.
+func NewReplicaRegistry() *ReplicaRegistry {
+	return &ReplicaRegistry{replicas: make(map[uint64]*ReplicaPeer), changed: make(chan struct{})}
+}
+
+// Add stores or updates a replica peer.
+func (r *ReplicaRegistry) Add(id uint64, conn net.Conn, listeningPort int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.replicas[id] = &ReplicaPeer{ID: id, Conn: conn, ListeningPort: listeningPort, writer: bufio.NewWriter(conn)}
+	r.notifyChangedLocked()
+}
+
+// UpdateAck records the latest processed replication offset for a replica peer.
+func (r *ReplicaRegistry) UpdateAck(id uint64, offset int64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	peer, ok := r.replicas[id]
+	if !ok {
+		return false
+	}
+	if offset > peer.AckOffset {
+		peer.AckOffset = offset
+		r.notifyChangedLocked()
+	}
+
+	return true
+}
+
+// CountReplicasAtOrAbove reports how many replicas have acknowledged at least targetOffset.
+func (r *ReplicaRegistry) CountReplicasAtOrAbove(targetOffset int64) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.countReplicasAtOrAboveLocked(targetOffset)
+}
+
+// CountReplicasAtOrAboveWithNotify returns the current matching replica count and a
+// notification channel that is closed whenever replica acknowledgement state changes.
+func (r *ReplicaRegistry) CountReplicasAtOrAboveWithNotify(targetOffset int64) (int, <-chan struct{}) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.countReplicasAtOrAboveLocked(targetOffset), r.changed
+}
+
+func (r *ReplicaRegistry) countReplicasAtOrAboveLocked(targetOffset int64) int {
+	count := 0
+	for _, peer := range r.replicas {
+		if peer.AckOffset >= targetOffset {
+			count++
+		}
+	}
+
+	return count
+}
+
+// Remove deletes a replica peer from the registry.
+func (r *ReplicaRegistry) Remove(id uint64) *ReplicaPeer {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	peer := r.replicas[id]
+	delete(r.replicas, id)
+	if peer != nil {
+		r.notifyChangedLocked()
+	}
+	return peer
+}
+
+// RemoveAndClose deletes a replica peer from the registry and closes its socket.
+func (r *ReplicaRegistry) RemoveAndClose(id uint64) error {
+	peer := r.Remove(id)
+	if peer != nil {
+		if err := peer.Conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Snapshot returns the currently tracked replica peers.
+func (r *ReplicaRegistry) Snapshot() []*ReplicaPeer {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	peers := make([]*ReplicaPeer, 0, len(r.replicas))
+	for _, peer := range r.replicas {
+		peers = append(peers, peer)
+	}
+
+	return peers
+}
+
+// Count reports the number of tracked replica peers.
+func (r *ReplicaRegistry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.replicas)
+}
+
+func (r *ReplicaRegistry) notifyChangedLocked() {
+	close(r.changed)
+	r.changed = make(chan struct{})
+}
+
+func randomReplicationID() string {
+	var raw [20]byte
+	if _, err := cryptorand.Read(raw[:]); err == nil {
+		return hex.EncodeToString(raw[:])
+	}
+
+	return fmt.Sprintf("%040x", time.Now().UnixNano())
+}
+
+func (s *Server) registerReplicaPeer(clientID uint64, conn net.Conn) {
+	state := s.getClientState(clientID)
+	if state == nil || !state.IsReplica() {
+		return
+	}
+
+	s.replicaPeers.Add(clientID, conn, state.ReplicaListeningPort())
+}
+
+func (s *Server) propagateToReplicas(values []protocol.Value) propagationReport {
+	if len(values) == 0 {
+		return propagationReport{}
+	}
+
+	payload, err := protocol.EncodeValues(values)
+	if err != nil {
+		s.logger.Warn("failed to encode propagated command", "error", err)
+		return propagationReport{}
+	}
+	report := propagationReport{attempted: s.replicaPeers.Count(), payloadSize: len(payload)}
+	report.endOffset = s.replication.AdvanceMasterOffset(int64(len(payload)))
+
+	for _, peer := range s.replicaPeers.Snapshot() {
+		if err := peer.WriteEncoded(payload); err != nil {
+			s.logger.Warn("failed to propagate command to replica", "replica_id", peer.ID, "error", err)
+			report.failed++
+			if closeErr := s.replicaPeers.RemoveAndClose(peer.ID); closeErr != nil {
+				s.logger.Debug("failed to close replica after propagation failure", "replica_id", peer.ID, "error", closeErr)
+			}
+			continue
+		}
+		report.succeeded++
+	}
+
+	if report.failed > 0 {
+		log := s.logger.Warn
+		message := "propagation to replicas was partially successful"
+		if report.succeeded == 0 && report.attempted > 0 {
+			log = s.logger.Error
+			message = "propagation to replicas failed for every replica"
+		}
+		log(message,
+			"attempted", report.attempted,
+			"succeeded", report.succeeded,
+			"failed", report.failed,
+			"payload_size", report.payloadSize,
+		)
+	}
+
+	return report
+}
+
+func (s *Server) recordClientWriteOffset(ctx context.Context, offset int64) {
+	if offset <= 0 {
+		return
+	}
+
+	state, ok := ClientStateFromContext(ctx)
+	if !ok || state == nil {
+		return
+	}
+
+	state.SetLastWriteReplicationOffset(offset)
+}
+
+func (s *Server) setUpstreamConn(conn net.Conn) {
+	s.upstreamConnMu.Lock()
+	defer s.upstreamConnMu.Unlock()
+
+	s.upstreamConn = conn
+}
+
+func (s *Server) clearUpstreamConn(conn net.Conn) {
+	s.upstreamConnMu.Lock()
+	defer s.upstreamConnMu.Unlock()
+
+	if s.upstreamConn == conn {
+		s.upstreamConn = nil
+	}
+}
+
+func (s *Server) closeUpstreamConn() {
+	s.upstreamConnMu.Lock()
+	conn := s.upstreamConn
+	s.upstreamConn = nil
+	s.upstreamConnMu.Unlock()
+
+	if conn != nil {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.logger.Debug("failed to close upstream connection", "error", err)
+		}
+	}
+}
+
+func (s *Server) startReplicaLink(ctx context.Context, listenerAddr string) {
+	defer s.handlerWG.Done()
+
+	masterAddr, err := s.cfg.ReplicaAddress()
+	if err != nil {
+		s.logger.Error("replica mode configuration invalid", "error", err)
+		return
+	}
+
+	listeningPort, err := parseListenerPort(listenerAddr)
+	if err != nil {
+		s.logger.Error("failed to determine replica listening port", "address", listenerAddr, "error", err)
+		return
+	}
+
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", masterAddr)
+	if err != nil {
+		s.logger.Error("failed to connect to master", "master_addr", masterAddr, "error", err)
+		return
+	}
+	s.setUpstreamConn(conn)
+	defer s.clearUpstreamConn(conn)
+	defer func() {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.logger.Debug("failed to close replica upstream connection", "master_addr", masterAddr, "error", err)
+		}
+	}()
+
+	stopClose := context.AfterFunc(ctx, func() {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.logger.Debug("failed to close replica upstream connection after cancellation", "master_addr", masterAddr, "error", err)
+		}
+	})
+	defer stopClose()
+
+	parser := protocol.NewParser(conn)
+	writer := bufio.NewWriter(conn)
+
+	if err := writeReplicaCommand(writer, "PING"); err != nil {
+		s.logger.Error("failed to send replica PING", "master_addr", masterAddr, "error", err)
+		return
+	}
+	if err := expectSimpleString(parser, "PONG"); err != nil {
+		s.logger.Error("invalid PING response from master", "master_addr", masterAddr, "error", err)
+		return
+	}
+
+	if err := writeReplicaCommand(writer, "REPLCONF", "listening-port", strconv.Itoa(listeningPort)); err != nil {
+		s.logger.Error("failed to send replica REPLCONF", "master_addr", masterAddr, "error", err)
+		return
+	}
+	if err := expectSimpleString(parser, "OK"); err != nil {
+		s.logger.Error("invalid REPLCONF response from master", "master_addr", masterAddr, "error", err)
+		return
+	}
+
+	if err := writeReplicaCommand(writer, "PSYNC", "?", "-1"); err != nil {
+		s.logger.Error("failed to send replica PSYNC", "master_addr", masterAddr, "error", err)
+		return
+	}
+	if err := s.consumeFullResync(parser); err != nil {
+		s.logger.Error("failed to consume FULLRESYNC from master", "master_addr", masterAddr, "error", err)
+		return
+	}
+
+	s.logger.Info("replica handshake completed", "master_addr", masterAddr, "listening_port", listeningPort)
+
+	replicationCtx := WithReplicationOrigin(ctx)
+
+	for {
+		value, err := parser.Parse()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				return
+			}
+
+			s.logger.Warn("replication stream parse failed", "master_addr", masterAddr, "error", err)
+			return
+		}
+
+		encoded, err := protocol.Encode(value)
+		if err != nil {
+			s.logger.Warn("failed to encode replication stream value", "master_addr", masterAddr, "error", err)
+			return
+		}
+		s.replication.AdvanceReplicaOffset(int64(len(encoded)))
+
+		result, execErr := s.executor.ExecuteDetailed(replicationCtx, value)
+		if execErr != nil {
+			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
+				return
+			}
+
+			s.logger.Warn("replication stream command failed", "master_addr", masterAddr, "error", execErr)
+			return
+		}
+		if len(result.UpstreamReplies) > 0 {
+			if err := writeReplicaResponses(writer, result.UpstreamReplies); err != nil {
+				s.logger.Warn("failed to write replication upstream reply", "master_addr", masterAddr, "error", err)
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) consumeFullResync(parser *protocol.Parser) error {
+	value, err := parser.Parse()
+	if err != nil {
+		return fmt.Errorf("read FULLRESYNC line: %w", err)
+	}
+
+	line, ok := value.(protocol.SimpleString)
+	if !ok {
+		return fmt.Errorf("unexpected FULLRESYNC response type %T", value)
+	}
+	parts := strings.Fields(line.Value)
+	if len(parts) != 3 || !strings.EqualFold(parts[0], "FULLRESYNC") || parts[1] == "" || parts[2] != "0" {
+		return fmt.Errorf("invalid FULLRESYNC response %q", line.Value)
+	}
+
+	snapshotValue, err := parser.Parse()
+	if err != nil {
+		return fmt.Errorf("read replication snapshot: %w", err)
+	}
+
+	snapshot, ok := snapshotValue.(protocol.BulkString)
+	if !ok || snapshot.Null {
+		return fmt.Errorf("unexpected replication snapshot type %T", snapshotValue)
+	}
+
+	snapshotStore := storage.NewStore()
+	if _, err := rdb.LoadReader(bytes.NewReader(snapshot.Data), snapshotStore); err != nil {
+		return fmt.Errorf("load replication snapshot: %w", err)
+	}
+	s.store.ReplaceWith(snapshotStore)
+
+	return nil
+}
+
+func parseListenerPort(address string) (int, error) {
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return 0, err
+	}
+
+	parsed, err := strconv.Atoi(port)
+	if err != nil {
+		return 0, err
+	}
+
+	return parsed, nil
+}
+
+func writeReplicaCommand(writer *bufio.Writer, parts ...string) error {
+	if err := protocol.WriteValue(writer, replicaCommand(parts...)); err != nil {
+		return err
+	}
+
+	return writer.Flush()
+}
+
+func writeReplicaResponses(writer *bufio.Writer, values []protocol.Value) error {
+	for _, value := range values {
+		if err := protocol.WriteValue(writer, value); err != nil {
+			return err
+		}
+	}
+
+	return writer.Flush()
+}
+
+func replicaCommand(parts ...string) protocol.Array {
+	elements := make([]protocol.Value, 0, len(parts))
+	for _, part := range parts {
+		elements = append(elements, protocol.BulkString{Data: []byte(part)})
+	}
+
+	return protocol.Array{Elements: elements}
+}
+
+func expectSimpleString(parser *protocol.Parser, expected string) error {
+	value, err := parser.Parse()
+	if err != nil {
+		return err
+	}
+
+	line, ok := value.(protocol.SimpleString)
+	if !ok {
+		return fmt.Errorf("unexpected response type %T", value)
+	}
+	if line.Value != expected {
+		return fmt.Errorf("unexpected response %q, want %q", line.Value, expected)
+	}
+
+	return nil
+}

--- a/internal/server/replication_test.go
+++ b/internal/server/replication_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/config"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestReplicaRegistryCountReplicasAtOrAboveWithNotify(t *testing.T) {
+	registry := NewReplicaRegistry()
+	serverConn, replicaConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	defer func() { _ = replicaConn.Close() }()
+
+	registry.Add(1, serverConn, 6380)
+
+	count, changed := registry.CountReplicasAtOrAboveWithNotify(10)
+	if count != 0 {
+		t.Fatalf("initial count = %d, want 0", count)
+	}
+
+	if ok := registry.UpdateAck(1, 10); !ok {
+		t.Fatal("UpdateAck() = false, want true")
+	}
+
+	select {
+	case <-changed:
+	case <-time.After(time.Second):
+		t.Fatal("CountReplicasAtOrAboveWithNotify() channel was not notified")
+	}
+
+	count, _ = registry.CountReplicasAtOrAboveWithNotify(10)
+	if count != 1 {
+		t.Fatalf("updated count = %d, want 1", count)
+	}
+}
+
+func TestReplicaRegistryRemoveAndCloseReturnsCloseError(t *testing.T) {
+	registry := NewReplicaRegistry()
+	registry.Add(1, &stubConn{closeErr: errors.New("close boom")}, 6380)
+
+	err := registry.RemoveAndClose(1)
+	if err == nil || err.Error() != "close boom" {
+		t.Fatalf("RemoveAndClose() error = %v, want close boom", err)
+	}
+}
+
+func TestServerPropagateToReplicasRemovesFailingReplica(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := New(config.Config{}, logger, storage.NewStore(), nil)
+
+	serverConn := &recordingConn{}
+	srv.replicaPeers.Add(1, serverConn, 6380)
+	srv.replicaPeers.Add(2, &stubConn{writeErr: errors.New("write boom")}, 6381)
+
+	report := srv.propagateToReplicas([]protocol.Value{protocol.SimpleString{Value: "OK"}})
+	if report.attempted != 2 {
+		t.Fatalf("report.attempted = %d, want 2", report.attempted)
+	}
+	if report.succeeded != 1 {
+		t.Fatalf("report.succeeded = %d, want 1", report.succeeded)
+	}
+	if report.failed != 1 {
+		t.Fatalf("report.failed = %d, want 1", report.failed)
+	}
+	if srv.replicaPeers.Count() != 1 {
+		t.Fatalf("replicaPeers.Count() = %d, want 1", srv.replicaPeers.Count())
+	}
+
+	parser := protocol.NewParser(bytes.NewReader(serverConn.Bytes()))
+	value, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got, ok := value.(protocol.SimpleString); !ok || got.Value != "OK" {
+		t.Fatalf("parsed value = %#v, want simple string OK", value)
+	}
+}
+
+type stubConn struct {
+	writeErr error
+	closeErr error
+}
+
+type recordingConn struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *stubConn) Read(_ []byte) (int, error) { return 0, io.EOF }
+func (c *stubConn) Write(p []byte) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	return len(p), nil
+}
+func (c *stubConn) Close() error                       { return c.closeErr }
+func (c *stubConn) LocalAddr() net.Addr                { return stubAddr("local") }
+func (c *stubConn) RemoteAddr() net.Addr               { return stubAddr("remote") }
+func (c *stubConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *stubConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *stubConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (c *recordingConn) Read(_ []byte) (int, error) { return 0, io.EOF }
+func (c *recordingConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+func (c *recordingConn) Close() error                       { return nil }
+func (c *recordingConn) LocalAddr() net.Addr                { return stubAddr("local") }
+func (c *recordingConn) RemoteAddr() net.Addr               { return stubAddr("remote") }
+func (c *recordingConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (c *recordingConn) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return bytes.Clone(c.buf.Bytes())
+}
+
+type stubAddr string
+
+func (a stubAddr) Network() string { return "tcp" }
+func (a stubAddr) String() string  { return string(a) }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,11 +16,19 @@ import (
 )
 
 type executor interface {
-	Execute(context.Context, protocol.Value) (protocol.Value, error)
+	ExecuteDetailed(context.Context, protocol.Value) (ExecuteResult, error)
 }
 
 type watchRegistryProvider interface {
 	WatchRegistry() *WatchRegistry
+}
+
+type replicationStateSetter interface {
+	SetReplicationState(*ReplicationState)
+}
+
+type replicaRegistrySetter interface {
+	SetReplicaRegistry(*ReplicaRegistry)
 }
 
 // Server owns the TCP listener, active clients, and command execution pipeline.
@@ -30,10 +38,15 @@ type Server struct {
 	store         *storage.Store
 	executor      executor
 	registry      *Registry
+	replicaPeers  *ReplicaRegistry
 	watchRegistry *WatchRegistry
+	replication   *ReplicationState
 
 	clientStates   map[uint64]*ClientState
 	clientStatesMu sync.RWMutex
+
+	upstreamConn   net.Conn
+	upstreamConnMu sync.Mutex
 
 	listener     net.Listener
 	listenerMu   sync.RWMutex
@@ -49,10 +62,21 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 		store:        store,
 		executor:     executor,
 		registry:     NewRegistry(),
+		replicaPeers: NewReplicaRegistry(),
+		replication:  newReplicationState(),
 		clientStates: make(map[uint64]*ClientState),
+	}
+	if store != nil {
+		store.SetLogger(logger)
 	}
 	if provider, ok := executor.(watchRegistryProvider); ok {
 		srv.watchRegistry = provider.WatchRegistry()
+	}
+	if setter, ok := executor.(replicationStateSetter); ok {
+		setter.SetReplicationState(srv.replication)
+	}
+	if setter, ok := executor.(replicaRegistrySetter); ok {
+		setter.SetReplicaRegistry(srv.replicaPeers)
 	}
 
 	return srv
@@ -60,6 +84,12 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 
 // ListenAndServe starts the TCP listener and blocks until shutdown.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	if s.cfg.IsReplica() {
+		if _, err := s.cfg.ReplicaAddress(); err != nil {
+			return fmt.Errorf("server: validate replica configuration: %w", err)
+		}
+	}
+
 	if s.cfg.RDBPath != "" {
 		startedAt := time.Now()
 		stats, err := rdb.LoadFile(s.cfg.RDBPath, s.store)
@@ -86,6 +116,10 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 
 	s.logger.Info("RuneDB listening", "address", listener.Addr().String())
 	s.store.StartEviction(ctx, s.cfg.EvictionInterval, s.cfg.EvictionSampleSize)
+	if s.cfg.IsReplica() {
+		s.handlerWG.Add(1)
+		go s.startReplicaLink(ctx, listener.Addr().String())
+	}
 
 	stopShutdown := context.AfterFunc(ctx, s.shutdown)
 	defer stopShutdown()
@@ -138,13 +172,19 @@ func (s *Server) setListener(listener net.Listener) {
 
 func (s *Server) shutdown() {
 	s.shutdownOnce.Do(func() {
+		s.closeUpstreamConn()
+
 		s.listenerMu.RLock()
 		listener := s.listener
 		s.listenerMu.RUnlock()
 		if listener != nil {
-			_ = listener.Close()
+			if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				s.logger.Debug("failed to close listener during shutdown", "error", err)
+			}
 		}
-		s.registry.CloseAll()
+		if err := s.registry.CloseAll(); err != nil {
+			s.logger.Debug("failed to close one or more client connections during shutdown", "error", err)
+		}
 		s.clearClientStates()
 	})
 }
@@ -193,4 +233,9 @@ func (s *Server) clearClientStates() {
 	for _, state := range states {
 		state.UnwatchAll()
 	}
+}
+
+// ReplicaCount returns the number of replica peers connected to this server.
+func (s *Server) ReplicaCount() int {
+	return s.replicaPeers.Count()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,9 +7,11 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/maltemindedal/runedb/internal/config"
 	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
 	"github.com/maltemindedal/runedb/internal/storage"
 )
 
@@ -58,6 +60,22 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 
 // ListenAndServe starts the TCP listener and blocks until shutdown.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	if s.cfg.RDBPath != "" {
+		startedAt := time.Now()
+		stats, err := rdb.LoadFile(s.cfg.RDBPath, s.store)
+		if err != nil {
+			return fmt.Errorf("server: load rdb %q: %w", s.cfg.RDBPath, err)
+		}
+
+		s.logger.Info(
+			"loaded RDB snapshot",
+			"path", s.cfg.RDBPath,
+			"loaded_keys", stats.LoadedKeys,
+			"skipped_expired_keys", stats.SkippedExpiredKeys,
+			"duration", time.Since(startedAt),
+		)
+	}
+
 	listener, err := net.Listen("tcp", s.cfg.Address())
 	if err != nil {
 		return fmt.Errorf("server: listen on %s: %w", s.cfg.Address(), err)

--- a/internal/storage/eviction.go
+++ b/internal/storage/eviction.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -17,15 +18,26 @@ func (s *Store) StartEviction(ctx context.Context, interval time.Duration, sampl
 	}
 
 	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				s.logError("background eviction loop panicked", "panic", fmt.Sprint(recovered))
+			}
+		}()
+
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+		s.logDebug("background eviction loop started", "interval", interval, "sample_size", sampleSize)
 
 		for {
 			select {
 			case <-ctx.Done():
+				s.logDebug("background eviction loop stopped", "reason", ctx.Err())
 				return
 			case <-ticker.C:
-				s.evictExpiredSample(time.Now().UnixMilli(), sampleSize)
+				removed := s.evictExpiredSample(time.Now().UnixMilli(), sampleSize)
+				if removed > 0 {
+					s.logDebug("background eviction removed expired keys", "removed", removed, "sample_size", sampleSize)
+				}
 			}
 		}
 	}()

--- a/internal/storage/list_waiters.go
+++ b/internal/storage/list_waiters.go
@@ -1,22 +1,36 @@
 package storage
 
-import "sync"
+import (
+	"container/list"
+	"sync"
+)
 
 type listWaiters struct {
 	mu      sync.Mutex
-	waiters map[string][]chan struct{}
+	waiters map[string]*waiterQueue
+}
+
+type waiterQueue struct {
+	order *list.List
+	index map[chan struct{}]*list.Element
 }
 
 func newListWaiters() *listWaiters {
-	return &listWaiters{waiters: make(map[string][]chan struct{})}
+	return &listWaiters{waiters: make(map[string]*waiterQueue)}
 }
 
 func (w *listWaiters) subscribe(key string) chan struct{} {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	queue := w.waiters[key]
+	if queue == nil {
+		queue = &waiterQueue{order: list.New(), index: make(map[chan struct{}]*list.Element)}
+		w.waiters[key] = queue
+	}
+
 	ch := make(chan struct{}, 1)
-	w.waiters[key] = append(w.waiters[key], ch)
+	queue.index[ch] = queue.order.PushBack(ch)
 	return ch
 }
 
@@ -24,36 +38,37 @@ func (w *listWaiters) unsubscribe(key string, ch chan struct{}) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	waiters := w.waiters[key]
-	for i, waiter := range waiters {
-		if waiter != ch {
-			continue
-		}
-
-		waiters = append(waiters[:i], waiters[i+1:]...)
-		if len(waiters) == 0 {
-			delete(w.waiters, key)
-		} else {
-			w.waiters[key] = waiters
-		}
+	queue := w.waiters[key]
+	if queue == nil {
 		return
+	}
+
+	element, ok := queue.index[ch]
+	if !ok {
+		return
+	}
+
+	queue.order.Remove(element)
+	delete(queue.index, ch)
+	if queue.order.Len() == 0 {
+		delete(w.waiters, key)
 	}
 }
 
 func (w *listWaiters) notifyOne(key string) {
 	w.mu.Lock()
-	waiters := w.waiters[key]
-	if len(waiters) == 0 {
+	queue := w.waiters[key]
+	if queue == nil || queue.order.Len() == 0 {
 		w.mu.Unlock()
 		return
 	}
 
-	ch := waiters[0]
-	remaining := append(waiters[:0:0], waiters[1:]...)
-	if len(remaining) == 0 {
+	front := queue.order.Front()
+	ch := front.Value.(chan struct{})
+	queue.order.Remove(front)
+	delete(queue.index, ch)
+	if queue.order.Len() == 0 {
 		delete(w.waiters, key)
-	} else {
-		w.waiters[key] = remaining
 	}
 	w.mu.Unlock()
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -61,16 +61,34 @@ func (s *Store) Set(key string, value []byte, expiresAt int64) {
 
 // Get fetches a value from the store, passively evicting it if it has expired.
 func (s *Store) Get(key string) ([]byte, bool, error) {
-	value, ok := s.loadValue(key)
+	now := time.Now().UnixMilli()
+
+	s.mu.RLock()
+	value, ok := s.data[key]
 	if !ok {
+		s.mu.RUnlock()
+		return nil, false, nil
+	}
+	if isExpired(value, now) {
+		s.mu.RUnlock()
+
+		s.mu.Lock()
+		value, ok = s.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			delete(s.data, key)
+		}
+		s.mu.Unlock()
 		return nil, false, nil
 	}
 	data, err := value.StringValue()
 	if err != nil {
+		s.mu.RUnlock()
 		return nil, true, err
 	}
+	cloned := cloneBytes(data)
+	s.mu.RUnlock()
 
-	return data, true, nil
+	return cloned, true, nil
 }
 
 // Delete removes a key from the store.
@@ -167,21 +185,40 @@ func (s *Store) LeftPop(key string) ([]byte, bool, error) {
 
 // ListRange returns an inclusive range of values from the list stored at key.
 func (s *Store) ListRange(key string, start, stop int64) ([][]byte, error) {
-	value, ok := s.loadValue(key)
+	now := time.Now().UnixMilli()
+
+	s.mu.RLock()
+	value, ok := s.data[key]
 	if !ok {
+		s.mu.RUnlock()
+		return [][]byte{}, nil
+	}
+	if isExpired(value, now) {
+		s.mu.RUnlock()
+
+		s.mu.Lock()
+		value, ok = s.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			delete(s.data, key)
+		}
+		s.mu.Unlock()
 		return [][]byte{}, nil
 	}
 	list, err := value.ListValue()
 	if err != nil {
+		s.mu.RUnlock()
 		return nil, err
 	}
 
 	from, to, ok := normalizeListRange(len(list), start, stop)
 	if !ok {
+		s.mu.RUnlock()
 		return [][]byte{}, nil
 	}
 
-	return list[from : to+1], nil
+	cloned := cloneList(list[from : to+1])
+	s.mu.RUnlock()
+	return cloned, nil
 }
 
 // ZAdd inserts or updates one or more sorted-set members and returns the number of newly added members.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -56,7 +56,7 @@ func (s *Store) Get(key string) ([]byte, bool, error) {
 		return nil, true, ErrWrongType
 	}
 
-	return cloneBytes(value.String), true, nil
+	return value.String, true, nil
 }
 
 // Delete removes a key from the store.
@@ -136,7 +136,7 @@ func (s *Store) LeftPop(key string) ([]byte, bool, error) {
 		return nil, false, nil
 	}
 
-	item := cloneBytes(value.List[0])
+	item := value.List[0]
 	value.List[0] = nil
 	value.List = value.List[1:]
 	if len(value.List) == 0 {
@@ -163,7 +163,7 @@ func (s *Store) ListRange(key string, start, stop int64) ([][]byte, error) {
 		return [][]byte{}, nil
 	}
 
-	return cloneList(value.List[from : to+1]), nil
+	return value.List[from : to+1], nil
 }
 
 // ZAdd inserts or updates one or more sorted-set members and returns the number of newly added members.
@@ -207,14 +207,14 @@ func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
 }
 
 // ZRange returns an inclusive rank range from the sorted set stored at key.
-func (s *Store) ZRange(key string, start, stop int64) ([]ZSetEntry, error) {
+func (s *Store) ZRange(key string, start, stop int64) ([]ZSetRangeEntry, error) {
 	now := time.Now().UnixMilli()
 
 	s.mu.RLock()
 	value, ok := s.data[key]
 	if !ok {
 		s.mu.RUnlock()
-		return []ZSetEntry{}, nil
+		return []ZSetRangeEntry{}, nil
 	}
 	if isExpired(value, now) {
 		s.mu.RUnlock()
@@ -225,7 +225,7 @@ func (s *Store) ZRange(key string, start, stop int64) ([]ZSetEntry, error) {
 			delete(s.data, key)
 		}
 		s.mu.Unlock()
-		return []ZSetEntry{}, nil
+		return []ZSetRangeEntry{}, nil
 	}
 	if value.Kind != ValueKindZSet {
 		s.mu.RUnlock()
@@ -235,14 +235,10 @@ func (s *Store) ZRange(key string, start, stop int64) ([]ZSetEntry, error) {
 	from, to, ok := normalizeListRange(value.ZSet.len(), start, stop)
 	if !ok {
 		s.mu.RUnlock()
-		return []ZSetEntry{}, nil
+		return []ZSetRangeEntry{}, nil
 	}
 
-	raw := value.ZSet.rangeByRank(from, to)
-	entries := make([]ZSetEntry, 0, len(raw))
-	for _, item := range raw {
-		entries = append(entries, ZSetEntry{Member: []byte(item.member), Score: item.score})
-	}
+	entries := value.ZSet.rangeByRank(from, to)
 	s.mu.RUnlock()
 
 	return entries, nil
@@ -406,17 +402,14 @@ func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) 
 
 	additions := cloneList(values)
 	if left {
-		combined := make([][]byte, 0, len(list)+len(additions))
-		for i := len(additions) - 1; i >= 0; i-- {
-			combined = append(combined, additions[i])
+		combined := make([][]byte, len(list)+len(additions))
+		for i := range additions {
+			combined[i] = additions[len(additions)-1-i]
 		}
-		combined = append(combined, list...)
+		copy(combined[len(additions):], list)
 		list = combined
 	} else {
-		combined := make([][]byte, 0, len(list)+len(additions))
-		combined = append(combined, list...)
-		combined = append(combined, additions...)
-		list = combined
+		list = append(list, additions...)
 	}
 
 	s.data[key] = newListValue(list, expiresAt)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -517,35 +517,6 @@ func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) 
 	return newLen, nil
 }
 
-func (s *Store) loadValue(key string) (StoredValue, bool) {
-	now := time.Now().UnixMilli()
-
-	s.mu.RLock()
-	value, ok := s.data[key]
-	s.mu.RUnlock()
-	if !ok {
-		return StoredValue{}, false
-	}
-
-	if !isExpired(value, now) {
-		return value, true
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	value, ok = s.data[key]
-	if !ok {
-		return StoredValue{}, false
-	}
-	if !isExpired(value, time.Now().UnixMilli()) {
-		return value, true
-	}
-
-	delete(s.data, key)
-	return StoredValue{}, false
-}
-
 func normalizeListRange(length int, start, stop int64) (int, int, bool) {
 	if length == 0 {
 		return 0, 0, false

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"log/slog"
 	"math"
 	"strconv"
 	"strings"
@@ -31,11 +32,23 @@ type Store struct {
 	mu      sync.RWMutex
 	data    map[string]StoredValue
 	waiters *listWaiters
+	logger  *slog.Logger
 }
 
 // NewStore constructs an empty Store.
 func NewStore() *Store {
 	return &Store{data: make(map[string]StoredValue), waiters: newListWaiters()}
+}
+
+// SetLogger configures optional structured logging for background store operations.
+func (s *Store) SetLogger(logger *slog.Logger) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logger = logger
 }
 
 // Set stores a byte slice under the provided key.
@@ -52,11 +65,12 @@ func (s *Store) Get(key string) ([]byte, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	if value.Kind != ValueKindString {
-		return nil, true, ErrWrongType
+	data, err := value.StringValue()
+	if err != nil {
+		return nil, true, err
 	}
 
-	return value.String, true, nil
+	return data, true, nil
 }
 
 // Delete removes a key from the store.
@@ -90,11 +104,12 @@ func (s *Store) Increment(key string) (int64, error) {
 		s.data[key] = newStringValue([]byte("1"), 0)
 		return 1, nil
 	}
-	if value.Kind != ValueKindString {
-		return 0, ErrWrongType
+	currentValue, err := value.StringValue()
+	if err != nil {
+		return 0, err
 	}
 
-	current, err := strconv.ParseInt(string(value.String), 10, 64)
+	current, err := strconv.ParseInt(string(currentValue), 10, 64)
 	if err != nil || current == math.MaxInt64 {
 		return 0, ErrValueNotInteger
 	}
@@ -128,18 +143,20 @@ func (s *Store) LeftPop(key string) ([]byte, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	if value.Kind != ValueKindList {
-		return nil, false, ErrWrongType
+	list, err := value.ListValue()
+	if err != nil {
+		return nil, false, err
 	}
-	if len(value.List) == 0 {
+	if len(list) == 0 {
 		delete(s.data, key)
 		return nil, false, nil
 	}
 
-	item := value.List[0]
-	value.List[0] = nil
-	value.List = value.List[1:]
-	if len(value.List) == 0 {
+	item := list[0]
+	list[0] = nil
+	list = list[1:]
+	value.List = list
+	if len(list) == 0 {
 		delete(s.data, key)
 	} else {
 		s.data[key] = value
@@ -154,16 +171,17 @@ func (s *Store) ListRange(key string, start, stop int64) ([][]byte, error) {
 	if !ok {
 		return [][]byte{}, nil
 	}
-	if value.Kind != ValueKindList {
-		return nil, ErrWrongType
+	list, err := value.ListValue()
+	if err != nil {
+		return nil, err
 	}
 
-	from, to, ok := normalizeListRange(len(value.List), start, stop)
+	from, to, ok := normalizeListRange(len(list), start, stop)
 	if !ok {
 		return [][]byte{}, nil
 	}
 
-	return value.List[from : to+1], nil
+	return list[from : to+1], nil
 }
 
 // ZAdd inserts or updates one or more sorted-set members and returns the number of newly added members.
@@ -186,10 +204,11 @@ func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
 		expiresAt int64
 	)
 	if ok {
-		if value.Kind != ValueKindZSet {
-			return 0, ErrWrongType
+		var err error
+		set, err = value.ZSetValue()
+		if err != nil {
+			return 0, err
 		}
-		set = value.ZSet
 		expiresAt = value.ExpiresAt
 	} else {
 		set = newSortedSet()
@@ -227,18 +246,19 @@ func (s *Store) ZRange(key string, start, stop int64) ([]ZSetRangeEntry, error) 
 		s.mu.Unlock()
 		return []ZSetRangeEntry{}, nil
 	}
-	if value.Kind != ValueKindZSet {
+	set, err := value.ZSetValue()
+	if err != nil {
 		s.mu.RUnlock()
-		return nil, ErrWrongType
+		return nil, err
 	}
 
-	from, to, ok := normalizeListRange(value.ZSet.len(), start, stop)
+	from, to, ok := normalizeListRange(set.len(), start, stop)
 	if !ok {
 		s.mu.RUnlock()
 		return []ZSetRangeEntry{}, nil
 	}
 
-	entries := value.ZSet.rangeByRank(from, to)
+	entries := set.rangeByRank(from, to)
 	s.mu.RUnlock()
 
 	return entries, nil
@@ -264,10 +284,11 @@ func (s *Store) XAdd(key, rawID string, values [][]byte) (string, error) {
 		expiresAt int64
 	)
 	if ok {
-		if value.Kind != ValueKindStream {
-			return "", ErrWrongType
+		var err error
+		stream, err = value.StreamValue()
+		if err != nil {
+			return "", err
 		}
-		stream = value.Stream
 		expiresAt = value.ExpiresAt
 	} else {
 		stream = newStream()
@@ -303,12 +324,13 @@ func (s *Store) XRead(key, rawID string) ([]StreamEntry, error) {
 		s.mu.Unlock()
 		return []StreamEntry{}, nil
 	}
-	if value.Kind != ValueKindStream {
+	stream, err := value.StreamValue()
+	if err != nil {
 		s.mu.RUnlock()
-		return nil, ErrWrongType
+		return nil, err
 	}
 
-	entries, err := value.Stream.readAfter(rawID)
+	entries, err := stream.readAfter(rawID)
 	s.mu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -333,6 +355,43 @@ func (s *Store) Len() int {
 	defer s.mu.RUnlock()
 
 	return len(s.data)
+}
+
+// ReplaceWith swaps the store contents with a snapshot from another store.
+//
+// The replacement is applied only after the source snapshot has already been
+// materialized, which makes it suitable for FULLRESYNC-style state replacement.
+func (s *Store) ReplaceWith(other *Store) {
+	if s == nil || other == nil {
+		return
+	}
+
+	other.mu.RLock()
+	replacement := make(map[string]StoredValue, len(other.data))
+	for key, value := range other.data {
+		replacement[key] = value
+	}
+	other.mu.RUnlock()
+
+	s.mu.Lock()
+	s.data = replacement
+	s.mu.Unlock()
+}
+
+func (s *Store) logDebug(msg string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+
+	s.logger.Debug(msg, args...)
+}
+
+func (s *Store) logError(msg string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+
+	s.logger.Error(msg, args...)
 }
 
 func (s *Store) snapshotKeys(limit int) []string {
@@ -392,11 +451,12 @@ func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) 
 	var list [][]byte
 	var expiresAt int64
 	if ok {
-		if value.Kind != ValueKindList {
+		var err error
+		list, err = value.ListValue()
+		if err != nil {
 			s.mu.Unlock()
-			return 0, ErrWrongType
+			return 0, err
 		}
-		list = value.List
 		expiresAt = value.ExpiresAt
 	}
 

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -36,6 +36,34 @@ func TestStoreValueBehavior(t *testing.T) {
 			},
 		},
 		{
+			name: "Get returns defensive copy",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+				store.Set("greeting", []byte("hello"), 0)
+
+				got, ok, err := store.Get("greeting")
+				if err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
+				if !ok {
+					t.Fatal("Get() ok = false, want true")
+				}
+
+				got[0] = 'H'
+
+				again, ok, err := store.Get("greeting")
+				if err != nil {
+					t.Fatalf("second Get() error = %v", err)
+				}
+				if !ok {
+					t.Fatal("second Get() ok = false, want true")
+				}
+				if string(again) != "hello" {
+					t.Fatalf("second Get() value = %q, want %q", string(again), "hello")
+				}
+			},
+		},
+		{
 			name: "Get passively evicts expired key",
 			run: func(t *testing.T, store *Store) {
 				t.Helper()
@@ -225,6 +253,32 @@ func TestStoreListBehavior(t *testing.T) {
 			if string(got) != want[i] {
 				t.Fatalf("ListRange()[%d] = %q, want %q", i, string(got), want[i])
 			}
+		}
+	})
+
+	t.Run("ListRange returns defensive copies", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.RightPush("letters", [][]byte{[]byte("a"), []byte("b")}); err != nil {
+			t.Fatalf("RightPush() error = %v", err)
+		}
+
+		values, err := store.ListRange("letters", 0, -1)
+		if err != nil {
+			t.Fatalf("ListRange() error = %v", err)
+		}
+
+		values[0][0] = 'A'
+		values[1] = []byte("changed")
+
+		again, err := store.ListRange("letters", 0, -1)
+		if err != nil {
+			t.Fatalf("second ListRange() error = %v", err)
+		}
+		if got := string(again[0]); got != "a" {
+			t.Fatalf("second ListRange()[0] = %q, want %q", got, "a")
+		}
+		if got := string(again[1]); got != "b" {
+			t.Fatalf("second ListRange()[1] = %q, want %q", got, "b")
 		}
 	})
 
@@ -652,6 +706,32 @@ func TestStoreStreamBehavior(t *testing.T) {
 		}
 		if got := string(entries[0].Values[1]); got != "value" {
 			t.Fatalf("entries[0].Values[1] = %q, want %q", got, "value")
+		}
+	})
+
+	t.Run("XRead returns defensive copies", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("value")}); err != nil {
+			t.Fatalf("XAdd() error = %v", err)
+		}
+
+		entries, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("XRead() error = %v", err)
+		}
+
+		entries[0].Values[0][0] = 'F'
+		entries[0].Values[1] = []byte("changed")
+
+		again, err := store.XRead("events", "0-0")
+		if err != nil {
+			t.Fatalf("second XRead() error = %v", err)
+		}
+		if got := string(again[0].Values[0]); got != "field" {
+			t.Fatalf("second XRead()[0].Values[0] = %q, want %q", got, "field")
+		}
+		if got := string(again[0].Values[1]); got != "value" {
+			t.Fatalf("second XRead()[0].Values[1] = %q, want %q", got, "value")
 		}
 	})
 

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -91,7 +91,7 @@ func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
 
 	entries := make([]StreamEntry, 0, len(s.entries)-start)
 	for _, entry := range s.entries[start:] {
-		entries = append(entries, StreamEntry{ID: entry.id.String(), Values: cloneList(entry.values)})
+		entries = append(entries, StreamEntry{ID: entry.id.String(), Values: entry.values})
 	}
 
 	return entries, nil

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -93,7 +93,7 @@ func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
 
 	entries := make([]StreamEntry, 0, len(s.entries)-start)
 	for _, entry := range s.entries[start:] {
-		entries = append(entries, StreamEntry{ID: entry.idText, Values: entry.values})
+		entries = append(entries, StreamEntry{ID: entry.idText, Values: cloneList(entry.values)})
 	}
 
 	return entries, nil

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -13,6 +13,7 @@ type streamID struct {
 
 type streamRecord struct {
 	id     streamID
+	idText string
 	values [][]byte
 }
 
@@ -68,11 +69,12 @@ func (s *streamValue) add(rawID string, values [][]byte, nowMillis int64) (strin
 		}
 	}
 
-	s.entries = append(s.entries, streamRecord{id: id, values: cloneList(values)})
+	idText := id.String()
+	s.entries = append(s.entries, streamRecord{id: id, idText: idText, values: cloneList(values)})
 	s.lastID = id
 	s.hasEntries = true
 
-	return id.String(), nil
+	return idText, nil
 }
 
 func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
@@ -91,7 +93,7 @@ func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
 
 	entries := make([]StreamEntry, 0, len(s.entries)-start)
 	for _, entry := range s.entries[start:] {
-		entries = append(entries, StreamEntry{ID: entry.id.String(), Values: entry.values})
+		entries = append(entries, StreamEntry{ID: entry.idText, Values: entry.values})
 	}
 
 	return entries, nil

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -20,6 +20,12 @@ type ZSetEntry struct {
 	Score  float64
 }
 
+// ZSetRangeEntry represents a member/score pair returned from ZRANGE.
+type ZSetRangeEntry struct {
+	Member string
+	Score  float64
+}
+
 // StreamEntry represents a stream entry returned by XREAD.
 type StreamEntry struct {
 	ID     string

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -1,5 +1,9 @@
 package storage
 
+import "errors"
+
+var errInvalidStoredValue = errors.New("storage: invalid stored value state")
+
 // ValueKind identifies the logical data shape of a stored value.
 type ValueKind string
 
@@ -43,6 +47,48 @@ type StoredValue struct {
 	Stream    *streamValue
 	ExpiresAt int64
 	Kind      ValueKind
+}
+
+// StringValue returns the string payload for a string value.
+func (v StoredValue) StringValue() ([]byte, error) {
+	if v.Kind != ValueKindString {
+		return nil, ErrWrongType
+	}
+
+	return v.String, nil
+}
+
+// ListValue returns the list payload for a list value.
+func (v StoredValue) ListValue() ([][]byte, error) {
+	if v.Kind != ValueKindList {
+		return nil, ErrWrongType
+	}
+
+	return v.List, nil
+}
+
+// ZSetValue returns the sorted-set payload for a sorted-set value.
+func (v StoredValue) ZSetValue() (*sortedSet, error) {
+	if v.Kind != ValueKindZSet {
+		return nil, ErrWrongType
+	}
+	if v.ZSet == nil {
+		return nil, errInvalidStoredValue
+	}
+
+	return v.ZSet, nil
+}
+
+// StreamValue returns the stream payload for a stream value.
+func (v StoredValue) StreamValue() (*streamValue, error) {
+	if v.Kind != ValueKindStream {
+		return nil, ErrWrongType
+	}
+	if v.Stream == nil {
+		return nil, errInvalidStoredValue
+	}
+
+	return v.Stream, nil
 }
 
 func newStringValue(data []byte, expiresAt int64) StoredValue {

--- a/internal/storage/types_test.go
+++ b/internal/storage/types_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStoredValueAccessorsRejectWrongKinds(t *testing.T) {
+	value := newStringValue([]byte("hello"), 0)
+
+	if _, err := value.ListValue(); !errors.Is(err, ErrWrongType) {
+		t.Fatalf("ListValue() error = %v, want ErrWrongType", err)
+	}
+	if _, err := value.ZSetValue(); !errors.Is(err, ErrWrongType) {
+		t.Fatalf("ZSetValue() error = %v, want ErrWrongType", err)
+	}
+	if _, err := value.StreamValue(); !errors.Is(err, ErrWrongType) {
+		t.Fatalf("StreamValue() error = %v, want ErrWrongType", err)
+	}
+}
+
+func TestStoredValueAccessorsRejectInvalidTaggedUnionState(t *testing.T) {
+	zsetValue := StoredValue{Kind: ValueKindZSet}
+	if _, err := zsetValue.ZSetValue(); !errors.Is(err, errInvalidStoredValue) {
+		t.Fatalf("ZSetValue() error = %v, want errInvalidStoredValue", err)
+	}
+
+	streamValue := StoredValue{Kind: ValueKindStream}
+	if _, err := streamValue.StreamValue(); !errors.Is(err, errInvalidStoredValue) {
+		t.Fatalf("StreamValue() error = %v, want errInvalidStoredValue", err)
+	}
+}
+
+func TestStoreRejectsInvalidTaggedUnionState(t *testing.T) {
+	store := NewStore()
+	store.data["leaders"] = StoredValue{Kind: ValueKindZSet}
+	store.data["events"] = StoredValue{Kind: ValueKindStream}
+
+	if _, err := store.ZRange("leaders", 0, -1); !errors.Is(err, errInvalidStoredValue) {
+		t.Fatalf("ZRange() error = %v, want errInvalidStoredValue", err)
+	}
+	if _, err := store.XRead("events", "0-0"); !errors.Is(err, errInvalidStoredValue) {
+		t.Fatalf("XRead() error = %v, want errInvalidStoredValue", err)
+	}
+}

--- a/internal/storage/zset.go
+++ b/internal/storage/zset.go
@@ -14,11 +14,6 @@ type sortedSet struct {
 	order *zsetSkipList
 }
 
-type zsetItem struct {
-	member string
-	score  float64
-}
-
 type zsetSkipList struct {
 	header *zsetNode
 	tail   *zsetNode
@@ -68,7 +63,7 @@ func (s *sortedSet) add(member string, score float64) bool {
 	return !exists
 }
 
-func (s *sortedSet) rangeByRank(start, stop int) []zsetItem {
+func (s *sortedSet) rangeByRank(start, stop int) []ZSetRangeEntry {
 	if start < 0 || stop < start || start >= s.order.length {
 		return nil
 	}
@@ -78,9 +73,9 @@ func (s *sortedSet) rangeByRank(start, stop int) []zsetItem {
 		return nil
 	}
 
-	items := make([]zsetItem, 0, stop-start+1)
+	items := make([]ZSetRangeEntry, 0, stop-start+1)
 	for remaining := stop - start + 1; remaining > 0 && node != nil; remaining-- {
-		items = append(items, zsetItem{member: node.member, score: node.score})
+		items = append(items, ZSetRangeEntry{Member: node.member, Score: node.score})
 		node = node.levels[0].forward
 	}
 

--- a/test/rdb_integration_test.go
+++ b/test/rdb_integration_test.go
@@ -1,0 +1,163 @@
+package test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/command"
+	"github.com/maltemindedal/runedb/internal/config"
+	runedblogger "github.com/maltemindedal/runedb/internal/logger"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
+	"github.com/maltemindedal/runedb/internal/server"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestServerLoadsRDBBeforeServingCommands(t *testing.T) {
+	rdbPath := writeTempRDBFile(t, buildTestRDB(
+		selectTestDB(0),
+		testStringEntry([]byte("name"), []byte("RuneDB")),
+		testExpiringMillisEntry(uint64(time.Now().Add(-time.Second).UnixMilli()), []byte("stale"), []byte("gone")),
+	))
+
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.RDBPath = rdbPath
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	t.Cleanup(func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Logf("failed to close test connection: %v", closeErr)
+		}
+	})
+
+	parser := protocol.NewParser(conn)
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Data: []byte("RuneDB")}, "GET", "name")
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Null: true}, "GET", "stale")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerFailsFastOnCorruptRDB(t *testing.T) {
+	dir := t.TempDir()
+	rdbPath := filepath.Join(dir, "bad.rdb")
+	if err := os.WriteFile(rdbPath, []byte("not-a-valid-rdb"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", rdbPath, err)
+	}
+
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.RDBPath = rdbPath
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	err := srv.ListenAndServe(context.Background())
+	if err == nil {
+		t.Fatal("ListenAndServe() error = nil, want startup failure")
+	}
+	if !errors.Is(err, rdb.ErrInvalidHeader) {
+		t.Fatalf("ListenAndServe() error = %v, want wrapped ErrInvalidHeader", err)
+	}
+	if srv.Addr() != "" {
+		t.Fatalf("Addr() = %q, want empty string on startup failure", srv.Addr())
+	}
+}
+
+func writeTempRDBFile(t *testing.T, payload []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dump.rdb")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func buildTestRDB(parts ...[]byte) []byte {
+	payload := append([]byte{}, []byte("REDIS0011")...)
+	for _, part := range parts {
+		payload = append(payload, part...)
+	}
+	payload = append(payload, 0xFF)
+	payload = append(payload, make([]byte, 8)...)
+	return payload
+}
+
+func selectTestDB(index uint64) []byte {
+	return append([]byte{0xFE}, encodeTestLength(index)...)
+}
+
+func testStringEntry(key, value []byte) []byte {
+	payload := []byte{0x00}
+	payload = append(payload, encodeTestString(key)...)
+	payload = append(payload, encodeTestString(value)...)
+	return payload
+}
+
+func testExpiringMillisEntry(expiresAt uint64, key, value []byte) []byte {
+	payload := []byte{0xFC}
+	raw := make([]byte, 8)
+	binary.LittleEndian.PutUint64(raw, expiresAt)
+	payload = append(payload, raw...)
+	payload = append(payload, testStringEntry(key, value)...)
+	return payload
+}
+
+func encodeTestString(value []byte) []byte {
+	payload := encodeTestLength(uint64(len(value)))
+	payload = append(payload, value...)
+	return payload
+}
+
+func encodeTestLength(length uint64) []byte {
+	if length < 1<<6 {
+		return []byte{byte(length)}
+	}
+	if length < 1<<14 {
+		return []byte{byte((length>>8)&0x3F) | 0x40, byte(length)}
+	}
+
+	raw := make([]byte, 5)
+	raw[0] = 0x80
+	binary.BigEndian.PutUint32(raw[1:], uint32(length))
+	return raw
+}

--- a/test/replication_integration_test.go
+++ b/test/replication_integration_test.go
@@ -1,0 +1,785 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/command"
+	"github.com/maltemindedal/runedb/internal/config"
+	runedblogger "github.com/maltemindedal/runedb/internal/logger"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
+	"github.com/maltemindedal/runedb/internal/server"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestServerHandlesMasterReplicaHandshake(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	parser := protocol.NewParser(conn)
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "PONG"}, "PING")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "REPLCONF", "listening-port", "6380")
+
+	if err := protocol.WriteValue(conn, request("PSYNC", "?", "-1")); err != nil {
+		t.Fatalf("WriteValue(PSYNC) error = %v", err)
+	}
+
+	fullResyncRaw, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() FULLRESYNC error = %v", err)
+	}
+	fullResync, ok := fullResyncRaw.(protocol.SimpleString)
+	if !ok {
+		t.Fatalf("FULLRESYNC type = %T, want protocol.SimpleString", fullResyncRaw)
+	}
+	parts := strings.Fields(fullResync.Value)
+	if len(parts) != 3 || parts[0] != "FULLRESYNC" || parts[1] == "" || parts[2] != "0" {
+		t.Fatalf("FULLRESYNC payload = %q, want 'FULLRESYNC <replid> 0'", fullResync.Value)
+	}
+
+	snapshotRaw, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() snapshot error = %v", err)
+	}
+	snapshot, ok := snapshotRaw.(protocol.BulkString)
+	if !ok {
+		t.Fatalf("snapshot type = %T, want protocol.BulkString", snapshotRaw)
+	}
+	if snapshot.Null {
+		t.Fatal("snapshot bulk string unexpectedly null")
+	}
+	if string(snapshot.Data) != string(rdb.EmptySnapshot()) {
+		t.Fatalf("snapshot payload = %q, want %q", string(snapshot.Data), string(rdb.EmptySnapshot()))
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.ReplicaCount() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.ReplicaCount() != 1 {
+		t.Fatalf("ReplicaCount() = %d, want 1", srv.ReplicaCount())
+	}
+
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "PONG"}, "PING")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerReplicaModeInitiatesHandshake(t *testing.T) {
+	masterListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() fake master error = %v", err)
+	}
+	defer func() { _ = masterListener.Close() }()
+
+	listeningPortCh := make(chan string, 1)
+	handshakeDone := make(chan struct{})
+	masterStop := make(chan struct{})
+	masterErrCh := make(chan error, 1)
+
+	go func() {
+		conn, err := masterListener.Accept()
+		if err != nil {
+			masterErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		parser := protocol.NewParser(conn)
+		writer := conn
+
+		if err := assertReplicaRequest(parser, "PING"); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "PONG"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		replconf, err := decodeReplicaRequest(parser)
+		if err != nil {
+			masterErrCh <- err
+			return
+		}
+		if replconf.Name != "REPLCONF" {
+			masterErrCh <- fmt.Errorf("second request = %q, want REPLCONF", replconf.Name)
+			return
+		}
+		if len(replconf.Args) != 2 || !strings.EqualFold(string(replconf.Args[0]), "listening-port") {
+			masterErrCh <- fmt.Errorf("REPLCONF args = %q, want listening-port <port>", replconf.Args)
+			return
+		}
+		listeningPortCh <- string(replconf.Args[1])
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "OK"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		if err := assertReplicaRequest(parser, "PSYNC", "?", "-1"); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "FULLRESYNC test-replid 0"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.BulkString{Data: rdb.EmptySnapshot()}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		close(handshakeDone)
+		<-masterStop
+		masterErrCh <- nil
+	}()
+
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.ReplicaOf = masterListener.Addr().String()
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		serverErrCh <- srv.ListenAndServe(ctx)
+	}()
+
+	replicaAddr := waitForAddr(t, srv)
+	_, replicaPortText, err := net.SplitHostPort(replicaAddr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q) error = %v", replicaAddr, err)
+	}
+
+	select {
+	case announcedPort := <-listeningPortCh:
+		if announcedPort != replicaPortText {
+			t.Fatalf("REPLCONF listening-port = %q, want %q", announcedPort, replicaPortText)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not send REPLCONF in time")
+	}
+
+	select {
+	case <-handshakeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not complete handshake in time")
+	}
+
+	clientConn, err := net.Dial("tcp", replicaAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) client error = %v", replicaAddr, err)
+	}
+	defer func() { _ = clientConn.Close() }()
+	clientParser := protocol.NewParser(clientConn)
+	assertCommandResponse(t, clientConn, clientParser, protocol.SimpleString{Value: "PONG"}, "PING")
+
+	close(masterStop)
+
+	select {
+	case err := <-masterErrCh:
+		if err != nil {
+			t.Fatalf("fake master error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake master did not stop within timeout")
+	}
+
+	cancel()
+	select {
+	case err := <-serverErrCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica server did not stop within timeout")
+	}
+}
+
+func TestServerReplicaFullResyncReplacesExistingData(t *testing.T) {
+	masterListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() fake master error = %v", err)
+	}
+	defer func() { _ = masterListener.Close() }()
+
+	handshakeDone := make(chan struct{})
+	masterStop := make(chan struct{})
+	masterErrCh := make(chan error, 1)
+	snapshot := buildTestRDB(
+		selectTestDB(0),
+		testStringEntry([]byte("fresh"), []byte("from-master")),
+	)
+
+	go func() {
+		conn, err := masterListener.Accept()
+		if err != nil {
+			masterErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		parser := protocol.NewParser(conn)
+		writer := conn
+
+		if err := assertReplicaRequest(parser, "PING"); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "PONG"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		replconf, err := decodeReplicaRequest(parser)
+		if err != nil {
+			masterErrCh <- err
+			return
+		}
+		if replconf.Name != "REPLCONF" || len(replconf.Args) != 2 || !strings.EqualFold(string(replconf.Args[0]), "listening-port") {
+			masterErrCh <- fmt.Errorf("REPLCONF args = %q, want listening-port <port>", replconf.Args)
+			return
+		}
+		if string(replconf.Args[1]) == "0" {
+			masterErrCh <- fmt.Errorf("REPLCONF listening-port = %q, want an ephemeral non-zero port", replconf.Args[1])
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "OK"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		if err := assertReplicaRequest(parser, "PSYNC", "?", "-1"); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.SimpleString{Value: "FULLRESYNC test-replid 0"}); err != nil {
+			masterErrCh <- err
+			return
+		}
+		if err := protocol.WriteValue(writer, protocol.BulkString{Data: snapshot}); err != nil {
+			masterErrCh <- err
+			return
+		}
+
+		close(handshakeDone)
+		<-masterStop
+		masterErrCh <- nil
+	}()
+
+	rdbPath := writeTempRDBFile(t, buildTestRDB(
+		selectTestDB(0),
+		testStringEntry([]byte("stale"), []byte("local")),
+	))
+
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.RDBPath = rdbPath
+	cfg.ReplicaOf = masterListener.Addr().String()
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		serverErrCh <- srv.ListenAndServe(ctx)
+	}()
+
+	replicaAddr := waitForAddr(t, srv)
+
+	select {
+	case <-handshakeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not complete FULLRESYNC in time")
+	}
+
+	clientConn, err := net.Dial("tcp", replicaAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) client error = %v", replicaAddr, err)
+	}
+	defer func() { _ = clientConn.Close() }()
+	clientParser := protocol.NewParser(clientConn)
+
+	assertCommandResponse(t, clientConn, clientParser, protocol.BulkString{Null: true}, "GET", "stale")
+	assertCommandResponse(t, clientConn, clientParser, protocol.BulkString{Data: []byte("from-master")}, "GET", "fresh")
+
+	close(masterStop)
+
+	select {
+	case err := <-masterErrCh:
+		if err != nil {
+			t.Fatalf("fake master error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake master did not stop within timeout")
+	}
+
+	cancel()
+	select {
+	case err := <-serverErrCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica server did not stop within timeout")
+	}
+}
+
+func assertReplicaRequest(parser *protocol.Parser, wantName string, wantArgs ...string) error {
+	request, err := decodeReplicaRequest(parser)
+	if err != nil {
+		return err
+	}
+	if request.Name != wantName {
+		return fmt.Errorf("request name = %q, want %q", request.Name, wantName)
+	}
+	if len(request.Args) != len(wantArgs) {
+		return fmt.Errorf("request args len = %d, want %d", len(request.Args), len(wantArgs))
+	}
+	for i := range wantArgs {
+		if string(request.Args[i]) != wantArgs[i] {
+			return fmt.Errorf("request arg[%d] = %q, want %q", i, string(request.Args[i]), wantArgs[i])
+		}
+	}
+	return nil
+}
+
+func decodeReplicaRequest(parser *protocol.Parser) (*command.Request, error) {
+	value, err := parser.Parse()
+	if err != nil {
+		return nil, err
+	}
+	return command.DecodeRequest(value)
+}
+
+func TestMasterPropagatesMutationsToReplica(t *testing.T) {
+	masterCfg := config.Default()
+	masterCfg.Host = "127.0.0.1"
+	masterCfg.Port = 0
+	masterCfg.LogLevel = "error"
+	masterCfg.EvictionInterval = 5 * time.Millisecond
+	masterCfg.EvictionSampleSize = 10
+
+	logger := runedblogger.New(masterCfg.LogLevel)
+
+	masterStore := storage.NewStore()
+	masterExecutor := command.NewExecutor(masterStore, logger)
+	master := server.New(masterCfg, logger, masterStore, masterExecutor)
+
+	masterCtx, cancelMaster := context.WithCancel(context.Background())
+	defer cancelMaster()
+
+	masterErrCh := make(chan error, 1)
+	go func() {
+		masterErrCh <- master.ListenAndServe(masterCtx)
+	}()
+
+	masterAddr := waitForAddr(t, master)
+
+	replicaCfg := config.Default()
+	replicaCfg.Host = "127.0.0.1"
+	replicaCfg.Port = 0
+	replicaCfg.LogLevel = "error"
+	replicaCfg.EvictionInterval = 5 * time.Millisecond
+	replicaCfg.EvictionSampleSize = 10
+	replicaCfg.ReplicaOf = masterAddr
+
+	replicaStore := storage.NewStore()
+	replicaExecutor := command.NewExecutor(replicaStore, logger)
+	replica := server.New(replicaCfg, logger, replicaStore, replicaExecutor)
+
+	replicaCtx, cancelReplica := context.WithCancel(context.Background())
+	defer cancelReplica()
+
+	replicaErrCh := make(chan error, 1)
+	go func() {
+		replicaErrCh <- replica.ListenAndServe(replicaCtx)
+	}()
+
+	replicaAddr := waitForAddr(t, replica)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if master.ReplicaCount() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if master.ReplicaCount() != 1 {
+		t.Fatalf("ReplicaCount() = %d, want 1", master.ReplicaCount())
+	}
+
+	masterConn, err := net.Dial("tcp", masterAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) master error = %v", masterAddr, err)
+	}
+	defer func() { _ = masterConn.Close() }()
+	masterParser := protocol.NewParser(masterConn)
+
+	replicaConn, err := net.Dial("tcp", replicaAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) replica error = %v", replicaAddr, err)
+	}
+	defer func() { _ = replicaConn.Close() }()
+	replicaParser := protocol.NewParser(replicaConn)
+
+	assertCommandResponse(t, masterConn, masterParser, protocol.SimpleString{Value: "OK"}, "SET", "name", "RuneDB")
+	assertEventuallyCommandResponse(t, replicaConn, replicaParser, protocol.BulkString{Data: []byte("RuneDB")}, 2*time.Second, "GET", "name")
+
+	assertCommandResponse(t, masterConn, masterParser, protocol.Integer{Value: 1}, "DEL", "name")
+	assertEventuallyCommandResponse(t, replicaConn, replicaParser, protocol.BulkString{Null: true}, 2*time.Second, "GET", "name")
+
+	assertCommandResponse(t, masterConn, masterParser, protocol.SimpleString{Value: "OK"}, "MULTI")
+	assertCommandResponse(t, masterConn, masterParser, protocol.SimpleString{Value: "QUEUED"}, "SET", "tx-key", "1")
+	assertCommandResponse(t, masterConn, masterParser, protocol.SimpleString{Value: "QUEUED"}, "DEL", "missing")
+	assertCommandResponse(t, masterConn, masterParser, protocol.Array{Elements: []protocol.Value{
+		protocol.SimpleString{Value: "OK"},
+		protocol.Integer{Value: 0},
+	}}, "EXEC")
+	assertEventuallyCommandResponse(t, replicaConn, replicaParser, protocol.BulkString{Data: []byte("1")}, 2*time.Second, "GET", "tx-key")
+
+	cancelReplica()
+	select {
+	case err := <-replicaErrCh:
+		if err != nil {
+			t.Fatalf("replica ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not stop within timeout")
+	}
+
+	cancelMaster()
+	select {
+	case err := <-masterErrCh:
+		if err != nil {
+			t.Fatalf("master ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("master did not stop within timeout")
+	}
+}
+
+func TestWaitReturnsReplicaAcknowledgements(t *testing.T) {
+	masterCfg := config.Default()
+	masterCfg.Host = "127.0.0.1"
+	masterCfg.Port = 0
+	masterCfg.LogLevel = "error"
+	masterCfg.EvictionInterval = 5 * time.Millisecond
+	masterCfg.EvictionSampleSize = 10
+
+	logger := runedblogger.New(masterCfg.LogLevel)
+
+	masterStore := storage.NewStore()
+	masterExecutor := command.NewExecutor(masterStore, logger)
+	master := server.New(masterCfg, logger, masterStore, masterExecutor)
+
+	masterCtx, cancelMaster := context.WithCancel(context.Background())
+	defer cancelMaster()
+
+	masterErrCh := make(chan error, 1)
+	go func() {
+		masterErrCh <- master.ListenAndServe(masterCtx)
+	}()
+
+	masterAddr := waitForAddr(t, master)
+
+	replicaCfg := config.Default()
+	replicaCfg.Host = "127.0.0.1"
+	replicaCfg.Port = 0
+	replicaCfg.LogLevel = "error"
+	replicaCfg.EvictionInterval = 5 * time.Millisecond
+	replicaCfg.EvictionSampleSize = 10
+	replicaCfg.ReplicaOf = masterAddr
+
+	replicaStore := storage.NewStore()
+	replicaExecutor := command.NewExecutor(replicaStore, logger)
+	replica := server.New(replicaCfg, logger, replicaStore, replicaExecutor)
+
+	replicaCtx, cancelReplica := context.WithCancel(context.Background())
+	defer cancelReplica()
+
+	replicaErrCh := make(chan error, 1)
+	go func() {
+		replicaErrCh <- replica.ListenAndServe(replicaCtx)
+	}()
+
+	_ = waitForAddr(t, replica)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if master.ReplicaCount() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if master.ReplicaCount() != 1 {
+		t.Fatalf("ReplicaCount() = %d, want 1", master.ReplicaCount())
+	}
+
+	masterConn, err := net.Dial("tcp", masterAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) master error = %v", masterAddr, err)
+	}
+	defer func() { _ = masterConn.Close() }()
+	masterParser := protocol.NewParser(masterConn)
+
+	assertCommandResponse(t, masterConn, masterParser, protocol.Integer{Value: 1}, "WAIT", "1", "1000")
+	assertCommandResponse(t, masterConn, masterParser, protocol.SimpleString{Value: "OK"}, "SET", "wait-key", "ready")
+	assertCommandResponse(t, masterConn, masterParser, protocol.Integer{Value: 1}, "WAIT", "1", "1000")
+
+	cancelReplica()
+	select {
+	case err := <-replicaErrCh:
+		if err != nil {
+			t.Fatalf("replica ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not stop within timeout")
+	}
+
+	cancelMaster()
+	select {
+	case err := <-masterErrCh:
+		if err != nil {
+			t.Fatalf("master ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("master did not stop within timeout")
+	}
+}
+
+func TestWaitTimesOutWithoutReplicas(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "solo", "1")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 0}, "WAIT", "1", "50")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestWaitUsesPerClientReplicationOffset(t *testing.T) {
+	masterCfg := config.Default()
+	masterCfg.Host = "127.0.0.1"
+	masterCfg.Port = 0
+	masterCfg.LogLevel = "error"
+	masterCfg.EvictionInterval = 5 * time.Millisecond
+	masterCfg.EvictionSampleSize = 10
+
+	logger := runedblogger.New(masterCfg.LogLevel)
+
+	masterStore := storage.NewStore()
+	masterExecutor := command.NewExecutor(masterStore, logger)
+	master := server.New(masterCfg, logger, masterStore, masterExecutor)
+
+	masterCtx, cancelMaster := context.WithCancel(context.Background())
+	defer cancelMaster()
+
+	masterErrCh := make(chan error, 1)
+	go func() {
+		masterErrCh <- master.ListenAndServe(masterCtx)
+	}()
+
+	masterAddr := waitForAddr(t, master)
+
+	replicaCfg := config.Default()
+	replicaCfg.Host = "127.0.0.1"
+	replicaCfg.Port = 0
+	replicaCfg.LogLevel = "error"
+	replicaCfg.EvictionInterval = 5 * time.Millisecond
+	replicaCfg.EvictionSampleSize = 10
+	replicaCfg.ReplicaOf = masterAddr
+
+	replicaStore := storage.NewStore()
+	replicaExecutor := command.NewExecutor(replicaStore, logger)
+	replica := server.New(replicaCfg, logger, replicaStore, replicaExecutor)
+
+	replicaCtx, cancelReplica := context.WithCancel(context.Background())
+	defer cancelReplica()
+
+	replicaErrCh := make(chan error, 1)
+	go func() {
+		replicaErrCh <- replica.ListenAndServe(replicaCtx)
+	}()
+
+	_ = waitForAddr(t, replica)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if master.ReplicaCount() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if master.ReplicaCount() != 1 {
+		t.Fatalf("ReplicaCount() = %d, want 1", master.ReplicaCount())
+	}
+
+	writerConn, err := net.Dial("tcp", masterAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) writer error = %v", masterAddr, err)
+	}
+	defer func() { _ = writerConn.Close() }()
+	writerParser := protocol.NewParser(writerConn)
+
+	waiterConn, err := net.Dial("tcp", masterAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) waiter error = %v", masterAddr, err)
+	}
+	defer func() { _ = waiterConn.Close() }()
+	waiterParser := protocol.NewParser(waiterConn)
+
+	assertCommandResponse(t, writerConn, writerParser, protocol.SimpleString{Value: "OK"}, "SET", "shared", "value")
+	assertCommandResponse(t, waiterConn, waiterParser, protocol.Integer{Value: 1}, "WAIT", "1", "1000")
+
+	cancelReplica()
+	select {
+	case err := <-replicaErrCh:
+		if err != nil {
+			t.Fatalf("replica ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica did not stop within timeout")
+	}
+
+	cancelMaster()
+	select {
+	case err := <-masterErrCh:
+		if err != nil {
+			t.Fatalf("master ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("master did not stop within timeout")
+	}
+}
+
+func assertEventuallyCommandResponse(t *testing.T, conn net.Conn, parser *protocol.Parser, want protocol.Value, timeout time.Duration, parts ...string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last protocol.Value
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		if err := protocol.WriteValue(conn, request(parts...)); err != nil {
+			t.Fatalf("WriteValue(%v) error = %v", parts, err)
+		}
+
+		got, err := parser.Parse()
+		if err == nil && valuesEquivalent(got, want) {
+			return
+		}
+
+		last = got
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if lastErr != nil {
+		t.Fatalf("eventual Parse(%v) last error = %v", parts, lastErr)
+	}
+	t.Fatalf("eventual response for %v = %#v, want %#v", parts, last, want)
+}
+
+func valuesEquivalent(got protocol.Value, want protocol.Value) bool {
+	gotEncoded, gotErr := protocol.Encode(got)
+	wantEncoded, wantErr := protocol.Encode(want)
+	if gotErr != nil || wantErr != nil {
+		return false
+	}
+
+	return bytes.Equal(gotEncoded, wantEncoded)
+}


### PR DESCRIPTION
This pull request introduces support for several advanced Redis replication commands and improves protocol responses for certain data types. The most significant changes are the implementation of `REPLCONF`, `PSYNC`, and `WAIT` commands for replication protocol compatibility, as well as improvements to how responses are formatted for streams, sorted sets, and lists. Additionally, the documentation is updated to reflect the current implementation status and clarify feature coverage.

**Replication protocol support:**

* Added full implementations for the `REPLCONF`, `PSYNC`, and `WAIT` commands in the `Executor`, enabling proper handling of replica handshakes, acknowledgements, and synchronization as part of the Redis replication protocol. (`internal/command/commands.go`)
* Updated the command handler for `EXEC` to return a `server.ExecuteResult` with propagation and upstream reply support, improving transactional command propagation and error handling. (`internal/command/commands.go`)

**Protocol response improvements:**

* Changed stream, sorted set, and list command responses to use `TextBulkString` and direct byte slices where appropriate, ensuring correct protocol formatting and eliminating unnecessary data copying. (`internal/command/commands.go`) [[1]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4L397-R530) [[2]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4L429-R577) [[3]](diffhunk://#diff-30ee0f2d298d90c54284b42790cb6dd0eef8a8e7f1fffa667b539ce8057ab7c4L459-R599)

**Documentation updates:**

* Updated the product requirements document (`docs/PRD.md`) to provide a detailed checklist of completed and pending features, clarify the current scope of RDB loading (startup-time, DB 0, string keys only), and indicate which replication and security features are implemented, partially done, or not started. [[1]](diffhunk://#diff-487b79d1751c30f1530aa326b1d31d6062b4244d4e08bc4bbabb2777ca6e5e6bR8-R17) [[2]](diffhunk://#diff-487b79d1751c30f1530aa326b1d31d6062b4244d4e08bc4bbabb2777ca6e5e6bL30-R202)
* Updated the `README.md` to document the availability of startup-time RDB loading and clarify the status of replication and persistence features.

**Dependency and import updates:**

* Added necessary imports for time and RDB handling to support the new replication and persistence features. (`internal/command/commands.go`)