### PR TITLE
Complete hardening of Pub/Sub broker and enhance delivery semantics

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -18,7 +18,7 @@ Legend: `[x]` done, `[~]` partially done, `[ ]` not done.
 - **Phase 7:** Planned
 - **Phase 8:** Done
 - **Phase 9:** Done
-- **Phase 10:** Planned
+- **Phase 10:** Done
 - **Phase 11:** Planned
 
 ## 1. Executive Summary
@@ -310,23 +310,23 @@ Formalize and harden the existing transaction semantics around queued execution 
 - [x] Abort `EXEC` with a null array when a watched key changed before commit.
 - [x] Expand lifecycle coverage around pre-`MULTI` invalidation and connection cleanup.
 
-### Phase 10: Pub/Sub Broker Hardening — **Planned**
+### Phase 10: Pub/Sub Broker Hardening — **Done**
 
 Strengthen Pub/Sub delivery semantics and subscription bookkeeping.
 
-#### Broker Registry — **Planned**
+#### Broker Registry — **Done**
 
-- [ ] Maintain a central channel-to-client registry for subscriber tracking.
+- [x] Maintain a central channel-to-client registry for subscriber tracking.
 
-#### Subscriber Mode Enforcement — **Planned**
+#### Subscriber Mode Enforcement — **Done**
 
-- [ ] Restrict subscribed clients to the allowed command surface.
-- [ ] Keep subscription bookkeeping synchronized with connection lifecycle changes.
+- [x] Restrict subscribed clients to the allowed command surface.
+- [x] Keep subscription bookkeeping synchronized with connection lifecycle changes.
 
-#### Fan-Out Delivery — **Planned**
+#### Fan-Out Delivery — **Done**
 
-- [ ] Deliver published payloads to every subscribed client on the target channel.
-- [ ] Harden writer synchronization and cleanup on disconnect.
+- [x] Deliver published payloads to every subscribed client on the target channel.
+- [x] Harden writer synchronization and cleanup on disconnect.
 
 ### Phase 11: Memory Limits & Eviction — **Planned**
 

--- a/internal/aof/writer.go
+++ b/internal/aof/writer.go
@@ -308,86 +308,14 @@ func (w *Writer) runRewrite(ctx context.Context, store *storage.Store) {
 		return
 	}
 
-	w.mu.Lock()
-	if w.closed {
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		_ = tempFile.Close()
-		return
-	}
-	if _, err := tempFile.Write(w.rewriteBuffer.Bytes()); err != nil {
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		_ = tempFile.Close()
-		w.logError("failed to write buffered rewrite payload", "path", tempPath, "error", err)
-		return
-	}
-	if err := tempFile.Sync(); err != nil {
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		_ = tempFile.Close()
-		w.logError("failed to sync rewritten append-only file", "path", tempPath, "error", err)
-		return
-	}
-	if err := tempFile.Close(); err != nil {
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		w.logError("failed to close rewritten append-only temp file", "path", tempPath, "error", err)
-		return
-	}
-	oldFile := w.file
-	if oldFile != nil {
-		if err := oldFile.Close(); err != nil {
-			w.rewriteActive = false
-			w.rewritePending = false
-			w.rewriteBuffer.Reset()
-			w.mu.Unlock()
-			w.logError("failed to close current append-only file before rewrite swap", "path", w.path, "error", err)
-			return
-		}
-	}
-	if err := replaceFile(tempPath, w.path); err != nil {
-		reopened, reopenErr := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-		if reopenErr == nil {
-			w.file = reopened
-			w.writer = bufio.NewWriter(reopened)
-		}
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		if reopenErr != nil {
-			w.logError("failed to replace append-only file with rewrite and reopen original file", "path", w.path, "error", err, "reopen_error", reopenErr)
-		} else {
-			w.logError("failed to replace append-only file with rewrite", "path", w.path, "error", err)
-		}
-		return
-	}
-
-	newFile, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	completed, err := w.finalizeRewrite(tempFile, tempPath)
 	if err != nil {
-		w.rewriteActive = false
-		w.rewritePending = false
-		w.rewriteBuffer.Reset()
-		w.mu.Unlock()
-		w.logError("failed to reopen append-only file after rewrite", "path", w.path, "error", err)
+		w.logError("failed to finalize append-only file rewrite", "path", w.path, "error", err)
 		return
 	}
-
-	w.file = newFile
-	w.writer = bufio.NewWriter(newFile)
-	w.rewriteActive = false
-	w.rewritePending = false
-	w.rewriteBuffer.Reset()
-	w.mu.Unlock()
+	if !completed {
+		return
+	}
 
 	cleanupTemp = false
 
@@ -404,11 +332,84 @@ func (w *Writer) runRewrite(ctx context.Context, store *storage.Store) {
 func (w *Writer) clearRewriteState(active bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.clearRewriteStateLocked(active)
+}
+
+func (w *Writer) clearRewriteStateLocked(active bool) {
 	if active {
 		w.rewriteActive = false
 		w.rewriteBuffer.Reset()
 	}
 	w.rewritePending = false
+}
+
+func (w *Writer) finalizeRewrite(tempFile *os.File, tempPath string) (bool, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		w.clearRewriteStateLocked(true)
+		_ = tempFile.Close()
+		return false, nil
+	}
+	if err := w.appendBufferedRewriteLocked(tempFile); err != nil {
+		w.clearRewriteStateLocked(true)
+		_ = tempFile.Close()
+		return false, fmt.Errorf("write buffered rewrite payload to %q: %w", tempPath, err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		w.clearRewriteStateLocked(true)
+		_ = tempFile.Close()
+		return false, fmt.Errorf("sync rewritten append-only file %q: %w", tempPath, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		w.clearRewriteStateLocked(true)
+		return false, fmt.Errorf("close rewritten append-only temp file %q: %w", tempPath, err)
+	}
+	if err := w.swapRewriteFileLocked(tempPath); err != nil {
+		w.clearRewriteStateLocked(true)
+		return false, err
+	}
+
+	w.clearRewriteStateLocked(true)
+	return true, nil
+}
+
+func (w *Writer) appendBufferedRewriteLocked(tempFile *os.File) error {
+	_, err := tempFile.Write(w.rewriteBuffer.Bytes())
+	return err
+}
+
+func (w *Writer) swapRewriteFileLocked(tempPath string) error {
+	oldFile := w.file
+	if oldFile != nil {
+		if err := oldFile.Close(); err != nil {
+			return fmt.Errorf("close current append-only file before rewrite swap: %w", err)
+		}
+	}
+	if err := replaceFile(tempPath, w.path); err != nil {
+		reopenErr := w.reopenAppendOnlyFileLocked()
+		if reopenErr != nil {
+			return fmt.Errorf("replace append-only file with rewrite: %w; reopen original file: %v", err, reopenErr)
+		}
+		return fmt.Errorf("replace append-only file with rewrite: %w", err)
+	}
+	if err := w.reopenAppendOnlyFileLocked(); err != nil {
+		return fmt.Errorf("reopen append-only file after rewrite: %w", err)
+	}
+
+	return nil
+}
+
+func (w *Writer) reopenAppendOnlyFileLocked() error {
+	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+
+	w.file = file
+	w.writer = bufio.NewWriter(file)
+	return nil
 }
 
 func (w *Writer) logInfo(msg string, args ...any) {

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maltemindedal/runedb/internal/protocol"
@@ -16,6 +17,13 @@ import (
 	"github.com/maltemindedal/runedb/internal/server"
 	"github.com/maltemindedal/runedb/internal/storage"
 )
+
+var cachedReplConfGetAckPayload = sync.OnceValues(func() ([]byte, error) {
+	return protocol.Encode(propagationFrame(&Request{
+		Name: "REPLCONF",
+		Args: [][]byte{[]byte("GETACK"), []byte("*")},
+	}))
+})
 
 func (e *Executor) handleWatch(ctx context.Context, request *Request) (protocol.Value, error) {
 	if len(request.Args) == 0 {
@@ -432,23 +440,7 @@ func (e *Executor) handlePublish(_ context.Context, request *Request) (protocol.
 		return nil, fmt.Errorf("encode pub/sub message: %w", err)
 	}
 
-	matched := int64(0)
-	for _, subscriber := range subscribers {
-		if subscriber == nil {
-			continue
-		}
-		if err := subscriber.WriteEncoded(encodedMessage); err != nil {
-			e.logger.Warn(
-				"failed to deliver pub/sub message",
-				"channel", channel,
-				"subscriber_id", subscriber.ID,
-				"error", err,
-			)
-			subscriber.UnsubscribeAll()
-			continue
-		}
-		matched++
-	}
+	matched := e.deliverPubSubMessage(channel, encodedMessage, subscribers)
 
 	return protocol.Integer{Value: matched}, nil
 }
@@ -830,6 +822,35 @@ func pubSubMessageResponse(channel []byte, payload []byte) protocol.Array {
 	}}
 }
 
+func (e *Executor) deliverPubSubMessage(channel string, payload []byte, subscribers []*server.ClientState) int64 {
+	matched := int64(0)
+	for _, subscriber := range subscribers {
+		if e.deliverPubSubMessageToSubscriber(channel, payload, subscriber) {
+			matched++
+		}
+	}
+
+	return matched
+}
+
+func (e *Executor) deliverPubSubMessageToSubscriber(channel string, payload []byte, subscriber *server.ClientState) bool {
+	if subscriber == nil {
+		return false
+	}
+	if err := subscriber.WriteEncoded(payload); err != nil {
+		e.logger.Warn(
+			"failed to deliver pub/sub message",
+			"channel", channel,
+			"subscriber_id", subscriber.ID,
+			"error", err,
+		)
+		subscriber.Disconnect()
+		return false
+	}
+
+	return true
+}
+
 func parseIntegerArgument(raw []byte) (int64, error) {
 	value, err := strconv.ParseInt(string(raw), 10, 64)
 	if err != nil {
@@ -908,8 +929,7 @@ func (e *Executor) requestReplicaAcknowledgements() error {
 		return nil
 	}
 
-	request := propagationFrame(&Request{Name: "REPLCONF", Args: [][]byte{[]byte("GETACK"), []byte("*")}})
-	encoded, err := protocol.Encode(request)
+	encoded, err := cachedReplConfGetAckPayload()
 	if err != nil {
 		return fmt.Errorf("encode REPLCONF GETACK: %w", err)
 	}

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -1640,6 +1640,40 @@ func TestExecutorPubSub(t *testing.T) {
 		if _, err := executor.Execute(ctx, requestValue("MULTI")); !errors.Is(err, ErrSubscribedModeOnly) {
 			t.Fatalf("MULTI error = %v, want ErrSubscribedModeOnly", err)
 		}
+		if _, err := executor.Execute(ctx, requestValue("WATCH", "news")); !errors.Is(err, ErrSubscribedModeOnly) {
+			t.Fatalf("WATCH error = %v, want ErrSubscribedModeOnly", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("EXEC")); !errors.Is(err, ErrSubscribedModeOnly) {
+			t.Fatalf("EXEC error = %v, want ErrSubscribedModeOnly", err)
+		}
+		if _, err := executor.Execute(ctx, requestValue("DISCARD")); !errors.Is(err, ErrSubscribedModeOnly) {
+			t.Fatalf("DISCARD error = %v, want ErrSubscribedModeOnly", err)
+		}
+	})
+
+	t.Run("PUBLISH skips disconnected subscribers and prunes the registry", func(t *testing.T) {
+		executor := newTestExecutor()
+		state := newTestClientState(executor, 1)
+		state.BindResponseWriter(bufio.NewWriter(io.Discard))
+		ctx := server.WithClientState(context.Background(), state)
+
+		if _, err := executor.ExecuteDetailed(ctx, requestValue("SUBSCRIBE", "news")); err != nil {
+			t.Fatalf("SUBSCRIBE error = %v", err)
+		}
+
+		state.Disconnect()
+
+		published, err := executor.Execute(context.Background(), requestValue("PUBLISH", "news", "hello"))
+		if err != nil {
+			t.Fatalf("PUBLISH error = %v", err)
+		}
+		assertValueEqual(t, published, protocol.Integer{Value: 0})
+		if got := len(executor.PubSubRegistry().Subscribers("news")); got != 0 {
+			t.Fatalf("len(Subscribers(news)) = %d after disconnected publish, want 0", got)
+		}
+		if state.IsSubscribed() {
+			t.Fatal("IsSubscribed() = true after disconnected publish cleanup, want false")
+		}
 	})
 
 	t.Run("SUBSCRIBE is rejected inside MULTI", func(t *testing.T) {

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -24,11 +24,15 @@ type ClientState struct {
 	mu         sync.RWMutex
 	responseMu sync.Mutex
 
-	watchRegistry      *WatchRegistry
-	watchedKeys        map[string]struct{}
+	watchRegistry *WatchRegistry
+	watchedKeys   map[string]struct{}
+	// pubSubRegistry and subscribedChannels mirror the same exact-channel
+	// membership. Registry mutations take PubSubRegistry.mu before mutating the
+	// client-local subscribedChannels set via ClientState.mu.
 	pubSubRegistry     *PubSubRegistry
 	subscribedChannels map[string]struct{}
 	responseWriter     *bufio.Writer
+	writerClosed       bool
 
 	Authenticated     bool
 	Replica           bool
@@ -101,6 +105,37 @@ func (s *ClientState) BindResponseWriter(writer *bufio.Writer) {
 	defer s.responseMu.Unlock()
 
 	s.responseWriter = writer
+	s.writerClosed = writer == nil
+}
+
+// HasActiveResponseWriter reports whether the client can currently receive
+// command replies or async push messages.
+func (s *ClientState) HasActiveResponseWriter() bool {
+	if s == nil {
+		return false
+	}
+
+	s.responseMu.Lock()
+	defer s.responseMu.Unlock()
+
+	return !s.writerClosed && s.responseWriter != nil
+}
+
+// Disconnect marks the client inactive and detaches it from shared registries so
+// future async deliveries fail fast.
+func (s *ClientState) Disconnect() {
+	if s == nil {
+		return
+	}
+
+	s.responseMu.Lock()
+	s.writerClosed = true
+	s.responseWriter = nil
+	s.responseMu.Unlock()
+
+	s.ResetTransaction()
+	s.UnsubscribeAll()
+	s.UnwatchAll()
 }
 
 // SetAuthenticated records whether the client has successfully authenticated.
@@ -125,7 +160,7 @@ func (s *ClientState) WriteResponses(values []protocol.Value) error {
 	s.responseMu.Lock()
 	defer s.responseMu.Unlock()
 
-	if s.responseWriter == nil {
+	if s.writerClosed || s.responseWriter == nil {
 		return fmt.Errorf("client response writer unavailable")
 	}
 
@@ -145,7 +180,7 @@ func (s *ClientState) WriteEncoded(payload []byte) error {
 	s.responseMu.Lock()
 	defer s.responseMu.Unlock()
 
-	if s.responseWriter == nil {
+	if s.writerClosed || s.responseWriter == nil {
 		return fmt.Errorf("client response writer unavailable")
 	}
 	if _, err := s.responseWriter.Write(payload); err != nil {

--- a/internal/server/client_state_test.go
+++ b/internal/server/client_state_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -148,6 +150,72 @@ func TestClientStateTransactionLifecycle(t *testing.T) {
 			t.Fatal("TransactionFailed() = true after registry.Touch post-cleanup, want false")
 		}
 	})
+}
+
+func TestClientStateDisconnectClearsWriterAndPubSubState(t *testing.T) {
+	registry := NewPubSubRegistry()
+	watchRegistry := NewWatchRegistry()
+	state := &ClientState{ID: 5, Authenticated: true}
+	state.SetPubSubRegistry(registry)
+	state.SetWatchRegistry(watchRegistry)
+
+	var outbound bytes.Buffer
+	state.BindResponseWriter(bufio.NewWriter(&outbound))
+	state.SubscribeChannel("alpha")
+	state.SubscribeChannel("beta")
+	state.WatchKeys("pubsub-key")
+	if ok := state.BeginTransaction(); !ok {
+		t.Fatal("BeginTransaction() = false, want true")
+	}
+	state.EnqueueCommand("SET", [][]byte{[]byte("pubsub-key"), []byte("1")})
+	state.MarkTransactionDirty()
+	state.MarkTransactionFailed()
+
+	if got := len(registry.Subscribers("alpha")); got != 1 {
+		t.Fatalf("len(Subscribers(alpha)) = %d, want 1", got)
+	}
+	if got := len(registry.Subscribers("beta")); got != 1 {
+		t.Fatalf("len(Subscribers(beta)) = %d, want 1", got)
+	}
+
+	state.Disconnect()
+	state.Disconnect()
+
+	if state.HasActiveResponseWriter() {
+		t.Fatal("HasActiveResponseWriter() = true after Disconnect, want false")
+	}
+	if got := state.SubscriptionCount(); got != 0 {
+		t.Fatalf("SubscriptionCount() = %d after Disconnect, want 0", got)
+	}
+	if len(state.SubscribedChannels()) != 0 {
+		t.Fatalf("SubscribedChannels() = %#v after Disconnect, want empty", state.SubscribedChannels())
+	}
+	if state.InTransactionActive() {
+		t.Fatal("InTransactionActive() = true after Disconnect, want false")
+	}
+	if state.TransactionFailed() {
+		t.Fatal("TransactionFailed() = true after Disconnect, want false")
+	}
+	if state.TransactionDirty() {
+		t.Fatal("TransactionDirty() = true after Disconnect, want false")
+	}
+	if state.TxQueue != nil {
+		t.Fatalf("TxQueue = %#v after Disconnect, want nil", state.TxQueue)
+	}
+	if got := len(registry.Subscribers("alpha")); got != 0 {
+		t.Fatalf("len(Subscribers(alpha)) = %d after Disconnect, want 0", got)
+	}
+	if got := len(registry.Subscribers("beta")); got != 0 {
+		t.Fatalf("len(Subscribers(beta)) = %d after Disconnect, want 0", got)
+	}
+	if err := state.WriteEncoded([]byte("+OK\r\n")); err == nil {
+		t.Fatal("WriteEncoded() error = nil after Disconnect, want error")
+	}
+
+	watchRegistry.Touch("pubsub-key")
+	if state.TransactionFailed() {
+		t.Fatal("TransactionFailed() = true after Disconnect and Touch, want false")
+	}
 }
 
 func TestClientStateLifecycle(t *testing.T) {

--- a/internal/server/client_state_test.go
+++ b/internal/server/client_state_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -377,5 +378,211 @@ func TestHandleConnectionDisconnectCleansTransactionState(t *testing.T) {
 	registry.Touch("alpha")
 	if state.TransactionFailed() {
 		t.Fatal("TransactionFailed() = true after registry.Touch post-disconnect, want false")
+	}
+}
+
+func TestHandleConnectionClosesConnectionBeforeDisconnect(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := New(config.Default(), logger, storage.NewStore(), stubExecutor{})
+
+	conn := newBlockingConn()
+	clientID := srv.registry.Add(conn)
+	state := srv.createClientState(clientID)
+
+	srv.handlerWG.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleConnection(context.Background(), clientID, conn)
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		return state.HasActiveResponseWriter()
+	}, "handleConnection to bind the client response writer")
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- state.WriteEncoded([]byte("+push\r\n"))
+	}()
+
+	waitForSignal(t, time.Second, conn.writeStarted, "async client write to start")
+	conn.ReleaseRead()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleConnection() did not exit; expected it to close the connection before disconnecting client state")
+	}
+
+	select {
+	case err := <-writeErrCh:
+		if err == nil {
+			t.Fatal("WriteEncoded() error = nil, want close-induced error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WriteEncoded() did not unblock after handleConnection closed the connection")
+	}
+
+	if got := srv.getClientState(clientID); got != nil {
+		t.Fatalf("getClientState(%d) after close-before-disconnect cleanup = %p, want nil", clientID, got)
+	}
+	if state.HasActiveResponseWriter() {
+		t.Fatal("HasActiveResponseWriter() = true after handleConnection cleanup, want false")
+	}
+	if got := srv.registry.Count(); got != 0 {
+		t.Fatalf("registry.Count() after handleConnection cleanup = %d, want 0", got)
+	}
+}
+
+func TestShutdownClosesConnectionsBeforeDisconnectingClientStates(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := config.Default()
+	cfg.DumpPath = ""
+	srv := New(cfg, logger, storage.NewStore(), stubExecutor{})
+
+	conn := newBlockingConn()
+	clientID := srv.registry.Add(conn)
+	state := srv.createClientState(clientID)
+	state.BindResponseWriter(bufio.NewWriter(conn))
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- state.WriteEncoded([]byte("+push\r\n"))
+	}()
+
+	waitForSignal(t, time.Second, conn.writeStarted, "shutdown write to start")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.shutdown()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown() did not return; expected it to close client connections before disconnecting client state")
+	}
+
+	select {
+	case err := <-writeErrCh:
+		if err == nil {
+			t.Fatal("WriteEncoded() error = nil, want close-induced error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WriteEncoded() did not unblock after shutdown closed the client connection")
+	}
+
+	if got := srv.getClientState(clientID); got != nil {
+		t.Fatalf("getClientState(%d) after shutdown cleanup = %p, want nil", clientID, got)
+	}
+	if state.HasActiveResponseWriter() {
+		t.Fatal("HasActiveResponseWriter() = true after shutdown cleanup, want false")
+	}
+	if got := srv.registry.Count(); got != 0 {
+		t.Fatalf("registry.Count() after shutdown cleanup = %d, want 0", got)
+	}
+}
+
+type blockingConn struct {
+	closed           chan struct{}
+	readRelease      chan struct{}
+	writeStarted     chan struct{}
+	closeOnce        sync.Once
+	readReleaseOnce  sync.Once
+	writeStartedOnce sync.Once
+}
+
+func newBlockingConn() *blockingConn {
+	return &blockingConn{
+		closed:       make(chan struct{}),
+		readRelease:  make(chan struct{}),
+		writeStarted: make(chan struct{}),
+	}
+}
+
+func (c *blockingConn) ReleaseRead() {
+	c.readReleaseOnce.Do(func() {
+		close(c.readRelease)
+	})
+}
+
+func (c *blockingConn) Read(_ []byte) (int, error) {
+	<-c.readRelease
+	return 0, io.EOF
+}
+
+func (c *blockingConn) Write(_ []byte) (int, error) {
+	c.writeStartedOnce.Do(func() {
+		close(c.writeStarted)
+	})
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (c *blockingConn) LocalAddr() net.Addr {
+	return blockingConnAddr("local")
+}
+
+func (c *blockingConn) RemoteAddr() net.Addr {
+	return blockingConnAddr("remote")
+}
+
+func (c *blockingConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type blockingConnAddr string
+
+func (a blockingConnAddr) Network() string {
+	return "test"
+}
+
+func (a blockingConnAddr) String() string {
+	return string(a)
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool, description string) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if condition() {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", description)
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForSignal(t *testing.T, timeout time.Duration, signal <-chan struct{}, description string) {
+	t.Helper()
+
+	select {
+	case <-signal:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for %s", description)
 	}
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -30,12 +30,12 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			logger.Info("replica disconnected", "replica_id", clientID, "listening_port", peer.ListeningPort)
 		}
 	}()
+	defer s.removeClientState(clientID)
 	defer func() {
 		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 			logger.Debug("failed to close connection", "error", err)
 		}
 	}()
-	defer s.removeClientState(clientID)
 
 	stopClose := context.AfterFunc(ctx, func() {
 		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -13,7 +13,6 @@ import (
 func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net.Conn) {
 	defer s.handlerWG.Done()
 	defer s.registry.Remove(clientID)
-	defer s.removeClientState(clientID)
 
 	parser := protocol.NewParser(conn)
 	writer := bufio.NewWriter(conn)
@@ -36,6 +35,7 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			logger.Debug("failed to close connection", "error", err)
 		}
 	}()
+	defer s.removeClientState(clientID)
 
 	stopClose := context.AfterFunc(ctx, func() {
 		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {

--- a/internal/server/pubsub_registry.go
+++ b/internal/server/pubsub_registry.go
@@ -2,7 +2,14 @@ package server
 
 import "sync"
 
-// PubSubRegistry tracks active exact-channel subscriptions across all client states.
+// PubSubRegistry tracks active exact-channel subscriptions across all client
+// states.
+//
+// A plain map plus RWMutex is used here because registry mutations must preserve
+// a second invariant on ClientState.subscribedChannels. When both structures are
+// touched, registry.mu is acquired before ClientState.mu. Subscriber snapshots
+// are copied while holding RLock and then used outside the lock so network I/O
+// never blocks registry mutations.
 type PubSubRegistry struct {
 	mu          sync.RWMutex
 	subscribers map[string]map[uint64]*ClientState

--- a/internal/server/pubsub_registry_test.go
+++ b/internal/server/pubsub_registry_test.go
@@ -1,0 +1,61 @@
+package server
+
+import "testing"
+
+func TestPubSubRegistryMaintainsClientStateInvariants(t *testing.T) {
+	t.Run("duplicate subscribe keeps counts stable and snapshots detached", func(t *testing.T) {
+		registry := NewPubSubRegistry()
+		state := &ClientState{ID: 1, Authenticated: true}
+		state.SetPubSubRegistry(registry)
+
+		registry.Subscribe(state, "updates")
+		registry.Subscribe(state, "updates")
+
+		if got := state.SubscriptionCount(); got != 1 {
+			t.Fatalf("SubscriptionCount() = %d, want 1", got)
+		}
+		snapshot := registry.Subscribers("updates")
+		if len(snapshot) != 1 {
+			t.Fatalf("len(Subscribers(updates)) = %d, want 1", len(snapshot))
+		}
+
+		snapshot[0] = nil
+		fresh := registry.Subscribers("updates")
+		if len(fresh) != 1 {
+			t.Fatalf("len(fresh Subscribers(updates)) = %d, want 1", len(fresh))
+		}
+		if fresh[0] != state {
+			t.Fatalf("fresh snapshot[0] = %p, want %p", fresh[0], state)
+		}
+
+		registry.Unsubscribe(state, "missing")
+		if got := state.SubscriptionCount(); got != 1 {
+			t.Fatalf("SubscriptionCount() after unsubscribing missing channel = %d, want 1", got)
+		}
+	})
+
+	t.Run("unsubscribe all removes every channel without mutating prior snapshots", func(t *testing.T) {
+		registry := NewPubSubRegistry()
+		state := &ClientState{ID: 2, Authenticated: true}
+		state.SetPubSubRegistry(registry)
+
+		registry.Subscribe(state, "alpha")
+		registry.Subscribe(state, "beta")
+
+		alphaSnapshot := registry.Subscribers("alpha")
+		registry.UnsubscribeAll(state)
+
+		if got := state.SubscriptionCount(); got != 0 {
+			t.Fatalf("SubscriptionCount() after UnsubscribeAll = %d, want 0", got)
+		}
+		if got := len(registry.Subscribers("alpha")); got != 0 {
+			t.Fatalf("len(Subscribers(alpha)) after UnsubscribeAll = %d, want 0", got)
+		}
+		if got := len(registry.Subscribers("beta")); got != 0 {
+			t.Fatalf("len(Subscribers(beta)) after UnsubscribeAll = %d, want 0", got)
+		}
+		if len(alphaSnapshot) != 1 || alphaSnapshot[0] != state {
+			t.Fatalf("alpha snapshot = %#v, want original subscriber entry intact", alphaSnapshot)
+		}
+	})
+}

--- a/internal/server/replication.go
+++ b/internal/server/replication.go
@@ -84,6 +84,11 @@ type propagationReport struct {
 	endOffset   int64
 }
 
+const (
+	replicaFanoutAsyncThreshold = 8
+	replicaFanoutMaxWorkers     = 32
+)
+
 // WriteEncoded writes a pre-encoded RESP payload to the replica socket.
 func (p *ReplicaPeer) WriteEncoded(payload []byte) error {
 	if p == nil || p.writer == nil {
@@ -290,17 +295,7 @@ func (s *Server) propagateToReplicas(values []protocol.Value) propagationReport 
 	report := propagationReport{attempted: len(peers), payloadSize: len(payload)}
 	report.endOffset = s.replication.AdvanceMasterOffset(int64(len(payload)))
 
-	for _, peer := range peers {
-		if err := peer.WriteEncoded(payload); err != nil {
-			s.logger.Warn("failed to propagate command to replica", "replica_id", peer.ID, "error", err)
-			report.failed++
-			if closeErr := s.replicaPeers.RemoveAndClose(peer.ID); closeErr != nil {
-				s.logger.Debug("failed to close replica after propagation failure", "replica_id", peer.ID, "error", closeErr)
-			}
-			continue
-		}
-		report.succeeded++
-	}
+	report.succeeded, report.failed = s.writePropagationPayload(payload, peers)
 	if report.attempted > 0 {
 		s.logger.Debug(
 			"propagated command to replicas",
@@ -328,6 +323,71 @@ func (s *Server) propagateToReplicas(values []protocol.Value) propagationReport 
 	}
 
 	return report
+}
+
+func (s *Server) writePropagationPayload(payload []byte, peers []*ReplicaPeer) (int, int) {
+	if len(peers) == 0 {
+		return 0, 0
+	}
+	if len(peers) < replicaFanoutAsyncThreshold {
+		return s.writePropagationPayloadSequential(payload, peers)
+	}
+
+	workerCount := min(len(peers), replicaFanoutMaxWorkers)
+	jobs := make(chan *ReplicaPeer, len(peers))
+	var succeeded atomic.Int64
+	var failed atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer wg.Done()
+			for peer := range jobs {
+				if s.writePropagationPayloadToReplica(peer, payload) {
+					succeeded.Add(1)
+				} else {
+					failed.Add(1)
+				}
+			}
+		}()
+	}
+
+	for _, peer := range peers {
+		jobs <- peer
+	}
+	close(jobs)
+	wg.Wait()
+
+	return int(succeeded.Load()), int(failed.Load())
+}
+
+func (s *Server) writePropagationPayloadSequential(payload []byte, peers []*ReplicaPeer) (int, int) {
+	succeeded := 0
+	failed := 0
+	for _, peer := range peers {
+		if s.writePropagationPayloadToReplica(peer, payload) {
+			succeeded++
+		} else {
+			failed++
+		}
+	}
+
+	return succeeded, failed
+}
+
+func (s *Server) writePropagationPayloadToReplica(peer *ReplicaPeer, payload []byte) bool {
+	if peer == nil {
+		return false
+	}
+	if err := peer.WriteEncoded(payload); err != nil {
+		s.logger.Warn("failed to propagate command to replica", "replica_id", peer.ID, "error", err)
+		if closeErr := s.replicaPeers.RemoveAndClose(peer.ID); closeErr != nil {
+			s.logger.Debug("failed to close replica after propagation failure", "replica_id", peer.ID, "error", closeErr)
+		}
+		return false
+	}
+
+	return true
 }
 
 func (s *Server) recordClientWriteOffset(ctx context.Context, offset int64) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,10 +209,10 @@ func (s *Server) shutdown() {
 				s.logger.Debug("failed to close listener during shutdown", "error", err)
 			}
 		}
+		s.clearClientStates()
 		if err := s.registry.CloseAll(); err != nil {
 			s.logger.Debug("failed to close one or more client connections during shutdown", "error", err)
 		}
-		s.clearClientStates()
 	})
 }
 
@@ -274,17 +274,21 @@ func (s *Server) getClientState(clientID uint64) *ClientState {
 	return s.clientStates[clientID]
 }
 
+func (s *Server) disconnectClientState(state *ClientState) {
+	if state == nil {
+		return
+	}
+
+	state.Disconnect()
+}
+
 func (s *Server) removeClientState(clientID uint64) {
 	s.clientStatesMu.Lock()
 	state := s.clientStates[clientID]
 	delete(s.clientStates, clientID)
 	s.clientStatesMu.Unlock()
 
-	if state != nil {
-		state.ResetTransaction()
-		state.UnsubscribeAll()
-		state.UnwatchAll()
-	}
+	s.disconnectClientState(state)
 }
 
 func (s *Server) clearClientStates() {
@@ -297,9 +301,7 @@ func (s *Server) clearClientStates() {
 	s.clientStatesMu.Unlock()
 
 	for _, state := range states {
-		state.ResetTransaction()
-		state.UnsubscribeAll()
-		state.UnwatchAll()
+		s.disconnectClientState(state)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,10 +209,10 @@ func (s *Server) shutdown() {
 				s.logger.Debug("failed to close listener during shutdown", "error", err)
 			}
 		}
-		s.clearClientStates()
 		if err := s.registry.CloseAll(); err != nil {
 			s.logger.Debug("failed to close one or more client connections during shutdown", "error", err)
 		}
+		s.clearClientStates()
 	})
 }
 

--- a/internal/storage/hash.go
+++ b/internal/storage/hash.go
@@ -80,10 +80,9 @@ func (s *Store) HGet(key, field string) ([]byte, bool, error) {
 		shard.mu.RUnlock()
 		return nil, false, nil
 	}
-	cloned := cloneBytes(raw)
 	shard.mu.RUnlock()
 
-	return cloned, true, nil
+	return cloneBytes(raw), true, nil
 }
 
 // HDel removes the named fields from the hash stored at key and returns the
@@ -157,9 +156,13 @@ func (s *Store) HGetAll(key string) ([]HashFieldValue, error) {
 
 	entries := make([]HashFieldValue, 0, len(hash))
 	for field, raw := range hash {
-		entries = append(entries, HashFieldValue{Field: field, Value: cloneBytes(raw)})
+		entries = append(entries, HashFieldValue{Field: field, Value: raw})
 	}
 	shard.mu.RUnlock()
+
+	for i := range entries {
+		entries[i].Value = cloneBytes(entries[i].Value)
+	}
 
 	return entries, nil
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -90,10 +90,9 @@ func (s *Store) Get(key string) ([]byte, bool, error) {
 		shard.mu.RUnlock()
 		return nil, true, err
 	}
-	cloned := cloneBytes(data)
 	shard.mu.RUnlock()
 
-	return cloned, true, nil
+	return cloneBytes(data), true, nil
 }
 
 // Delete removes a key from the store.
@@ -404,9 +403,11 @@ func (s *Store) ListRange(key string, start, stop int64) ([][]byte, error) {
 		return [][]byte{}, nil
 	}
 
-	cloned := cloneList(list[from : to+1])
+	snapshot := make([][]byte, to-from+1)
+	copy(snapshot, list[from:to+1])
 	shard.mu.RUnlock()
-	return cloned, nil
+
+	return cloneList(snapshot), nil
 }
 
 // ZAdd inserts or updates one or more sorted-set members and returns the number of newly added members.
@@ -559,13 +560,13 @@ func (s *Store) XRead(key, rawID string) ([]StreamEntry, error) {
 		return nil, err
 	}
 
-	entries, err := stream.readAfter(rawID)
+	records, err := stream.snapshotAfter(rawID)
 	shard.mu.RUnlock()
 	if err != nil {
 		return nil, err
 	}
 
-	return entries, nil
+	return cloneStreamEntries(records), nil
 }
 
 // SubscribeListPush registers a waiter that is notified when a push occurs for key.

--- a/internal/storage/stream.go
+++ b/internal/storage/stream.go
@@ -77,9 +77,9 @@ func (s *streamValue) add(rawID string, values [][]byte, nowMillis int64) (strin
 	return idText, nil
 }
 
-func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
+func (s *streamValue) snapshotAfter(rawID string) ([]streamRecord, error) {
 	if len(s.entries) == 0 {
-		return []StreamEntry{}, nil
+		return nil, nil
 	}
 
 	after, err := parseStreamReadID(rawID, s.lastID)
@@ -90,13 +90,26 @@ func (s *streamValue) readAfter(rawID string) ([]StreamEntry, error) {
 	start := sort.Search(len(s.entries), func(i int) bool {
 		return compareStreamIDs(s.entries[i].id, after) > 0
 	})
-
-	entries := make([]StreamEntry, 0, len(s.entries)-start)
-	for _, entry := range s.entries[start:] {
-		entries = append(entries, StreamEntry{ID: entry.idText, Values: cloneList(entry.values)})
+	if start == len(s.entries) {
+		return nil, nil
 	}
 
-	return entries, nil
+	snapshot := make([]streamRecord, len(s.entries)-start)
+	copy(snapshot, s.entries[start:])
+	return snapshot, nil
+}
+
+func cloneStreamEntries(records []streamRecord) []StreamEntry {
+	if len(records) == 0 {
+		return []StreamEntry{}
+	}
+
+	entries := make([]StreamEntry, 0, len(records))
+	for _, record := range records {
+		entries = append(entries, StreamEntry{ID: record.idText, Values: cloneList(record.values)})
+	}
+
+	return entries
 }
 
 func (s *streamValue) nextAutoID(nowMillis int64) streamID {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -614,6 +614,147 @@ func TestServerHandlesPubSubCommands(t *testing.T) {
 	}
 }
 
+func TestServerPubSubPublishesToEverySubscriber(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.DumpPath = ""
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	subscriberOneConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) subscriber one error = %v", addr, err)
+	}
+	defer func() { _ = subscriberOneConn.Close() }()
+	subscriberOneParser := protocol.NewParser(subscriberOneConn)
+
+	subscriberTwoConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) subscriber two error = %v", addr, err)
+	}
+	defer func() { _ = subscriberTwoConn.Close() }()
+	subscriberTwoParser := protocol.NewParser(subscriberTwoConn)
+
+	publisherConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) publisher error = %v", addr, err)
+	}
+	defer func() { _ = publisherConn.Close() }()
+	publisherParser := protocol.NewParser(publisherConn)
+
+	assertCommandResponse(t, subscriberOneConn, subscriberOneParser, protocol.Array{Elements: []protocol.Value{
+		protocol.TextBulkString{Value: "subscribe"},
+		protocol.BulkString{Data: []byte("updates")},
+		protocol.Integer{Value: 1},
+	}}, "SUBSCRIBE", "updates")
+	assertCommandResponse(t, subscriberTwoConn, subscriberTwoParser, protocol.Array{Elements: []protocol.Value{
+		protocol.TextBulkString{Value: "subscribe"},
+		protocol.BulkString{Data: []byte("updates")},
+		protocol.Integer{Value: 1},
+	}}, "SUBSCRIBE", "updates")
+
+	assertCommandResponse(t, publisherConn, publisherParser, protocol.Integer{Value: 2}, "PUBLISH", "updates", "hello")
+
+	messageOne, err := subscriberOneParser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() subscriber one message error = %v", err)
+	}
+	assertValuesEqual(t, messageOne, protocol.Array{Elements: []protocol.Value{
+		protocol.TextBulkString{Value: "message"},
+		protocol.BulkString{Data: []byte("updates")},
+		protocol.BulkString{Data: []byte("hello")},
+	}})
+
+	messageTwo, err := subscriberTwoParser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() subscriber two message error = %v", err)
+	}
+	assertValuesEqual(t, messageTwo, protocol.Array{Elements: []protocol.Value{
+		protocol.TextBulkString{Value: "message"},
+		protocol.BulkString{Data: []byte("updates")},
+		protocol.BulkString{Data: []byte("hello")},
+	}})
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerSubscribedClientsRejectTransactionCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.DumpPath = ""
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) error = %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	parser := protocol.NewParser(conn)
+
+	assertCommandResponse(t, conn, parser, protocol.Array{Elements: []protocol.Value{
+		protocol.TextBulkString{Value: "subscribe"},
+		protocol.BulkString{Data: []byte("updates")},
+		protocol.Integer{Value: 1},
+	}}, "SUBSCRIBE", "updates")
+
+	blocked := protocol.ErrorValue{Message: "ERR only PING, SUBSCRIBE, and UNSUBSCRIBE are allowed in this context"}
+	assertCommandResponse(t, conn, parser, blocked, "WATCH", "updates")
+	assertCommandResponse(t, conn, parser, blocked, "MULTI")
+	assertCommandResponse(t, conn, parser, blocked, "EXEC")
+	assertCommandResponse(t, conn, parser, blocked, "DISCARD")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
 func TestServerPubSubDisconnectCleanup(t *testing.T) {
 	cfg := config.Default()
 	cfg.Host = "127.0.0.1"


### PR DESCRIPTION
Strengthen the Pub/Sub delivery semantics and improve subscription bookkeeping. Ensure that disconnected subscribers are pruned from the registry and maintain client state invariants during subscription operations.