### PR TITLE
Implement AOF persistence and related features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A high-performance, concurrent Redis-compatible key-value store built from scrat
 - raw TCP listener with one goroutine per client
 - RESP parser and writer
 - thread-safe in-memory store with TTL **support**
+- append-only-file durability with startup replay, configurable `appendfsync`, and `BGREWRITEAOF`
 - active connection registry for cleaner shutdowns
 - Commands: `PING`, `ECHO`, `SET`, `GET`, `DEL`, `INCR`
 - password-gated connections via `--requirepass` and `AUTH <password>`
@@ -47,6 +48,14 @@ A high-performance, concurrent Redis-compatible key-value store built from scrat
 - active TTL eviction in a background loop
 - atomic `INCR` at the storage layer
 
+### Persistence
+
+- startup RDB loading via `--rdb`
+- graceful shutdown RDB snapshots via `--dump`
+- append-only file replay via `--aof`
+- configurable `--appendfsync=always|everysec|no`
+- background AOF compaction via `BGREWRITEAOF`
+
 ### Commands
 
 - `PING`
@@ -56,6 +65,7 @@ A high-performance, concurrent Redis-compatible key-value store built from scrat
 - `GET <key>`
 - `DEL <key> [key ...]`
 - `INCR <key>`
+- `BGREWRITEAOF`
 
 ### Quality and verification
 
@@ -84,6 +94,7 @@ From `d:\10_personal\runedb`:
 ### Start the server
 
 - `go run ./cmd/runedb --port 6379`
+- `go run ./cmd/runedb --port 6379 --aof appendonly.aof --appendfsync everysec`
 
 ### Validate the project
 
@@ -133,9 +144,11 @@ Then try:
 - The store currently uses a single `sync.RWMutex` for correctness and simplicity.
 - TTLs are normalized to Unix milliseconds internally.
 - Startup-time RDB loading is available via `--rdb`, currently for DB `0` string keys only.
+- Append-only durability is available via `--aof`; when the file exists and is non-empty it takes precedence over `--rdb` during startup.
+- `BGREWRITEAOF` compacts the current append-only file in the background by snapshotting live state and atomically swapping in a rewritten command stream.
 - The server is still intentionally RESP2-centric at the command-behavior level, even though RESP3 boolean/null support exists in the protocol layer.
 - `--requirepass` and one-argument `AUTH <password>` are implemented. Unauthenticated clients may still use `PING`, but protected masters now require authenticated replica handshakes before `REPLCONF` / `PSYNC`; replica mode can supply that password with `--masterauth`.
-- Core replication protocol support exists (`REPLCONF`, `PSYNC`, and `WAIT`), but broader replication completeness, broader persistence coverage, richer data structures, pub/sub, and full security features remain future milestones.
+- Core replication protocol support exists (`REPLCONF`, `PSYNC`, and `WAIT`), and append-only persistence now covers the supported mutating command surface; broader replication completeness and further persistence hardening remain future milestones.
 
 ## Related docs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # RuneDB Architecture
 
-This repository is structured as a Phase 1-first implementation of a Redis-compatible TCP server in Go. The current scaffold is intentionally narrow: it provides the networking, protocol, storage, and command boundaries needed for `PING`, `ECHO`, `SET`, and `GET`, while leaving space for RESP3, transactions, replication, and richer data types in later phases.
+This repository is structured as a phase-by-phase implementation of a Redis-compatible TCP server in Go. The codebase now covers the raw TCP server, RESP parsing/encoding, sharded in-memory storage, transactions, pub/sub, replication, RDB snapshots, and append-only-file durability while still keeping clear package seams for later phases.
 
 ## Package layout
 
@@ -19,6 +19,17 @@ Holds startup configuration such as host, port, log level, and TTL eviction sett
 ### `internal/logger`
 
 Provides a small `log/slog` initializer so the whole server shares one structured logging setup.
+
+### `internal/aof`
+
+Owns append-only-file durability.
+
+Current responsibilities:
+
+- replay RESP command streams on startup before the listener opens
+- append successful mutating commands in RESP form
+- apply `appendfsync` policies (`always`, `everysec`, `no`)
+- rewrite the current durable state in the background for `BGREWRITEAOF`
 
 ### `internal/protocol`
 
@@ -47,12 +58,7 @@ Current responsibilities:
 
 Translates RESP arrays into executable requests and dispatches them to handlers.
 
-Current command set:
-
-- `PING`
-- `ECHO`
-- `SET` with optional `EX` / `PX`
-- `GET`
+Current command surface includes strings, hashes, lists, sets, sorted sets, streams, transactions, pub/sub, replication handshakes, `WAIT`, and `BGREWRITEAOF`.
 
 ### `internal/server`
 
@@ -65,6 +71,8 @@ Current responsibilities:
 - spawn one goroutine per client
 - parse → execute → respond for each request
 - maintain an active connection registry for shutdown
+- load startup persistence (RDB and/or AOF) before accepting TCP connections
+- append durable command frames and fan out replication writes after successful execution
 - stop cleanly when the process receives `SIGINT` or `SIGTERM`
 
 ### `test`
@@ -81,14 +89,11 @@ The scaffold starts with one `sync.RWMutex` around the entire keyspace because c
 
 The user requested RESP3-aware structure, but full RESP3 support is out of scope for the current implementation. The protocol package therefore exposes lightweight placeholder types so later expansion does not require redesigning the core abstraction.
 
-### Why only four commands?
+### Why keep persistence separate from replication?
 
-`PING`, `ECHO`, `SET`, and `GET` are enough to validate the entire stack:
+Replication and AOF both reuse RESP-encoded command frames, but they serve different correctness goals:
 
-- TCP listener and handler loop
-- RESP parsing and encoding
-- command routing
-- thread-safe store access
-- TTL behavior
+- replication forwards commands to live replicas
+- AOF records only durable state mutations for crash recovery
 
-That makes them an excellent Phase 1 foundation.
+Keeping those paths separate lets the server replicate transient commands like `PUBLISH` without persisting them, while still logging durable commands such as `XADD` even when they are not part of the replication handshake flow.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -16,7 +16,7 @@ Legend: `[x]` done, `[~]` partially done, `[ ]` not done.
 - **Phase 5:** Done
 - **Phase 6:** Done
 - **Phase 7:** Planned
-- **Phase 8:** Planned
+- **Phase 8:** Done
 - **Phase 9:** Planned
 - **Phase 10:** Planned
 - **Phase 11:** Planned
@@ -257,30 +257,30 @@ Reduce the single-lock bottleneck by making key ownership explicit and shard-loc
 - [x] Handle multi-key commands such as `DEL key1 key2 key3` across different shards.
 - [x] Sort shard IDs before locking to avoid deadlocks, then unlock in reverse order.
 
-### Phase 8: Durability via Append-Only Files — **Planned**
+### Phase 8: Durability via Append-Only Files — **Done**
 
 Add an AOF-based durability path that complements the current snapshot-oriented persistence support.
 
-#### AOF Writer — **Planned**
+#### AOF Writer — **Done**
 
-- [ ] Create a background service that opens and manages a `.aof` file.
-- [ ] Append raw RESP for successful mutating commands such as `SET`, `DEL`, and `INCR`.
+- [x] Create a background service that opens and manages a `.aof` file.
+- [x] Append raw RESP for successful mutating commands such as `SET`, `DEL`, and `INCR`.
 
-#### AOF Recovery — **Planned**
+#### AOF Recovery — **Done**
 
-- [ ] On startup, detect the `.aof` file before accepting TCP connections.
-- [ ] Parse and replay commands to rebuild in-memory state.
+- [x] On startup, detect the `.aof` file before accepting TCP connections.
+- [x] Parse and replay commands to rebuild in-memory state.
 
-#### `appendfsync` Policies — **Planned**
+#### `appendfsync` Policies — **Done**
 
-- [ ] Add an `--appendfsync` flag.
-- [ ] Support at least `always` and `everysec` policies.
-- [ ] For `everysec`, flush to disk from a background goroutine once per second.
+- [x] Add an `--appendfsync` flag.
+- [x] Support at least `always` and `everysec` policies.
+- [x] For `everysec`, flush to disk from a background goroutine once per second.
 
-#### Background Rewrite (`BGREWRITEAOF`) — **Planned**
+#### Background Rewrite (`BGREWRITEAOF`) — **Done**
 
-- [ ] Compact large AOF files by writing a fresh command stream to a temporary file.
-- [ ] Emit the shortest practical rebuild sequence, then atomically rename it into place.
+- [x] Compact large AOF files by writing a fresh command stream to a temporary file.
+- [x] Emit the shortest practical rebuild sequence, then atomically rename it into place.
 
 ### Phase 9: Transaction Execution Hardening — **Planned**
 
@@ -353,4 +353,4 @@ Protect the server from unbounded memory growth under sustained write pressure.
 
 - Redis Cluster Mode (sharding / gossip protocol)
 - Lua scripting execution (`EVAL`)
-- Continuous AOF (Append Only File) writing
+- Multi-part AOF manifests / RDB preambles / automatic rewrite thresholds

--- a/internal/aof/doc.go
+++ b/internal/aof/doc.go
@@ -1,0 +1,2 @@
+// Package aof implements append-only-file durability and rewrite support.
+package aof

--- a/internal/aof/loader.go
+++ b/internal/aof/loader.go
@@ -1,0 +1,72 @@
+package aof
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+)
+
+// LoadFile replays RESP-encoded commands from an append-only file.
+func LoadFile(ctx context.Context, path string, replay func(context.Context, protocol.Value) error) (stats LoadStats, err error) {
+	if replay == nil {
+		return LoadStats{}, errors.New("aof: nil replay function")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return LoadStats{}, fmt.Errorf("aof: read %q: %w", path, err)
+	}
+	defer func() {
+		closeErr := file.Close()
+		if closeErr != nil && err == nil {
+			err = fmt.Errorf("aof: close %q: %w", path, closeErr)
+		}
+	}()
+
+	parser := protocol.NewParser(bufio.NewReader(file))
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return stats, fmt.Errorf("aof: load %q canceled: %w", path, ctxErr)
+		}
+
+		value, parseErr := parser.Parse()
+		if parseErr != nil {
+			if errors.Is(parseErr, io.EOF) {
+				return stats, nil
+			}
+			if isRecoverableTruncation(parseErr) {
+				stats.TruncatedTail = true
+				return stats, nil
+			}
+
+			return stats, fmt.Errorf("aof: parse %q after %d commands: %w", path, stats.ReplayedCommands, parseErr)
+		}
+		if replayErr := replay(ctx, value); replayErr != nil {
+			return stats, fmt.Errorf("aof: replay command %d from %q: %w", stats.ReplayedCommands+1, path, replayErr)
+		}
+		stats.ReplayedCommands++
+	}
+}
+
+func isRecoverableTruncation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// The RESP parser currently normalizes a missing trailing CRLF into a plain
+	// parse error rather than wrapping EOF. Treat that as a recoverable truncated
+	// tail when replaying an append-only file.
+	return strings.Contains(err.Error(), "missing CRLF terminator")
+}

--- a/internal/aof/loader_test.go
+++ b/internal/aof/loader_test.go
@@ -1,0 +1,121 @@
+package aof_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maltemindedal/runedb/internal/aof"
+	"github.com/maltemindedal/runedb/internal/command"
+	"github.com/maltemindedal/runedb/internal/protocol"
+)
+
+func TestLoadFile(t *testing.T) {
+	t.Run("replays valid RESP commands", func(t *testing.T) {
+		path := writeTempAOF(t, mustEncodeValues(t,
+			request("SET", "name", "RuneDB"),
+			request("INCR", "counter"),
+		))
+
+		var replayed []string
+		stats, err := aof.LoadFile(context.Background(), path, func(_ context.Context, value protocol.Value) error {
+			req, decodeErr := command.DecodeRequest(value)
+			if decodeErr != nil {
+				return decodeErr
+			}
+			replayed = append(replayed, req.Name)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("LoadFile() error = %v", err)
+		}
+		if stats.ReplayedCommands != 2 {
+			t.Fatalf("stats.ReplayedCommands = %d, want 2", stats.ReplayedCommands)
+		}
+		if stats.TruncatedTail {
+			t.Fatal("stats.TruncatedTail = true, want false")
+		}
+		if len(replayed) != 2 || replayed[0] != "SET" || replayed[1] != "INCR" {
+			t.Fatalf("replayed = %v, want [SET INCR]", replayed)
+		}
+	})
+
+	t.Run("treats truncated tail as recoverable", func(t *testing.T) {
+		full := mustEncodeValues(t,
+			request("SET", "name", "RuneDB"),
+			request("INCR", "counter"),
+		)
+		path := writeTempAOF(t, full[:len(full)-3])
+
+		stats, err := aof.LoadFile(context.Background(), path, func(_ context.Context, value protocol.Value) error {
+			_, decodeErr := command.DecodeRequest(value)
+			return decodeErr
+		})
+		if err != nil {
+			t.Fatalf("LoadFile() error = %v, want truncated tail recovery", err)
+		}
+		if stats.ReplayedCommands != 1 {
+			t.Fatalf("stats.ReplayedCommands = %d, want 1", stats.ReplayedCommands)
+		}
+		if !stats.TruncatedTail {
+			t.Fatal("stats.TruncatedTail = false, want true")
+		}
+	})
+
+	t.Run("fails on corrupt middle payload", func(t *testing.T) {
+		path := writeTempAOF(t, append(mustEncodeValues(t, request("PING")), []byte("not-resp")...))
+
+		_, err := aof.LoadFile(context.Background(), path, func(_ context.Context, value protocol.Value) error {
+			_, decodeErr := command.DecodeRequest(value)
+			return decodeErr
+		})
+		if err == nil {
+			t.Fatal("LoadFile() error = nil, want parse failure")
+		}
+	})
+
+	t.Run("honors canceled context", func(t *testing.T) {
+		path := writeTempAOF(t, mustEncodeValues(t, request("SET", "name", "RuneDB")))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := aof.LoadFile(ctx, path, func(_ context.Context, value protocol.Value) error {
+			_, decodeErr := command.DecodeRequest(value)
+			return decodeErr
+		})
+		if err == nil {
+			t.Fatal("LoadFile() error = nil, want canceled context failure")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("LoadFile() error = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func writeTempAOF(t *testing.T, payload []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "appendonly.aof")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func mustEncodeValues(t *testing.T, values ...protocol.Value) []byte {
+	t.Helper()
+	payload, err := protocol.EncodeValues(values)
+	if err != nil {
+		t.Fatalf("EncodeValues() error = %v", err)
+	}
+	return payload
+}
+
+func request(parts ...string) protocol.Value {
+	elements := make([]protocol.Value, 0, len(parts))
+	for _, part := range parts {
+		elements = append(elements, protocol.BulkString{Data: []byte(part)})
+	}
+	return protocol.Array{Elements: elements}
+}

--- a/internal/aof/rewrite.go
+++ b/internal/aof/rewrite.go
@@ -1,0 +1,138 @@
+package aof
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+// GenerateRewrite emits the shortest practical RESP command stream for the supplied snapshot.
+func GenerateRewrite(entries []storage.SnapshotEntry, writer io.Writer) (RewriteStats, error) {
+	sorted := make([]storage.SnapshotEntry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Key < sorted[j].Key
+	})
+
+	now := time.Now().UnixMilli()
+	stats := RewriteStats{}
+	for _, entry := range sorted {
+		frames, err := rewriteFramesForEntry(entry, now)
+		if err != nil {
+			return stats, err
+		}
+		if len(frames) == 0 {
+			continue
+		}
+		stats.Keys++
+		stats.Commands += len(frames)
+		for _, frame := range frames {
+			if err := protocol.WriteValue(writer, frame); err != nil {
+				return stats, fmt.Errorf("aof: write rewrite frame for key %q: %w", entry.Key, err)
+			}
+		}
+	}
+
+	return stats, nil
+}
+
+func rewriteFramesForEntry(entry storage.SnapshotEntry, now int64) ([]protocol.Value, error) {
+	switch entry.Kind {
+	case storage.ValueKindString:
+		if entry.ExpiresAt > 0 && entry.ExpiresAt <= now {
+			return nil, nil
+		}
+		args := []protocol.Value{bulkString(entry.Key), bulkBytes(entry.String)}
+		if entry.ExpiresAt > 0 {
+			ttl := entry.ExpiresAt - now
+			if ttl <= 0 {
+				return nil, nil
+			}
+			args = append(args, bulkString("PX"), bulkString(strconv.FormatInt(ttl, 10)))
+		}
+		return []protocol.Value{rewriteCommand("SET", args...)}, nil
+	case storage.ValueKindList:
+		if len(entry.List) == 0 {
+			return nil, nil
+		}
+		args := make([]protocol.Value, 0, len(entry.List)+1)
+		args = append(args, bulkString(entry.Key))
+		for _, item := range entry.List {
+			args = append(args, bulkBytes(item))
+		}
+		return []protocol.Value{rewriteCommand("RPUSH", args...)}, nil
+	case storage.ValueKindHash:
+		if len(entry.Hash) == 0 {
+			return nil, nil
+		}
+		sorted := make([]storage.HashFieldValue, len(entry.Hash))
+		copy(sorted, entry.Hash)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Field < sorted[j].Field
+		})
+		args := make([]protocol.Value, 0, len(sorted)*2+1)
+		args = append(args, bulkString(entry.Key))
+		for _, field := range sorted {
+			args = append(args, bulkString(field.Field), bulkBytes(field.Value))
+		}
+		return []protocol.Value{rewriteCommand("HSET", args...)}, nil
+	case storage.ValueKindSet:
+		if len(entry.Set) == 0 {
+			return nil, nil
+		}
+		members := make([]string, 0, len(entry.Set))
+		for _, member := range entry.Set {
+			members = append(members, string(member))
+		}
+		sort.Strings(members)
+		args := make([]protocol.Value, 0, len(members)+1)
+		args = append(args, bulkString(entry.Key))
+		for _, member := range members {
+			args = append(args, bulkString(member))
+		}
+		return []protocol.Value{rewriteCommand("SADD", args...)}, nil
+	case storage.ValueKindZSet:
+		if len(entry.ZSet) == 0 {
+			return nil, nil
+		}
+		args := make([]protocol.Value, 0, len(entry.ZSet)*2+1)
+		args = append(args, bulkString(entry.Key))
+		for _, zsetEntry := range entry.ZSet {
+			args = append(args, bulkString(strconv.FormatFloat(zsetEntry.Score, 'g', -1, 64)), bulkString(zsetEntry.Member))
+		}
+		return []protocol.Value{rewriteCommand("ZADD", args...)}, nil
+	case storage.ValueKindStream:
+		frames := make([]protocol.Value, 0, len(entry.Stream))
+		for _, streamEntry := range entry.Stream {
+			args := make([]protocol.Value, 0, len(streamEntry.Values)+2)
+			args = append(args, bulkString(entry.Key), bulkString(streamEntry.ID))
+			for _, value := range streamEntry.Values {
+				args = append(args, bulkBytes(value))
+			}
+			frames = append(frames, rewriteCommand("XADD", args...))
+		}
+		return frames, nil
+	default:
+		return nil, fmt.Errorf("aof: unsupported rewrite value kind %q for key %q", entry.Kind, entry.Key)
+	}
+}
+
+func rewriteCommand(name string, args ...protocol.Value) protocol.Array {
+	elements := make([]protocol.Value, 0, len(args)+1)
+	elements = append(elements, protocol.TextBulkString{Value: name})
+	elements = append(elements, args...)
+	return protocol.Array{Elements: elements}
+}
+
+func bulkString(value string) protocol.BulkString {
+	return protocol.BulkString{Data: []byte(value)}
+}
+
+func bulkBytes(value []byte) protocol.BulkString {
+	return protocol.BulkString{Data: value}
+}

--- a/internal/aof/rewrite_test.go
+++ b/internal/aof/rewrite_test.go
@@ -1,0 +1,111 @@
+package aof_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/aof"
+	"github.com/maltemindedal/runedb/internal/command"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestGenerateRewriteRoundTripsState(t *testing.T) {
+	store := storage.NewStore()
+	store.Set("name", []byte("RuneDB"), 0)
+	store.Set("expiring", []byte("soon"), time.Now().Add(time.Minute).UnixMilli())
+	if _, err := store.RightPush("letters", [][]byte{[]byte("a"), []byte("b")}); err != nil {
+		t.Fatalf("RightPush() error = %v", err)
+	}
+	if _, err := store.HSet("profile", []storage.HashFieldValue{{Field: "lang", Value: []byte("go")}, {Field: "tier", Value: []byte("senior")}}); err != nil {
+		t.Fatalf("HSet() error = %v", err)
+	}
+	if _, err := store.SAdd("tags", [][]byte{[]byte("fast"), []byte("durable")}); err != nil {
+		t.Fatalf("SAdd() error = %v", err)
+	}
+	if _, err := store.ZAdd("leaders", []storage.ZSetEntry{{Member: []byte("alpha"), Score: 1}, {Member: []byte("beta"), Score: 2}}); err != nil {
+		t.Fatalf("ZAdd() error = %v", err)
+	}
+	if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("type"), []byte("start")}); err != nil {
+		t.Fatalf("XAdd() error = %v", err)
+	}
+
+	entries, _ := store.SnapshotAll()
+	var payload bytes.Buffer
+	stats, err := aof.GenerateRewrite(entries, &payload)
+	if err != nil {
+		t.Fatalf("GenerateRewrite() error = %v", err)
+	}
+	if stats.Keys != 7 {
+		t.Fatalf("stats.Keys = %d, want 7", stats.Keys)
+	}
+	if stats.Commands != 7 {
+		t.Fatalf("stats.Commands = %d, want 7", stats.Commands)
+	}
+
+	replayedStore := storage.NewStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	executor := command.NewExecutor(replayedStore, logger)
+	parser := protocol.NewParser(bytes.NewReader(payload.Bytes()))
+	for {
+		value, parseErr := parser.Parse()
+		if parseErr != nil {
+			break
+		}
+		if _, execErr := executor.ExecuteDetailed(context.Background(), value); execErr != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", execErr)
+		}
+	}
+
+	if got, ok, err := replayedStore.Get("name"); err != nil {
+		t.Fatalf("Get(name) error = %v", err)
+	} else if !ok || string(got) != "RuneDB" {
+		t.Fatalf("Get(name) = (%q, %v), want (RuneDB, true)", string(got), ok)
+	}
+	if got, ok, err := replayedStore.Get("expiring"); err != nil {
+		t.Fatalf("Get(expiring) error = %v", err)
+	} else if !ok || string(got) != "soon" {
+		t.Fatalf("Get(expiring) = (%q, %v), want (soon, true)", string(got), ok)
+	}
+
+	replayedEntries, _ := replayedStore.SnapshotAll()
+	var foundTTL bool
+	for _, entry := range replayedEntries {
+		if entry.Key == "expiring" {
+			foundTTL = entry.ExpiresAt > time.Now().UnixMilli()
+		}
+	}
+	if !foundTTL {
+		t.Fatal("rewritten expiring key did not retain a future TTL")
+	}
+
+	if values, err := replayedStore.ListRange("letters", 0, -1); err != nil {
+		t.Fatalf("ListRange() error = %v", err)
+	} else if len(values) != 2 || string(values[0]) != "a" || string(values[1]) != "b" {
+		t.Fatalf("ListRange() = %q, want [a b]", values)
+	}
+	if fields, err := replayedStore.HGetAll("profile"); err != nil {
+		t.Fatalf("HGetAll() error = %v", err)
+	} else if len(fields) != 2 {
+		t.Fatalf("len(HGetAll()) = %d, want 2", len(fields))
+	}
+	if members, err := replayedStore.SMembers("tags"); err != nil {
+		t.Fatalf("SMembers() error = %v", err)
+	} else if len(members) != 2 {
+		t.Fatalf("len(SMembers()) = %d, want 2", len(members))
+	}
+	if entries, err := replayedStore.ZRange("leaders", 0, -1); err != nil {
+		t.Fatalf("ZRange() error = %v", err)
+	} else if len(entries) != 2 || entries[0].Member != "alpha" || entries[1].Member != "beta" {
+		t.Fatalf("ZRange() = %#v, want alpha/beta order", entries)
+	}
+	if entries, err := replayedStore.XRead("events", "0-0"); err != nil {
+		t.Fatalf("XRead() error = %v", err)
+	} else if len(entries) != 1 || entries[0].ID != "1-0" {
+		t.Fatalf("XRead() = %#v, want single entry 1-0", entries)
+	}
+}

--- a/internal/aof/rewrite_test.go
+++ b/internal/aof/rewrite_test.go
@@ -3,6 +3,7 @@ package aof_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -54,7 +55,10 @@ func TestGenerateRewriteRoundTripsState(t *testing.T) {
 	for {
 		value, parseErr := parser.Parse()
 		if parseErr != nil {
-			break
+			if errors.Is(parseErr, io.EOF) {
+				break
+			}
+			t.Fatalf("Parse() error = %v", parseErr)
 		}
 		if _, execErr := executor.ExecuteDetailed(context.Background(), value); execErr != nil {
 			t.Fatalf("ExecuteDetailed() error = %v", execErr)

--- a/internal/aof/types.go
+++ b/internal/aof/types.go
@@ -1,0 +1,66 @@
+package aof
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Policy controls how often the AOF writer flushes buffered state to disk.
+type Policy int
+
+const (
+	// PolicyAlways fsyncs before acknowledging the command.
+	PolicyAlways Policy = iota
+	// PolicyEverysec fsyncs once per second from a background goroutine.
+	PolicyEverysec
+	// PolicyNo leaves flushing to the operating system.
+	PolicyNo
+)
+
+var (
+	// ErrInvalidPolicy reports an unknown appendfsync policy.
+	ErrInvalidPolicy = errors.New("aof: invalid appendfsync policy")
+	// ErrRewriteInProgress reports that BGREWRITEAOF is already active.
+	ErrRewriteInProgress = errors.New("append only file rewrite already in progress")
+	// ErrClosed reports that the writer is no longer available.
+	ErrClosed = errors.New("aof: writer closed")
+)
+
+// LoadStats summarizes AOF replay during startup.
+type LoadStats struct {
+	ReplayedCommands int
+	TruncatedTail    bool
+}
+
+// RewriteStats summarizes BGREWRITEAOF payload generation.
+type RewriteStats struct {
+	Keys     int
+	Commands int
+}
+
+// ParsePolicy parses the appendfsync policy name.
+func ParsePolicy(raw string) (Policy, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "everysec":
+		return PolicyEverysec, nil
+	case "always":
+		return PolicyAlways, nil
+	case "no":
+		return PolicyNo, nil
+	default:
+		return PolicyEverysec, fmt.Errorf("%w %q", ErrInvalidPolicy, raw)
+	}
+}
+
+// String returns the canonical flag value for the policy.
+func (p Policy) String() string {
+	switch p {
+	case PolicyAlways:
+		return "always"
+	case PolicyNo:
+		return "no"
+	default:
+		return "everysec"
+	}
+}

--- a/internal/aof/writer.go
+++ b/internal/aof/writer.go
@@ -1,0 +1,447 @@
+package aof
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+var (
+	renameFile = os.Rename
+	removeFile = os.Remove
+)
+
+// Writer appends RESP payloads to an append-only file and can rewrite it in the background.
+type Writer struct {
+	path   string
+	policy Policy
+	logger *slog.Logger
+
+	mu             sync.Mutex
+	file           *os.File
+	writer         *bufio.Writer
+	rewriteBuffer  bytes.Buffer
+	rewriteActive  bool
+	rewritePending bool
+	closed         bool
+	closeOnce      sync.Once
+	closeCh        chan struct{}
+	wg             sync.WaitGroup
+}
+
+// OpenWriter opens or creates an append-only file writer for the supplied path.
+func OpenWriter(ctx context.Context, path string, policy Policy, logger *slog.Logger) (*Writer, error) {
+	if path == "" {
+		return nil, errors.New("aof: empty file path")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("aof: create directory %q: %w", dir, err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("aof: open %q: %w", path, err)
+	}
+
+	writer := &Writer{
+		path:    path,
+		policy:  policy,
+		logger:  logger,
+		file:    file,
+		writer:  bufio.NewWriter(file),
+		closeCh: make(chan struct{}),
+	}
+	if policy == PolicyEverysec {
+		writer.wg.Add(1)
+		go writer.runEverysec(ctx)
+	}
+
+	return writer, nil
+}
+
+// Policy returns the configured appendfsync policy.
+func (w *Writer) Policy() Policy {
+	if w == nil {
+		return PolicyEverysec
+	}
+
+	return w.policy
+}
+
+// Append writes a payload without forcing an immediate fsync.
+func (w *Writer) Append(payload []byte) error {
+	return w.append(payload, false)
+}
+
+// AppendSync writes a payload and fsyncs it before returning.
+func (w *Writer) AppendSync(payload []byte) error {
+	return w.append(payload, true)
+}
+
+// Close flushes, fsyncs, and closes the underlying AOF file.
+func (w *Writer) Close() error {
+	if w == nil {
+		return nil
+	}
+
+	w.closeOnce.Do(func() {
+		close(w.closeCh)
+	})
+	w.wg.Wait()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+
+	flushErr := w.syncLocked()
+	closeErr := w.file.Close()
+	if flushErr != nil && closeErr != nil {
+		return errors.Join(flushErr, closeErr)
+	}
+	if flushErr != nil {
+		return flushErr
+	}
+	if closeErr != nil {
+		return fmt.Errorf("aof: close %q: %w", w.path, closeErr)
+	}
+
+	return nil
+}
+
+// BeginRewrite starts a background rewrite of the current AOF file.
+func (w *Writer) BeginRewrite(ctx context.Context, store *storage.Store) error {
+	if w == nil {
+		return ErrClosed
+	}
+	if store == nil {
+		return errors.New("aof: store unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return ErrClosed
+	}
+	if w.rewritePending || w.rewriteActive {
+		w.mu.Unlock()
+		return ErrRewriteInProgress
+	}
+	w.rewritePending = true
+	w.mu.Unlock()
+
+	w.wg.Add(1)
+	go w.runRewrite(ctx, store)
+	return nil
+}
+
+func (w *Writer) append(payload []byte, syncNow bool) error {
+	if w == nil || len(payload) == 0 {
+		return nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrClosed
+	}
+	if _, err := w.writer.Write(payload); err != nil {
+		return fmt.Errorf("aof: write %q: %w", w.path, err)
+	}
+	if w.rewriteActive {
+		if _, err := w.rewriteBuffer.Write(payload); err != nil {
+			return fmt.Errorf("aof: buffer rewrite payload for %q: %w", w.path, err)
+		}
+	}
+	if syncNow {
+		return w.syncLocked()
+	}
+
+	return nil
+}
+
+func (w *Writer) runEverysec(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.closeCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := w.sync(); err != nil && !errors.Is(err, ErrClosed) {
+				w.logWarn("failed to sync append-only file", "path", w.path, "error", err)
+			}
+		}
+	}
+}
+
+func (w *Writer) sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrClosed
+	}
+
+	return w.syncLocked()
+}
+
+func (w *Writer) syncLocked() error {
+	if err := w.writer.Flush(); err != nil {
+		return fmt.Errorf("aof: flush %q: %w", w.path, err)
+	}
+	if err := w.file.Sync(); err != nil {
+		return fmt.Errorf("aof: sync %q: %w", w.path, err)
+	}
+
+	return nil
+}
+
+func (w *Writer) runRewrite(ctx context.Context, store *storage.Store) {
+	defer w.wg.Done()
+
+	select {
+	case <-w.closeCh:
+		w.clearRewriteState(false)
+		return
+	case <-ctx.Done():
+		w.clearRewriteState(false)
+		return
+	default:
+	}
+
+	startedAt := time.Now()
+	dir := filepath.Dir(w.path)
+	if dir == "" {
+		dir = "."
+	}
+	tempFile, err := os.CreateTemp(dir, filepath.Base(w.path)+".rewrite-*")
+	if err != nil {
+		w.clearRewriteState(false)
+		w.logError("failed to create rewrite temp file", "path", w.path, "error", err)
+		return
+	}
+	tempPath := tempFile.Name()
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			if removeErr := removeFile(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				w.logWarn("failed to remove rewrite temp file", "path", tempPath, "error", removeErr)
+			}
+		}
+	}()
+
+	activated := false
+	entries, snapshotStats := store.SnapshotAllWithWriteBarrier(func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if w.closed {
+			w.rewritePending = false
+			return
+		}
+
+		w.rewriteActive = true
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		activated = true
+	})
+	if !activated {
+		_ = tempFile.Close()
+		return
+	}
+
+	select {
+	case <-w.closeCh:
+		w.clearRewriteState(true)
+		_ = tempFile.Close()
+		return
+	case <-ctx.Done():
+		w.clearRewriteState(true)
+		_ = tempFile.Close()
+		return
+	default:
+	}
+
+	rewriteStats, err := GenerateRewrite(entries, tempFile)
+	if err != nil {
+		w.clearRewriteState(true)
+		_ = tempFile.Close()
+		w.logError("failed to generate rewritten append-only file", "path", w.path, "error", err)
+		return
+	}
+
+	w.mu.Lock()
+	if w.closed {
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		_ = tempFile.Close()
+		return
+	}
+	if _, err := tempFile.Write(w.rewriteBuffer.Bytes()); err != nil {
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		_ = tempFile.Close()
+		w.logError("failed to write buffered rewrite payload", "path", tempPath, "error", err)
+		return
+	}
+	if err := tempFile.Sync(); err != nil {
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		_ = tempFile.Close()
+		w.logError("failed to sync rewritten append-only file", "path", tempPath, "error", err)
+		return
+	}
+	if err := tempFile.Close(); err != nil {
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		w.logError("failed to close rewritten append-only temp file", "path", tempPath, "error", err)
+		return
+	}
+	oldFile := w.file
+	if oldFile != nil {
+		if err := oldFile.Close(); err != nil {
+			w.rewriteActive = false
+			w.rewritePending = false
+			w.rewriteBuffer.Reset()
+			w.mu.Unlock()
+			w.logError("failed to close current append-only file before rewrite swap", "path", w.path, "error", err)
+			return
+		}
+	}
+	if err := replaceFile(tempPath, w.path); err != nil {
+		reopened, reopenErr := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if reopenErr == nil {
+			w.file = reopened
+			w.writer = bufio.NewWriter(reopened)
+		}
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		if reopenErr != nil {
+			w.logError("failed to replace append-only file with rewrite and reopen original file", "path", w.path, "error", err, "reopen_error", reopenErr)
+		} else {
+			w.logError("failed to replace append-only file with rewrite", "path", w.path, "error", err)
+		}
+		return
+	}
+
+	newFile, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		w.rewriteActive = false
+		w.rewritePending = false
+		w.rewriteBuffer.Reset()
+		w.mu.Unlock()
+		w.logError("failed to reopen append-only file after rewrite", "path", w.path, "error", err)
+		return
+	}
+
+	w.file = newFile
+	w.writer = bufio.NewWriter(newFile)
+	w.rewriteActive = false
+	w.rewritePending = false
+	w.rewriteBuffer.Reset()
+	w.mu.Unlock()
+
+	cleanupTemp = false
+
+	w.logInfo(
+		"completed append-only file rewrite",
+		"path", w.path,
+		"snapshot_keys", snapshotStats.ExportedKeys,
+		"rewrite_keys", rewriteStats.Keys,
+		"rewrite_commands", rewriteStats.Commands,
+		"duration", time.Since(startedAt),
+	)
+}
+
+func (w *Writer) clearRewriteState(active bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if active {
+		w.rewriteActive = false
+		w.rewriteBuffer.Reset()
+	}
+	w.rewritePending = false
+}
+
+func (w *Writer) logInfo(msg string, args ...any) {
+	if w != nil && w.logger != nil {
+		w.logger.Info(msg, args...)
+	}
+}
+
+func (w *Writer) logWarn(msg string, args ...any) {
+	if w != nil && w.logger != nil {
+		w.logger.Warn(msg, args...)
+	}
+}
+
+func (w *Writer) logError(msg string, args ...any) {
+	if w != nil && w.logger != nil {
+		w.logger.Error(msg, args...)
+	}
+}
+
+func replaceFile(tempPath string, targetPath string) error {
+	err := renameFile(tempPath, targetPath)
+	if err == nil {
+		return nil
+	}
+	if !isReplaceTargetExistsError(err) {
+		return fmt.Errorf("aof: replace %q: %w", targetPath, err)
+	}
+
+	removeErr := removeFile(targetPath)
+	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("aof: replace %q: rename error: %w; remove error: %v", targetPath, err, removeErr)
+	}
+	if retryErr := renameFile(tempPath, targetPath); retryErr != nil {
+		return fmt.Errorf("aof: replace %q after removing existing target: %w", targetPath, retryErr)
+	}
+
+	return nil
+}
+
+func isReplaceTargetExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, fs.ErrExist) || os.IsExist(err)
+}

--- a/internal/aof/writer.go
+++ b/internal/aof/writer.go
@@ -179,6 +179,9 @@ func (w *Writer) append(payload []byte, syncNow bool) error {
 	if syncNow {
 		return w.syncLocked()
 	}
+	if w.policy == PolicyNo {
+		return w.flushLocked()
+	}
 
 	return nil
 }
@@ -214,11 +217,19 @@ func (w *Writer) sync() error {
 }
 
 func (w *Writer) syncLocked() error {
-	if err := w.writer.Flush(); err != nil {
-		return fmt.Errorf("aof: flush %q: %w", w.path, err)
+	if err := w.flushLocked(); err != nil {
+		return err
 	}
 	if err := w.file.Sync(); err != nil {
 		return fmt.Errorf("aof: sync %q: %w", w.path, err)
+	}
+
+	return nil
+}
+
+func (w *Writer) flushLocked() error {
+	if err := w.writer.Flush(); err != nil {
+		return fmt.Errorf("aof: flush %q: %w", w.path, err)
 	}
 
 	return nil

--- a/internal/aof/writer_test.go
+++ b/internal/aof/writer_test.go
@@ -1,0 +1,37 @@
+package aof_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maltemindedal/runedb/internal/aof"
+)
+
+func TestWriterPolicyNoFlushesOnAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "appendonly.aof")
+	writer, err := aof.OpenWriter(context.Background(), path, aof.PolicyNo, nil)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	defer func() {
+		if closeErr := writer.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	}()
+
+	payload := []byte("*1\r\n$4\r\nPING\r\n")
+	if err := writer.Append(payload); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("file contents = %q, want %q", got, payload)
+	}
+}

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -142,6 +142,7 @@ func (e *Executor) handleExec(ctx context.Context, request *Request) (server.Exe
 	queued := state.DrainTransaction()
 	responses := make([]protocol.Value, 0, len(queued))
 	propagation := make([]protocol.Value, 0, len(queued))
+	durability := make([]protocol.Value, 0, len(queued))
 	for _, queuedCommand := range queued {
 		result, execErr := e.executeRequestDetailed(ctx, &Request{Name: queuedCommand.Name, Args: queuedCommand.Args}, false)
 		if execErr != nil {
@@ -157,11 +158,27 @@ func (e *Executor) handleExec(ctx context.Context, request *Request) (server.Exe
 		}
 		responses = append(responses, result.Responses[0])
 		propagation = append(propagation, result.Propagation...)
+		durability = append(durability, result.Durability...)
 	}
 
 	result := server.SingleResponse(protocol.Array{Elements: responses})
 	result.Propagation = propagation
+	result.Durability = durability
 	return result, nil
+}
+
+func (e *Executor) handleBGRewriteAOF(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 0 {
+		return nil, wrongNumberOfArgumentsError("BGREWRITEAOF")
+	}
+	if e.aofRewrite == nil {
+		return nil, fmt.Errorf("append only file persistence is not enabled")
+	}
+	if err := e.aofRewrite(ctx); err != nil {
+		return nil, err
+	}
+
+	return protocol.SimpleString{Value: "Background append only file rewriting started"}, nil
 }
 
 func (e *Executor) handleReplConf(ctx context.Context, request *Request) (server.ExecuteResult, error) {

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -32,6 +32,7 @@ type commandSpec struct {
 	validate           commandValidator
 	transactionControl bool
 	propagates         bool
+	durable            bool
 }
 
 // Executor routes protocol frames to concrete command handlers.
@@ -44,6 +45,7 @@ type Executor struct {
 	commands       map[string]commandSpec
 	replication    *server.ReplicationState
 	replicaPeers   *server.ReplicaRegistry
+	aofRewrite     func(context.Context) error
 }
 
 // NewExecutor constructs a command executor with the currently supported command set.
@@ -81,6 +83,11 @@ func (e *Executor) SetReplicaRegistry(registry *server.ReplicaRegistry) {
 // SetRequirePass injects the configured connection password requirement.
 func (e *Executor) SetRequirePass(password string) {
 	e.requirePass = password
+}
+
+// SetAOFRewriteTrigger injects the background AOF rewrite hook.
+func (e *Executor) SetAOFRewriteTrigger(trigger func(context.Context) error) {
+	e.aofRewrite = trigger
 }
 
 // Execute dispatches a parsed RESP frame to its command handler.
@@ -138,6 +145,7 @@ func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request,
 
 	result := server.SingleResponse(response)
 	result.Propagation = e.propagationFrames(ctx, request)
+	result.Durability = e.durabilityFrames(request)
 	return result, nil
 }
 
@@ -203,6 +211,15 @@ func (e *Executor) propagationFrames(ctx context.Context, request *Request) []pr
 
 	spec, ok := e.command(request.Name)
 	if !ok || !spec.propagates {
+		return nil
+	}
+
+	return []protocol.Value{propagationFrame(request)}
+}
+
+func (e *Executor) durabilityFrames(request *Request) []protocol.Value {
+	spec, ok := e.command(request.Name)
+	if !ok || !spec.durable {
 		return nil
 	}
 
@@ -302,6 +319,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleSet,
 			validate:   validateSetRequest,
 			propagates: true,
+			durable:    true,
 		},
 		"GET": {
 			handler:  e.handleGet,
@@ -311,21 +329,25 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleDel,
 			validate:   minArgsValidator("DEL", 1),
 			propagates: true,
+			durable:    true,
 		},
 		"INCR": {
 			handler:    e.handleIncr,
 			validate:   exactArgsValidator("INCR", 1),
 			propagates: true,
+			durable:    true,
 		},
 		"LPUSH": {
 			handler:    e.handleLPush,
 			validate:   minArgsValidator("LPUSH", 2),
 			propagates: true,
+			durable:    true,
 		},
 		"RPUSH": {
 			handler:    e.handleRPush,
 			validate:   minArgsValidator("RPUSH", 2),
 			propagates: true,
+			durable:    true,
 		},
 		"LRANGE": {
 			handler:  e.handleLRange,
@@ -335,11 +357,13 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleLPop,
 			validate:   validateLPopRequest,
 			propagates: true,
+			durable:    true,
 		},
 		"RPOP": {
 			handler:    e.handleRPop,
 			validate:   validateRPopRequest,
 			propagates: true,
+			durable:    true,
 		},
 		"BLPOP": {
 			handler:  e.handleBLPop,
@@ -349,6 +373,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleZAdd,
 			validate:   validateZAddRequest,
 			propagates: true,
+			durable:    true,
 		},
 		"ZRANGE": {
 			handler:  e.handleZRange,
@@ -357,6 +382,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 		"XADD": {
 			handler:  e.handleXAdd,
 			validate: validateXAddRequest,
+			durable:  true,
 		},
 		"XREAD": {
 			handler:  e.handleXRead,
@@ -366,6 +392,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleHSet,
 			validate:   validateHSetRequest,
 			propagates: true,
+			durable:    true,
 		},
 		"HGET": {
 			handler:  e.handleHGet,
@@ -375,6 +402,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleHDel,
 			validate:   minArgsValidator("HDEL", 2),
 			propagates: true,
+			durable:    true,
 		},
 		"HGETALL": {
 			handler:  e.handleHGetAll,
@@ -384,6 +412,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleSAdd,
 			validate:   minArgsValidator("SADD", 2),
 			propagates: true,
+			durable:    true,
 		},
 		"SISMEMBER": {
 			handler:  e.handleSIsMember,
@@ -393,6 +422,7 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:    e.handleSRem,
 			validate:   minArgsValidator("SREM", 2),
 			propagates: true,
+			durable:    true,
 		},
 		"SMEMBERS": {
 			handler:  e.handleSMembers,
@@ -414,6 +444,10 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 		"WAIT": {
 			detailed: e.handleWait,
 			validate: validateWaitRequest,
+		},
+		"BGREWRITEAOF": {
+			handler:  e.handleBGRewriteAOF,
+			validate: exactArgsValidator("BGREWRITEAOF", 0),
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -17,6 +18,8 @@ type Config struct {
 	EvictionSampleSize int
 	RDBPath            string
 	DumpPath           string
+	AOFPath            string
+	AppendFsync        string
 	ReplicaOf          string
 	MasterAuth         string
 	RequirePass        string
@@ -32,6 +35,8 @@ func Default() Config {
 		EvictionSampleSize: 20,
 		RDBPath:            "",
 		DumpPath:           "dump.rdb",
+		AOFPath:            "",
+		AppendFsync:        "everysec",
 		ReplicaOf:          "",
 		MasterAuth:         "",
 	}
@@ -39,21 +44,45 @@ func Default() Config {
 
 // ParseFlags parses command-line flags into a Config value.
 func ParseFlags() Config {
+	cfg, err := parseFlags(flag.CommandLine, os.Args[1:])
+	if err == nil {
+		return cfg
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "failed to parse flags: %v\n", err)
+	os.Exit(2)
+	return Config{}
+}
+
+func parseFlags(fs *flag.FlagSet, args []string) (Config, error) {
 	cfg := Default()
 
-	flag.StringVar(&cfg.Host, "host", cfg.Host, "host interface to bind the TCP listener to")
-	flag.IntVar(&cfg.Port, "port", cfg.Port, "TCP port to listen on")
-	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "log level: debug, info, warn, error")
-	flag.DurationVar(&cfg.EvictionInterval, "eviction-interval", cfg.EvictionInterval, "interval for active TTL eviction")
-	flag.IntVar(&cfg.EvictionSampleSize, "eviction-sample-size", cfg.EvictionSampleSize, "number of keys to sample on each eviction pass")
-	flag.StringVar(&cfg.RDBPath, "rdb", cfg.RDBPath, "optional path to an RDB file to load before accepting TCP connections")
-	flag.StringVar(&cfg.DumpPath, "dump", cfg.DumpPath, "path to write an RDB snapshot during graceful shutdown")
-	flag.StringVar(&cfg.ReplicaOf, "replicaof", cfg.ReplicaOf, "optional master address in host:port form for replica mode")
-	flag.StringVar(&cfg.MasterAuth, "masterauth", cfg.MasterAuth, "optional password used by replica mode to AUTH against a protected master")
-	flag.StringVar(&cfg.RequirePass, "requirepass", cfg.RequirePass, "optional password required for AUTH-protected client commands")
-	flag.Parse()
+	fs.StringVar(&cfg.Host, "host", cfg.Host, "host interface to bind the TCP listener to")
+	fs.IntVar(&cfg.Port, "port", cfg.Port, "TCP port to listen on")
+	fs.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "log level: debug, info, warn, error")
+	fs.DurationVar(&cfg.EvictionInterval, "eviction-interval", cfg.EvictionInterval, "interval for active TTL eviction")
+	fs.IntVar(&cfg.EvictionSampleSize, "eviction-sample-size", cfg.EvictionSampleSize, "number of keys to sample on each eviction pass")
+	fs.StringVar(&cfg.RDBPath, "rdb", cfg.RDBPath, "optional path to an RDB file to load before accepting TCP connections")
+	fs.StringVar(&cfg.DumpPath, "dump", cfg.DumpPath, "path to write an RDB snapshot during graceful shutdown")
+	fs.StringVar(&cfg.AOFPath, "aof", cfg.AOFPath, "optional path to an append-only file used for durable command logging")
+	fs.StringVar(&cfg.ReplicaOf, "replicaof", cfg.ReplicaOf, "optional master address in host:port form for replica mode")
+	fs.StringVar(&cfg.MasterAuth, "masterauth", cfg.MasterAuth, "optional password used by replica mode to AUTH against a protected master")
+	fs.StringVar(&cfg.RequirePass, "requirepass", cfg.RequirePass, "optional password required for AUTH-protected client commands")
+	fs.Func("appendfsync", "appendfsync policy: always, everysec, no", func(value string) error {
+		normalized, err := normalizeAppendFsync(value)
+		if err != nil {
+			return err
+		}
 
-	return cfg
+		cfg.AppendFsync = normalized
+		return nil
+	})
+
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
 }
 
 // Address formats the listen address used by net.Listen.
@@ -86,4 +115,14 @@ func (c Config) ReplicaAddress() (string, error) {
 	}
 
 	return net.JoinHostPort(host, port), nil
+}
+
+func normalizeAppendFsync(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "always", "everysec", "no":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid appendfsync policy %q: expected always, everysec, or no", value)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"flag"
+	"io"
+	"testing"
+)
 
 func TestDefaultIncludesShutdownSnapshotPath(t *testing.T) {
 	cfg := Default()
@@ -11,4 +15,37 @@ func TestDefaultIncludesShutdownSnapshotPath(t *testing.T) {
 	if cfg.MasterAuth != "" {
 		t.Fatalf("MasterAuth = %q, want empty string", cfg.MasterAuth)
 	}
+	if cfg.AppendFsync != "everysec" {
+		t.Fatalf("AppendFsync = %q, want %q", cfg.AppendFsync, "everysec")
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	t.Run("parses AOF flags", func(t *testing.T) {
+		fs := flag.NewFlagSet("runedb-test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+
+		cfg, err := parseFlags(fs, []string{"--aof", "appendonly.aof", "--appendfsync", "always", "--dump", "snapshot.rdb"})
+		if err != nil {
+			t.Fatalf("parseFlags() error = %v", err)
+		}
+		if cfg.AOFPath != "appendonly.aof" {
+			t.Fatalf("AOFPath = %q, want %q", cfg.AOFPath, "appendonly.aof")
+		}
+		if cfg.AppendFsync != "always" {
+			t.Fatalf("AppendFsync = %q, want %q", cfg.AppendFsync, "always")
+		}
+		if cfg.DumpPath != "snapshot.rdb" {
+			t.Fatalf("DumpPath = %q, want %q", cfg.DumpPath, "snapshot.rdb")
+		}
+	})
+
+	t.Run("rejects invalid appendfsync policy", func(t *testing.T) {
+		fs := flag.NewFlagSet("runedb-test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+
+		if _, err := parseFlags(fs, []string{"--appendfsync", "sometimes"}); err == nil {
+			t.Fatal("parseFlags() error = nil, want invalid appendfsync failure")
+		}
+	})
 }

--- a/internal/server/aof.go
+++ b/internal/server/aof.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/aof"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/rdb"
+)
+
+func (s *Server) initializePersistence(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	loadRDB := func() error {
+		if s.cfg.RDBPath == "" {
+			return nil
+		}
+
+		startedAt := time.Now()
+		stats, err := rdb.LoadFile(s.cfg.RDBPath, s.store)
+		if err != nil {
+			return fmt.Errorf("server: load rdb %q: %w", s.cfg.RDBPath, err)
+		}
+
+		s.logger.Info(
+			"loaded RDB snapshot",
+			"path", s.cfg.RDBPath,
+			"loaded_keys", stats.LoadedKeys,
+			"skipped_expired_keys", stats.SkippedExpiredKeys,
+			"duration", time.Since(startedAt),
+		)
+		return nil
+	}
+
+	if s.cfg.AOFPath == "" {
+		return loadRDB()
+	}
+
+	policy, err := aof.ParsePolicy(s.cfg.AppendFsync)
+	if err != nil {
+		return fmt.Errorf("server: parse appendfsync policy %q: %w", s.cfg.AppendFsync, err)
+	}
+
+	exists, size, err := aofFileState(s.cfg.AOFPath)
+	if err != nil {
+		return fmt.Errorf("server: inspect aof %q: %w", s.cfg.AOFPath, err)
+	}
+	if exists && size > 0 {
+		s.logger.Info("AOF detected, skipping RDB startup load", "aof_path", s.cfg.AOFPath, "rdb_path", s.cfg.RDBPath)
+		startedAt := time.Now()
+		stats, err := aof.LoadFile(WithReplicationOrigin(ctx), s.cfg.AOFPath, func(replayCtx context.Context, value protocol.Value) error {
+			_, replayErr := s.executor.ExecuteDetailed(replayCtx, value)
+			return replayErr
+		})
+		if err != nil {
+			return fmt.Errorf("server: load aof %q: %w", s.cfg.AOFPath, err)
+		}
+
+		s.logger.Info(
+			"loaded append-only file",
+			"path", s.cfg.AOFPath,
+			"replayed_commands", stats.ReplayedCommands,
+			"truncated_tail", stats.TruncatedTail,
+			"duration", time.Since(startedAt),
+		)
+	} else if err := loadRDB(); err != nil {
+		return err
+	}
+
+	writer, err := aof.OpenWriter(ctx, s.cfg.AOFPath, policy, s.logger)
+	if err != nil {
+		return fmt.Errorf("server: open aof writer %q: %w", s.cfg.AOFPath, err)
+	}
+	if s.aofWriter != nil {
+		if closeErr := s.aofWriter.Close(); closeErr != nil {
+			s.logger.Warn("failed to close stale AOF writer before reopening", "path", s.cfg.AOFPath, "error", closeErr)
+		}
+	}
+	s.aofWriter = writer
+	return nil
+}
+
+func (s *Server) beginAOFRewrite(_ context.Context) error {
+	if s == nil || s.aofWriter == nil {
+		return fmt.Errorf("append only file persistence is not enabled")
+	}
+
+	runtimeCtx := s.runtimeCtx
+	if runtimeCtx == nil {
+		runtimeCtx = context.Background()
+	}
+
+	return s.aofWriter.BeginRewrite(runtimeCtx, s.store)
+}
+
+func (s *Server) closeAOFWriter() error {
+	if s == nil || s.aofWriter == nil {
+		return nil
+	}
+
+	writer := s.aofWriter
+	s.aofWriter = nil
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("server: close aof writer: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Server) persistReplicaDurability(values []protocol.Value) error {
+	if s == nil || s.aofWriter == nil || len(values) == 0 {
+		return nil
+	}
+
+	payload, err := protocol.EncodeValues(values)
+	if err != nil {
+		return fmt.Errorf("server: encode replica durability frames: %w", err)
+	}
+	if s.aofWriter.Policy() == aof.PolicyAlways {
+		if err := s.aofWriter.AppendSync(payload); err != nil {
+			return fmt.Errorf("server: append replica durability frames: %w", err)
+		}
+		return nil
+	}
+	if err := s.aofWriter.Append(payload); err != nil {
+		return fmt.Errorf("server: append replica durability frames: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) prepareDurabilityBeforeResponse(values []protocol.Value, logger *slog.Logger) ([]byte, error) {
+	if s == nil || s.aofWriter == nil || s.aofWriter.Policy() != aof.PolicyAlways || len(values) == 0 {
+		return nil, nil
+	}
+
+	payload, err := protocol.EncodeValues(values)
+	if err != nil {
+		logger.Error("failed to encode AOF payload", "error", err)
+		return nil, err
+	}
+	if err := s.aofWriter.AppendSync(payload); err != nil {
+		logger.Error("failed to append command to AOF before responding", "error", err)
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+func (s *Server) finalizeMutationEffects(ctx context.Context, durability []protocol.Value, durabilityPayload []byte, propagation []protocol.Value, logger *slog.Logger) {
+	if s == nil {
+		return
+	}
+
+	if len(durability) > 0 && s.aofWriter != nil && s.aofWriter.Policy() != aof.PolicyAlways {
+		payload := durabilityPayload
+		if len(payload) == 0 {
+			encoded, err := protocol.EncodeValues(durability)
+			if err != nil {
+				logger.Warn("failed to encode deferred AOF payload", "error", err)
+			} else {
+				payload = encoded
+			}
+		}
+		if len(payload) > 0 {
+			if err := s.aofWriter.Append(payload); err != nil {
+				logger.Warn("failed to append command to AOF", "error", err)
+			}
+		}
+	}
+
+	if len(propagation) > 0 {
+		report := s.propagateToReplicas(propagation)
+		s.recordClientWriteOffset(ctx, report.endOffset)
+	}
+}
+
+func persistenceFailureResponse() protocol.ErrorValue {
+	return protocol.ErrorValue{Message: "ERR persistence failure"}
+}
+
+func aofFileState(path string) (bool, int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, 0, nil
+		}
+		return false, 0, err
+	}
+
+	return true, info.Size(), nil
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -68,21 +68,23 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			result = SingleResponse(responseError(execErr))
 		}
 
+		durabilityPayload, durableErr := s.prepareDurabilityBeforeResponse(result.Durability, logger)
+		if durableErr != nil {
+			result = SingleResponse(persistenceFailureResponse())
+			result.Propagation = nil
+			result.Durability = nil
+			durabilityPayload = nil
+		}
+
 		if err := s.writeClientResponses(ctx, writer, result.Responses); err != nil {
-			if len(result.Propagation) > 0 {
-				report := s.propagateToReplicas(result.Propagation)
-				s.recordClientWriteOffset(ctx, report.endOffset)
-			}
+			s.finalizeMutationEffects(ctx, result.Durability, durabilityPayload, result.Propagation, logger)
 			logger.Warn("failed to write response", "error", err, "propagation_frames", len(result.Propagation))
 			return
 		}
 		if result.RegisterReplica {
 			s.registerReplicaPeer(clientID, conn)
 		}
-		if len(result.Propagation) > 0 {
-			report := s.propagateToReplicas(result.Propagation)
-			s.recordClientWriteOffset(ctx, report.endOffset)
-		}
+		s.finalizeMutationEffects(ctx, result.Durability, durabilityPayload, result.Propagation, logger)
 	}
 }
 

--- a/internal/server/replication.go
+++ b/internal/server/replication.go
@@ -26,6 +26,7 @@ type ExecuteResult struct {
 	Responses       []protocol.Value
 	UpstreamReplies []protocol.Value
 	Propagation     []protocol.Value
+	Durability      []protocol.Value
 	RegisterReplica bool
 }
 
@@ -484,6 +485,10 @@ func (s *Server) startReplicaLink(ctx context.Context, listenerAddr string) {
 			}
 
 			s.logger.Warn("replication stream command failed", "master_addr", masterAddr, "error", execErr)
+			return
+		}
+		if err := s.persistReplicaDurability(result.Durability); err != nil {
+			s.logger.Error("failed to append replicated command to AOF", "master_addr", masterAddr, "error", err)
 			return
 		}
 		if len(result.UpstreamReplies) > 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"net"
 	"sync"
-	"time"
 
+	"github.com/maltemindedal/runedb/internal/aof"
 	"github.com/maltemindedal/runedb/internal/config"
 	"github.com/maltemindedal/runedb/internal/protocol"
 	"github.com/maltemindedal/runedb/internal/rdb"
@@ -39,6 +39,10 @@ type authConfigSetter interface {
 	SetRequirePass(string)
 }
 
+type aofRewriteTriggerSetter interface {
+	SetAOFRewriteTrigger(func(context.Context) error)
+}
+
 type temporaryError interface {
 	error
 	Temporary() bool
@@ -55,6 +59,8 @@ type Server struct {
 	watchRegistry  *WatchRegistry
 	pubSubRegistry *PubSubRegistry
 	replication    *ReplicationState
+	aofWriter      *aof.Writer
+	runtimeCtx     context.Context
 
 	clientStates   map[uint64]*ClientState
 	clientStatesMu sync.RWMutex
@@ -98,36 +104,31 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 	if setter, ok := executor.(authConfigSetter); ok {
 		setter.SetRequirePass(cfg.RequirePass)
 	}
+	if setter, ok := executor.(aofRewriteTriggerSetter); ok {
+		setter.SetAOFRewriteTrigger(srv.beginAOFRewrite)
+	}
 
 	return srv
 }
 
 // ListenAndServe starts the TCP listener and blocks until shutdown.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	s.runtimeCtx = ctx
+	if err := s.initializePersistence(ctx); err != nil {
+		return err
+	}
+
 	if s.cfg.IsReplica() {
 		if _, err := s.cfg.ReplicaAddress(); err != nil {
 			return fmt.Errorf("server: validate replica configuration: %w", err)
 		}
 	}
 
-	if s.cfg.RDBPath != "" {
-		startedAt := time.Now()
-		stats, err := rdb.LoadFile(s.cfg.RDBPath, s.store)
-		if err != nil {
-			return fmt.Errorf("server: load rdb %q: %w", s.cfg.RDBPath, err)
-		}
-
-		s.logger.Info(
-			"loaded RDB snapshot",
-			"path", s.cfg.RDBPath,
-			"loaded_keys", stats.LoadedKeys,
-			"skipped_expired_keys", stats.SkippedExpiredKeys,
-			"duration", time.Since(startedAt),
-		)
-	}
-
 	listener, err := net.Listen("tcp", s.cfg.Address())
 	if err != nil {
+		if closeErr := s.closeAOFWriter(); closeErr != nil {
+			s.logger.Warn("failed to close AOF writer after listen failure", "error", closeErr)
+		}
 		return fmt.Errorf("server: listen on %s: %w", s.cfg.Address(), err)
 	}
 
@@ -167,6 +168,9 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	}
 
 	s.handlerWG.Wait()
+	if err := s.closeAOFWriter(); err != nil {
+		return err
+	}
 	if err := s.persistSnapshot(); err != nil {
 		return err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,14 +114,14 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 // ListenAndServe starts the TCP listener and blocks until shutdown.
 func (s *Server) ListenAndServe(ctx context.Context) error {
 	s.runtimeCtx = ctx
-	if err := s.initializePersistence(ctx); err != nil {
-		return err
-	}
 
 	if s.cfg.IsReplica() {
 		if _, err := s.cfg.ReplicaAddress(); err != nil {
 			return fmt.Errorf("server: validate replica configuration: %w", err)
 		}
+	}
+	if err := s.initializePersistence(ctx); err != nil {
+		return err
 	}
 
 	listener, err := net.Listen("tcp", s.cfg.Address())

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -125,31 +125,52 @@ func (s *Store) DeleteMany(keys []string) []string {
 		return nil
 	}
 
-	keysByShard := make(map[int][]string, len(keys))
-	shardIDs := make([]int, 0, len(keys))
+	shardCount := len(s.shards)
+	counts := make([]int, shardCount)
 	for _, key := range keys {
-		shardID := s.shardIndex(key)
-		if _, ok := keysByShard[shardID]; !ok {
-			shardIDs = append(shardIDs, shardID)
-		}
-		keysByShard[shardID] = append(keysByShard[shardID], key)
+		counts[s.shardIndex(key)]++
 	}
 
-	slices.Sort(shardIDs)
-	for _, shardID := range shardIDs {
+	offsets := make([]int, shardCount)
+	total := 0
+	for shardID, count := range counts {
+		offsets[shardID] = total
+		total += count
+	}
+
+	groupedKeys := make([]string, len(keys))
+	next := make([]int, shardCount)
+	copy(next, offsets)
+	for _, key := range keys {
+		shardID := s.shardIndex(key)
+		groupedKeys[next[shardID]] = key
+		next[shardID]++
+	}
+
+	for shardID, count := range counts {
+		if count == 0 {
+			continue
+		}
 		s.shards[shardID].mu.Lock()
 	}
 	defer func() {
-		for i := len(shardIDs) - 1; i >= 0; i-- {
-			s.shards[shardIDs[i]].mu.Unlock()
+		for shardID := shardCount - 1; shardID >= 0; shardID-- {
+			if counts[shardID] == 0 {
+				continue
+			}
+			s.shards[shardID].mu.Unlock()
 		}
 	}()
 
 	now := time.Now().UnixMilli()
 	removed := make([]string, 0, len(keys))
-	for _, shardID := range shardIDs {
+	for shardID, count := range counts {
+		if count == 0 {
+			continue
+		}
 		shard := &s.shards[shardID]
-		for _, key := range keysByShard[shardID] {
+		start := offsets[shardID]
+		for _, key := range groupedKeys[start : start+count] {
 			value, ok := shard.data[key]
 			if !ok {
 				continue
@@ -578,15 +599,13 @@ func (s *Store) SnapshotStrings() ([]StringSnapshotEntry, StringSnapshotStats) {
 	s.readLockAllShards()
 	defer s.readUnlockAllShards()
 
-	totalKeys := 0
+	stats := StringSnapshotStats{}
+	entries := make([]StringSnapshotEntry, 0)
 	for i := range s.shards {
-		totalKeys += len(s.shards[i].data)
-	}
-
-	stats := StringSnapshotStats{TotalKeys: totalKeys}
-	entries := make([]StringSnapshotEntry, 0, totalKeys)
-	for i := range s.shards {
-		for key, value := range s.shards[i].data {
+		shard := &s.shards[i]
+		stats.TotalKeys += len(shard.data)
+		entries = slices.Grow(entries, len(shard.data))
+		for key, value := range shard.data {
 			if isExpired(value, now) {
 				stats.SkippedExpiredKeys++
 				continue
@@ -603,6 +622,28 @@ func (s *Store) SnapshotStrings() ([]StringSnapshotEntry, StringSnapshotStats) {
 			})
 			stats.ExportedKeys++
 		}
+	}
+
+	return entries, stats
+}
+
+// SnapshotAll returns defensive copies of every currently supported non-expired value.
+func (s *Store) SnapshotAll() ([]SnapshotEntry, SnapshotStats) {
+	s.readLockAllShards()
+	defer s.readUnlockAllShards()
+
+	return s.snapshotAllLocked(time.Now().UnixMilli())
+}
+
+// SnapshotAllWithWriteBarrier snapshots the full keyspace while holding the store's
+// write locks, invoking barrier immediately before write traffic resumes.
+func (s *Store) SnapshotAllWithWriteBarrier(barrier func()) ([]SnapshotEntry, SnapshotStats) {
+	s.writeLockAllShards()
+	defer s.writeUnlockAllShards()
+
+	entries, stats := s.snapshotAllLocked(time.Now().UnixMilli())
+	if barrier != nil {
+		barrier()
 	}
 
 	return entries, stats
@@ -631,6 +672,56 @@ func (s *Store) ReplaceWith(other *Store) {
 		s.shards[i].data = replacement[i].data
 	}
 	s.writeUnlockAllShards()
+}
+
+func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
+	stats := SnapshotStats{}
+	entries := make([]SnapshotEntry, 0)
+	for i := range s.shards {
+		shard := &s.shards[i]
+		stats.TotalKeys += len(shard.data)
+		entries = slices.Grow(entries, len(shard.data))
+		for key, value := range shard.data {
+			if isExpired(value, now) {
+				stats.SkippedExpiredKeys++
+				continue
+			}
+
+			entry := SnapshotEntry{Key: key, Kind: value.Kind, ExpiresAt: value.ExpiresAt}
+			switch value.Kind {
+			case ValueKindString:
+				entry.String = cloneBytes(value.String)
+			case ValueKindList:
+				entry.List = cloneList(value.List)
+			case ValueKindZSet:
+				if value.ZSet != nil {
+					entry.ZSet = value.ZSet.rangeByRank(0, value.ZSet.len()-1)
+				}
+			case ValueKindStream:
+				if value.Stream != nil {
+					entry.Stream = make([]StreamEntry, 0, len(value.Stream.entries))
+					for _, record := range value.Stream.entries {
+						entry.Stream = append(entry.Stream, StreamEntry{ID: record.idText, Values: cloneList(record.values)})
+					}
+				}
+			case ValueKindHash:
+				entry.Hash = make([]HashFieldValue, 0, len(value.Hash))
+				for field, raw := range value.Hash {
+					entry.Hash = append(entry.Hash, HashFieldValue{Field: field, Value: cloneBytes(raw)})
+				}
+			case ValueKindSet:
+				entry.Set = make([][]byte, 0, len(value.Set))
+				for member := range value.Set {
+					entry.Set = append(entry.Set, []byte(member))
+				}
+			}
+
+			entries = append(entries, entry)
+			stats.ExportedKeys++
+		}
+	}
+
+	return entries, stats
 }
 
 func (s *Store) logDebug(msg string, args ...any) {

--- a/internal/storage/store_benchmark_test.go
+++ b/internal/storage/store_benchmark_test.go
@@ -10,6 +10,15 @@ import (
 
 func BenchmarkStore(b *testing.B) {
 	payload := []byte("value")
+	deleteKeys := make([]string, 0, 128)
+	for i := 0; i < 128; i++ {
+		deleteKeys = append(deleteKeys, fmt.Sprintf("delete-%d", i))
+	}
+
+	snapshotKeys := make([]string, 0, 1024)
+	for i := 0; i < 1024; i++ {
+		snapshotKeys = append(snapshotKeys, fmt.Sprintf("snapshot-%d", i))
+	}
 
 	b.Run("Set same key", func(b *testing.B) {
 		store := NewStore()
@@ -137,5 +146,43 @@ func BenchmarkStore(b *testing.B) {
 				_, _, _ = store.Get(key)
 			}
 		})
+	})
+
+	b.Run("DeleteMany 128 keys", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			store := NewStore()
+			for _, key := range deleteKeys {
+				store.Set(key, payload, 0)
+			}
+			b.StartTimer()
+
+			removed := store.DeleteMany(deleteKeys)
+			if len(removed) != len(deleteKeys) {
+				b.Fatalf("len(DeleteMany()) = %d, want %d", len(removed), len(deleteKeys))
+			}
+		}
+	})
+
+	b.Run("SnapshotAll 1024 strings", func(b *testing.B) {
+		store := NewStore()
+		for _, key := range snapshotKeys {
+			store.Set(key, payload, 0)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			entries, stats := store.SnapshotAll()
+			if len(entries) != len(snapshotKeys) {
+				b.Fatalf("len(SnapshotAll()) = %d, want %d", len(entries), len(snapshotKeys))
+			}
+			if stats.TotalKeys != len(snapshotKeys) || stats.ExportedKeys != len(snapshotKeys) {
+				b.Fatalf("SnapshotAll() stats = %+v, want total/exported %d", stats, len(snapshotKeys))
+			}
+		}
 	})
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -66,6 +66,26 @@ type StringSnapshotStats struct {
 	SkippedUnsupportedKeys int
 }
 
+// SnapshotEntry is a defensive copy of a stored value used for AOF rewrite generation.
+type SnapshotEntry struct {
+	Key       string
+	Kind      ValueKind
+	ExpiresAt int64
+	String    []byte
+	List      [][]byte
+	ZSet      []ZSetRangeEntry
+	Stream    []StreamEntry
+	Hash      []HashFieldValue
+	Set       [][]byte
+}
+
+// SnapshotStats summarizes a full-value snapshot export.
+type SnapshotStats struct {
+	TotalKeys          int
+	ExportedKeys       int
+	SkippedExpiredKeys int
+}
+
 // ValueObject is the internal representation of an item stored in RuneDB.
 //
 // The type is a tagged union: Kind selects which payload field is valid.

--- a/test/aof_integration_test.go
+++ b/test/aof_integration_test.go
@@ -1,0 +1,254 @@
+package test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/command"
+	"github.com/maltemindedal/runedb/internal/config"
+	runedblogger "github.com/maltemindedal/runedb/internal/logger"
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/server"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func TestServerPersistsAndReplaysAOF(t *testing.T) {
+	aofPath := filepath.Join(t.TempDir(), "appendonly.aof")
+	cfg := testAOFConfig(aofPath)
+
+	addr, stop, errCh := startTestServer(t, cfg)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "name", "RuneDB")
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "expiring", "soon", "PX", "60000")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 1}, "HSET", "profile", "lang", "go")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "RPUSH", "letters", "a", "b")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "SADD", "tags", "fast", "durable")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "ZADD", "leaders", "1", "alpha", "2", "beta")
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Data: []byte("1-0")}, "XADD", "events", "1-0", "type", "start")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 1}, "INCR", "counter")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "INCR", "counter")
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	stop()
+	waitForServerStop(t, errCh)
+
+	restartCfg := testAOFConfig(aofPath)
+	restartAddr, restartStop, restartErrCh := startTestServer(t, restartCfg)
+	restartConn, err := net.Dial("tcp", restartAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) restart error = %v", restartAddr, err)
+	}
+	defer func() { _ = restartConn.Close() }()
+	restartParser := protocol.NewParser(restartConn)
+
+	assertCommandResponse(t, restartConn, restartParser, protocol.BulkString{Data: []byte("RuneDB")}, "GET", "name")
+	assertCommandResponse(t, restartConn, restartParser, protocol.BulkString{Data: []byte("soon")}, "GET", "expiring")
+	assertCommandResponse(t, restartConn, restartParser, protocol.BulkString{Data: []byte("go")}, "HGET", "profile", "lang")
+	assertCommandResponse(t, restartConn, restartParser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("a")},
+		protocol.BulkString{Data: []byte("b")},
+	}}, "LRANGE", "letters", "0", "-1")
+	assertCommandResponse(t, restartConn, restartParser, protocol.Integer{Value: 1}, "SISMEMBER", "tags", "durable")
+	assertCommandResponse(t, restartConn, restartParser, protocol.Array{Elements: []protocol.Value{
+		protocol.BulkString{Data: []byte("alpha")},
+		protocol.BulkString{Data: []byte("beta")},
+	}}, "ZRANGE", "leaders", "0", "-1")
+	assertCommandResponse(t, restartConn, restartParser, protocol.Array{Elements: []protocol.Value{
+		protocol.Array{Elements: []protocol.Value{
+			protocol.BulkString{Data: []byte("events")},
+			protocol.Array{Elements: []protocol.Value{
+				protocol.Array{Elements: []protocol.Value{
+					protocol.BulkString{Data: []byte("1-0")},
+					protocol.Array{Elements: []protocol.Value{
+						protocol.BulkString{Data: []byte("type")},
+						protocol.BulkString{Data: []byte("start")},
+					}},
+				}},
+			}},
+		}},
+	}}, "XREAD", "STREAMS", "events", "0-0")
+	assertCommandResponse(t, restartConn, restartParser, protocol.BulkString{Data: []byte("2")}, "GET", "counter")
+
+	restartStop()
+	waitForServerStop(t, restartErrCh)
+}
+
+func TestServerPrefersAOFOverRDB(t *testing.T) {
+	dir := t.TempDir()
+	aofPath := filepath.Join(dir, "appendonly.aof")
+	rdbPath := writeTempRDBFile(t, buildTestRDB(
+		selectTestDB(0),
+		testStringEntry([]byte("name"), []byte("rdb")),
+	))
+	payload, err := protocol.Encode(request("SET", "name", "aof"))
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if err := os.WriteFile(aofPath, payload, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", aofPath, err)
+	}
+
+	cfg := testAOFConfig(aofPath)
+	cfg.RDBPath = rdbPath
+	addr, stop, errCh := startTestServer(t, cfg)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.BulkString{Data: []byte("aof")}, "GET", "name")
+
+	stop()
+	waitForServerStop(t, errCh)
+}
+
+func TestServerDoesNotPersistPublishToAOF(t *testing.T) {
+	aofPath := filepath.Join(t.TempDir(), "appendonly.aof")
+	cfg := testAOFConfig(aofPath)
+	addr, stop, errCh := startTestServer(t, cfg)
+
+	subscriberConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) subscriber error = %v", addr, err)
+	}
+	defer func() { _ = subscriberConn.Close() }()
+	subscriberParser := protocol.NewParser(subscriberConn)
+	if err := protocol.WriteValue(subscriberConn, request("SUBSCRIBE", "updates")); err != nil {
+		t.Fatalf("WriteValue(SUBSCRIBE) error = %v", err)
+	}
+	if _, err := subscriberParser.Parse(); err != nil {
+		t.Fatalf("Parse() SUBSCRIBE error = %v", err)
+	}
+
+	publisherConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) publisher error = %v", addr, err)
+	}
+	defer func() { _ = publisherConn.Close() }()
+	publisherParser := protocol.NewParser(publisherConn)
+	assertCommandResponse(t, publisherConn, publisherParser, protocol.Integer{Value: 1}, "PUBLISH", "updates", "hello")
+	if _, err := subscriberParser.Parse(); err != nil {
+		t.Fatalf("Parse() pushed pubsub message error = %v", err)
+	}
+
+	info, err := os.Stat(aofPath)
+	if err != nil {
+		t.Fatalf("Stat(%q) error = %v", aofPath, err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("AOF size after PUBLISH = %d, want 0", info.Size())
+	}
+
+	stop()
+	waitForServerStop(t, errCh)
+}
+
+func TestServerBGRewriteAOFCompactsAndReloads(t *testing.T) {
+	aofPath := filepath.Join(t.TempDir(), "appendonly.aof")
+	cfg := testAOFConfig(aofPath)
+	addr, stop, errCh := startTestServer(t, cfg)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	parser := protocol.NewParser(conn)
+
+	for i := 0; i < 20; i++ {
+		assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "name", "value"+time.Date(2000, 1, 1, 0, 0, i, 0, time.UTC).Format("05"))
+	}
+	before, err := os.Stat(aofPath)
+	if err != nil {
+		t.Fatalf("Stat(%q) before rewrite error = %v", aofPath, err)
+	}
+	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "Background append only file rewriting started"}, "BGREWRITEAOF")
+
+	deadline := time.Now().Add(3 * time.Second)
+	compacted := false
+	for time.Now().Before(deadline) {
+		info, statErr := os.Stat(aofPath)
+		if statErr != nil {
+			t.Fatalf("Stat(%q) during rewrite error = %v", aofPath, statErr)
+		}
+		if info.Size() < before.Size() {
+			compacted = true
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !compacted {
+		t.Fatalf("BGREWRITEAOF did not compact file within timeout (before=%d)", before.Size())
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	stop()
+	waitForServerStop(t, errCh)
+
+	restartCfg := testAOFConfig(aofPath)
+	restartAddr, restartStop, restartErrCh := startTestServer(t, restartCfg)
+	restartConn, err := net.Dial("tcp", restartAddr)
+	if err != nil {
+		t.Fatalf("Dial(%q) restart error = %v", restartAddr, err)
+	}
+	defer func() { _ = restartConn.Close() }()
+	restartParser := protocol.NewParser(restartConn)
+	assertCommandResponse(t, restartConn, restartParser, protocol.BulkString{Data: []byte("value19")}, "GET", "name")
+
+	restartStop()
+	waitForServerStop(t, restartErrCh)
+}
+
+func testAOFConfig(aofPath string) config.Config {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.DumpPath = ""
+	cfg.AOFPath = aofPath
+	cfg.AppendFsync = "always"
+	return cfg
+}
+
+func startTestServer(t *testing.T, cfg config.Config) (string, context.CancelFunc, <-chan error) {
+	t.Helper()
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	return waitForAddr(t, srv), cancel, errCh
+}
+
+func waitForServerStop(t *testing.T, errCh <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}

--- a/test/aof_integration_test.go
+++ b/test/aof_integration_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -154,6 +155,25 @@ func TestServerDoesNotPersistPublishToAOF(t *testing.T) {
 
 	stop()
 	waitForServerStop(t, errCh)
+}
+
+func TestServerRejectsInvalidReplicaConfigBeforeOpeningAOF(t *testing.T) {
+	aofPath := filepath.Join(t.TempDir(), "appendonly.aof")
+	cfg := testAOFConfig(aofPath)
+	cfg.ReplicaOf = "not-a-host-port"
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	err := srv.ListenAndServe(context.Background())
+	if err == nil {
+		t.Fatal("ListenAndServe() error = nil, want invalid replica configuration failure")
+	}
+	if _, statErr := os.Stat(aofPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Stat(%q) error = %v, want file not created", aofPath, statErr)
+	}
 }
 
 func TestServerBGRewriteAOFCompactsAndReloads(t *testing.T) {


### PR DESCRIPTION
Add support for Append-Only File (AOF) persistence, enabling command logging for durability. Introduce configuration options for AOF path and appendfsync policy, enhance command execution for durability, and implement AOF loading during server initialization. Include tests for AOF functionality and refactor storage for full-value snapshots. Update command specifications to mark commands as durable where applicable.