### PR TITLE
Add MONITOR command support and slowlog functionality

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -20,6 +20,7 @@ Legend: `[x]` done, `[~]` partially done, `[ ]` not done.
 - **Phase 9:** Done
 - **Phase 10:** Done
 - **Phase 11:** Done
+- **Phase 12:** Done
 
 ## 1. Executive Summary
 
@@ -352,9 +353,9 @@ Protect the server from unbounded memory growth under sustained write pressure.
 
 A production-ready database requires tooling to monitor its internal state under load.
 
-- [ ] **The `INFO` Command:** Implement sections for `INFO memory` (heap stats, fragmentation), `INFO replication` (master/replica offsets, lag), and `INFO clients` (connected counts).
-- [ ] **The `SLOWLOG`:** Track queries that exceed a configurable execution time (`slowlog-log-slower-than`). Implement a bounded, thread-safe queue to store slow query metadata (timestamp, execution time, command array) without blocking the hot path.
-- [ ] **The `MONITOR` Command:** Implement a debugging command that streams every command processed by the server back to the calling client, utilizing the Pub/Sub fan-out architecture for internal server events.
+- [x] **The `INFO` Command:** Implement sections for `INFO memory` (heap stats, fragmentation), `INFO replication` (master/replica offsets, lag), and `INFO clients` (connected counts).
+- [x] **The `SLOWLOG`:** Track queries that exceed a configurable execution time (`slowlog-log-slower-than`). Implement a bounded, thread-safe queue to store slow query metadata (timestamp, execution time, command array) without blocking the hot path.
+- [x] **The `MONITOR` Command:** Implement a debugging command that streams every command processed by the server back to the calling client, utilizing the Pub/Sub fan-out architecture for internal server events.
 
 ### Phase 13: Advanced Memory Efficiency (Internal Encodings)
 

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -777,6 +778,41 @@ func TestExecutorSlowlog(t *testing.T) {
 		// RESET itself is recorded at a zero threshold after clearing older entries.
 		if got := registry.Len(); got != 1 {
 			t.Fatalf("slowlog Len() = %d after RESET at zero threshold, want 1", got)
+		}
+	})
+
+	t.Run("does not record commands rejected before dispatch", func(t *testing.T) {
+		executor := newTestExecutor()
+		executor.SetRequirePass("secret")
+		registry := server.NewSlowlogRegistry()
+		executor.SetSlowlogConfig(registry, 0)
+		ctx := withUnauthenticatedClientStateForExecutor(context.Background(), executor, 77)
+
+		if _, err := executor.Execute(ctx, requestValue("SET", "name", "RuneDB")); !errors.Is(err, ErrNoAuth) {
+			t.Fatalf("SET unauthenticated error = %v, want ErrNoAuth", err)
+		}
+		if got := registry.Len(); got != 0 {
+			t.Fatalf("slowlog Len() = %d after rejected SET, want 0", got)
+		}
+	})
+
+	t.Run("redacts sensitive command arguments", func(t *testing.T) {
+		executor := newTestExecutor()
+		executor.SetRequirePass("secret")
+		registry := server.NewSlowlogRegistry()
+		executor.SetSlowlogConfig(registry, 0)
+		ctx := withUnauthenticatedClientStateForExecutor(context.Background(), executor, 78)
+
+		if _, err := executor.Execute(ctx, requestValue("AUTH", "secret")); err != nil {
+			t.Fatalf("AUTH error = %v", err)
+		}
+		entries := registry.Entries(1)
+		if len(entries) != 1 {
+			t.Fatalf("len(slowlog entries) = %d, want 1", len(entries))
+		}
+		want := []string{"AUTH", "[redacted]"}
+		if !reflect.DeepEqual(entries[0].Command, want) {
+			t.Fatalf("slowlog command = %#v, want %#v", entries[0].Command, want)
 		}
 	})
 }

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -693,6 +693,94 @@ func TestExecutorMaxMemory(t *testing.T) {
 	})
 }
 
+func TestExecutorInfo(t *testing.T) {
+	executor := newTestExecutor()
+	if _, err := executor.Execute(context.Background(), requestValue("SET", "name", "RuneDB")); err != nil {
+		t.Fatalf("SET error = %v", err)
+	}
+	if _, err := executor.Execute(context.Background(), requestValue("LPUSH", "letters", "a")); err != nil {
+		t.Fatalf("LPUSH error = %v", err)
+	}
+
+	value, err := executor.Execute(context.Background(), requestValue("INFO", "memory"))
+	if err != nil {
+		t.Fatalf("INFO memory error = %v", err)
+	}
+	text := mustBulkStringText(t, value)
+	for _, want := range []string{"# Memory", "used_memory:", "mem_fragmentation_ratio:", "go_heap_alloc:", "key_count:2", "key_count_string:1", "key_count_list:1"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("INFO memory = %q, missing %q", text, want)
+		}
+	}
+
+	value, err = executor.Execute(context.Background(), requestValue("INFO"))
+	if err != nil {
+		t.Fatalf("INFO error = %v", err)
+	}
+	text = mustBulkStringText(t, value)
+	for _, want := range []string{"# Memory", "# Replication", "# Clients", "role:master"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("INFO = %q, missing %q", text, want)
+		}
+	}
+}
+
+func TestExecutorSlowlog(t *testing.T) {
+	t.Run("records commands at zero threshold", func(t *testing.T) {
+		executor := newTestExecutor()
+		registry := server.NewSlowlogRegistry()
+		executor.SetSlowlogConfig(registry, 0)
+
+		if _, err := executor.Execute(context.Background(), requestValue("PING")); err != nil {
+			t.Fatalf("PING error = %v", err)
+		}
+		value, err := executor.Execute(context.Background(), requestValue("SLOWLOG", "LEN"))
+		if err != nil {
+			t.Fatalf("SLOWLOG LEN error = %v", err)
+		}
+		assertValueEqual(t, value, protocol.Integer{Value: 1})
+
+		value, err = executor.Execute(context.Background(), requestValue("SLOWLOG", "GET", "1"))
+		if err != nil {
+			t.Fatalf("SLOWLOG GET error = %v", err)
+		}
+		array, ok := value.(protocol.Array)
+		if !ok || len(array.Elements) != 1 {
+			t.Fatalf("SLOWLOG GET response = %#v, want one entry", value)
+		}
+	})
+
+	t.Run("negative threshold disables recording", func(t *testing.T) {
+		executor := newTestExecutor()
+		registry := server.NewSlowlogRegistry()
+		executor.SetSlowlogConfig(registry, -time.Microsecond)
+
+		if _, err := executor.Execute(context.Background(), requestValue("PING")); err != nil {
+			t.Fatalf("PING error = %v", err)
+		}
+		if got := registry.Len(); got != 0 {
+			t.Fatalf("slowlog Len() = %d, want 0", got)
+		}
+	})
+
+	t.Run("reset clears entries", func(t *testing.T) {
+		executor := newTestExecutor()
+		registry := server.NewSlowlogRegistry()
+		executor.SetSlowlogConfig(registry, 0)
+
+		if _, err := executor.Execute(context.Background(), requestValue("PING")); err != nil {
+			t.Fatalf("PING error = %v", err)
+		}
+		if _, err := executor.Execute(context.Background(), requestValue("SLOWLOG", "RESET")); err != nil {
+			t.Fatalf("SLOWLOG RESET error = %v", err)
+		}
+		// RESET itself is recorded at a zero threshold after clearing older entries.
+		if got := registry.Len(); got != 1 {
+			t.Fatalf("slowlog Len() = %d after RESET at zero threshold, want 1", got)
+		}
+	})
+}
+
 func TestExecutorReplicationAcknowledgements(t *testing.T) {
 	t.Run("replica-origin GETACK emits upstream ACK reply", func(t *testing.T) {
 		executor := newTestExecutor()

--- a/internal/command/executor.go
+++ b/internal/command/executor.go
@@ -40,6 +40,8 @@ var (
 	ErrSubscribedModeOnly = errors.New("only PING, SUBSCRIBE, and UNSUBSCRIBE are allowed in this context")
 	// ErrSubscribeInsideMulti reports that subscribe state changes are not allowed inside MULTI.
 	ErrSubscribeInsideMulti = errors.New("SUBSCRIBE and UNSUBSCRIBE inside MULTI are not allowed")
+	// ErrMonitorModeOnly reports that a MONITOR client attempted a disallowed command.
+	ErrMonitorModeOnly = errors.New("only PING is allowed in this context")
 	// ErrOutOfMemory reports that a write could not fit under maxmemory.
 	ErrOutOfMemory = errors.New("command not allowed when used memory > 'maxmemory'")
 )
@@ -175,6 +177,11 @@ func ErrSubscribedModeOnlyError() error {
 // ErrSubscribeInsideMultiError reports that subscription state changes are disallowed in MULTI.
 func ErrSubscribeInsideMultiError() error {
 	return newRESPWrappedError("ERR", ErrSubscribeInsideMulti)
+}
+
+// ErrMonitorModeOnlyError reports that only monitor-safe commands are allowed.
+func ErrMonitorModeOnlyError() error {
+	return newRESPWrappedError("ERR", ErrMonitorModeOnly)
 }
 
 // ErrOutOfMemoryError reports a Redis-style OOM failure.

--- a/internal/command/info.go
+++ b/internal/command/info.go
@@ -1,0 +1,197 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/server"
+	"github.com/maltemindedal/runedb/internal/storage"
+)
+
+func (e *Executor) handleInfo(_ context.Context, request *Request) (protocol.Value, error) {
+	sections := []string{"memory", "replication", "clients"}
+	if len(request.Args) == 1 {
+		section := strings.ToLower(string(request.Args[0]))
+		switch section {
+		case "default", "all":
+			// Keep all implemented sections.
+		case "memory", "replication", "clients":
+			sections = []string{section}
+		default:
+			return nil, ErrSyntaxError()
+		}
+	}
+
+	var buf bytes.Buffer
+	for i, section := range sections {
+		if i > 0 {
+			buf.WriteString("\r\n")
+		}
+		switch section {
+		case "memory":
+			e.appendInfoMemory(&buf)
+		case "replication":
+			e.appendInfoReplication(&buf)
+		case "clients":
+			e.appendInfoClients(&buf)
+		}
+	}
+
+	return protocol.TextBulkString{Value: buf.String()}, nil
+}
+
+func validateInfoRequest(request *Request) error {
+	if len(request.Args) > 1 {
+		return wrongNumberOfArgumentsError("INFO")
+	}
+	return nil
+}
+
+func (e *Executor) appendInfoMemory(buf *bytes.Buffer) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	keyStats := storage.KeyStats{ByKind: make(map[storage.ValueKind]int)}
+	if e.store != nil {
+		keyStats = e.store.KeyStats()
+	}
+	usedMemory := int64(0)
+	maxMemory := int64(0)
+	if e.store != nil {
+		usedMemory = e.store.UsedMemory()
+		maxMemory = e.store.MaxMemory()
+	}
+
+	buf.WriteString("# Memory\r\n")
+	appendInfoField(buf, "used_memory", usedMemory)
+	appendInfoField(buf, "used_memory_human", humanBytes(uint64(max(usedMemory, 0))))
+	appendInfoField(buf, "maxmemory", maxMemory)
+	appendInfoField(buf, "maxmemory_human", humanBytes(uint64(max(maxMemory, 0))))
+	appendInfoField(buf, "mem_fragmentation_ratio", "1.00")
+	appendInfoField(buf, "go_heap_alloc", mem.HeapAlloc)
+	appendInfoField(buf, "go_heap_sys", mem.HeapSys)
+	appendInfoField(buf, "go_heap_idle", mem.HeapIdle)
+	appendInfoField(buf, "key_count", keyStats.TotalKeys)
+
+	kinds := []storage.ValueKind{
+		storage.ValueKindString,
+		storage.ValueKindList,
+		storage.ValueKindHash,
+		storage.ValueKindSet,
+		storage.ValueKindZSet,
+		storage.ValueKindStream,
+	}
+	for _, kind := range kinds {
+		appendInfoField(buf, "key_count_"+string(kind), keyStats.ByKind[kind])
+	}
+}
+
+func (e *Executor) appendInfoReplication(buf *bytes.Buffer) {
+	stats := e.serverStats()
+
+	buf.WriteString("# Replication\r\n")
+	appendInfoField(buf, "role", stats.Role)
+	appendInfoField(buf, "master_replid", stats.MasterReplicationID)
+	appendInfoField(buf, "master_repl_offset", stats.MasterOffset)
+	appendInfoField(buf, "slave_repl_offset", stats.ReplicaOffset)
+	appendInfoField(buf, "connected_slaves", len(stats.Replicas))
+
+	replicas := append([]serverReplicaInfo(nil), stats.Replicas...)
+	sort.Slice(replicas, func(i, j int) bool { return replicas[i].ID < replicas[j].ID })
+	for i, replica := range replicas {
+		appendInfoField(buf, fmt.Sprintf("slave%d", i), fmt.Sprintf("id=%d,port=%d,offset=%d", replica.ID, replica.ListeningPort, replica.AckOffset))
+	}
+}
+
+func (e *Executor) appendInfoClients(buf *bytes.Buffer) {
+	stats := e.serverStats()
+
+	buf.WriteString("# Clients\r\n")
+	appendInfoField(buf, "connected_clients", stats.ConnectedClients)
+	appendInfoField(buf, "monitoring_clients", stats.MonitoringClients)
+	appendInfoField(buf, "total_commands_processed", stats.CommandsProcessed)
+}
+
+func (e *Executor) serverStats() commandServerStats {
+	if e.serverStatsProvider == nil {
+		return commandServerStats{Role: "master"}
+	}
+	stats := e.serverStatsProvider()
+	return commandServerStats{
+		ConnectedClients:    stats.ConnectedClients,
+		MonitoringClients:   stats.MonitoringClients,
+		CommandsProcessed:   stats.CommandsProcessed,
+		Role:                stats.Role,
+		MasterReplicationID: stats.MasterReplicationID,
+		MasterOffset:        stats.MasterOffset,
+		ReplicaOffset:       stats.ReplicaOffset,
+		Replicas:            toCommandReplicaInfo(stats.Replicas),
+	}
+}
+
+type commandServerStats struct {
+	ConnectedClients    int
+	MonitoringClients   int
+	CommandsProcessed   int64
+	Role                string
+	MasterReplicationID string
+	MasterOffset        int64
+	ReplicaOffset       int64
+	Replicas            []serverReplicaInfo
+}
+
+type serverReplicaInfo struct {
+	ID            uint64
+	ListeningPort int
+	AckOffset     int64
+}
+
+func toCommandReplicaInfo(replicas []server.ReplicaInfo) []serverReplicaInfo {
+	converted := make([]serverReplicaInfo, 0, len(replicas))
+	for _, replica := range replicas {
+		converted = append(converted, serverReplicaInfo{ID: replica.ID, ListeningPort: replica.ListeningPort, AckOffset: replica.AckOffset})
+	}
+	return converted
+}
+
+func appendInfoField(buf *bytes.Buffer, name string, value any) {
+	buf.WriteString(name)
+	buf.WriteByte(':')
+	buf.WriteString(infoValueString(value))
+	buf.WriteString("\r\n")
+}
+
+func infoValueString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case uint64:
+		return strconv.FormatUint(typed, 10)
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func humanBytes(value uint64) string {
+	const unit = 1024
+	if value < unit {
+		return fmt.Sprintf("%dB", value)
+	}
+	divisor := uint64(unit)
+	unitIndex := 0
+	for n := value / unit; n >= unit && unitIndex < 4; n /= unit {
+		divisor *= unit
+		unitIndex++
+	}
+	return fmt.Sprintf("%.2f%c", float64(value)/float64(divisor), "KMGTP"[unitIndex])
+}

--- a/internal/command/monitor.go
+++ b/internal/command/monitor.go
@@ -1,0 +1,31 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+)
+
+func (e *Executor) handleMonitor(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 0 {
+		return nil, wrongNumberOfArgumentsError("MONITOR")
+	}
+
+	state, err := clientStateFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if state.InTransactionActive() {
+		return nil, fmt.Errorf("MONITOR inside MULTI is not allowed")
+	}
+	if state.IsSubscribed() {
+		return nil, ErrSubscribedModeOnlyError()
+	}
+	if e.monitorRegistry == nil {
+		return nil, fmt.Errorf("monitor registry unavailable")
+	}
+
+	state.StartMonitoring()
+	return protocol.SimpleString{Value: "OK"}, nil
+}

--- a/internal/command/slowlog.go
+++ b/internal/command/slowlog.go
@@ -102,8 +102,24 @@ func requestTokens(request *Request) []string {
 
 	tokens := make([]string, 0, len(request.Args)+1)
 	tokens = append(tokens, request.Name)
+	if isSensitiveSlowlogCommand(request.Name) {
+		for range request.Args {
+			tokens = append(tokens, "[redacted]")
+		}
+		return tokens
+	}
+
 	for _, arg := range request.Args {
 		tokens = append(tokens, string(arg))
 	}
 	return tokens
+}
+
+func isSensitiveSlowlogCommand(name string) bool {
+	switch name {
+	case "AUTH":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/command/slowlog.go
+++ b/internal/command/slowlog.go
@@ -1,0 +1,109 @@
+package command
+
+import (
+	"context"
+	"strings"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+	"github.com/maltemindedal/runedb/internal/server"
+)
+
+func (e *Executor) handleSlowlog(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) == 0 {
+		return nil, wrongNumberOfArgumentsError("SLOWLOG")
+	}
+
+	subcommand := strings.ToUpper(string(request.Args[0]))
+	switch subcommand {
+	case "GET":
+		limit := -1
+		if len(request.Args) == 2 {
+			parsed, err := parseIntegerArgument(request.Args[1])
+			if err != nil || parsed < 0 {
+				return nil, ErrValueNotIntegerError()
+			}
+			limit = int(parsed)
+		}
+		return slowlogEntriesResponse(e.slowlogEntries(limit)), nil
+	case "LEN":
+		if e.slowlogRegistry == nil {
+			return protocol.Integer{Value: 0}, nil
+		}
+		return protocol.Integer{Value: int64(e.slowlogRegistry.Len())}, nil
+	case "RESET":
+		if e.slowlogRegistry != nil {
+			e.slowlogRegistry.Reset()
+		}
+		return protocol.SimpleString{Value: "OK"}, nil
+	default:
+		return nil, ErrSyntaxError()
+	}
+}
+
+func validateSlowlogRequest(request *Request) error {
+	if len(request.Args) == 0 {
+		return wrongNumberOfArgumentsError("SLOWLOG")
+	}
+
+	subcommand := strings.ToUpper(string(request.Args[0]))
+	switch subcommand {
+	case "GET":
+		if len(request.Args) > 2 {
+			return wrongNumberOfArgumentsError("SLOWLOG")
+		}
+		if len(request.Args) == 2 {
+			parsed, err := parseIntegerArgument(request.Args[1])
+			if err != nil || parsed < 0 {
+				return ErrValueNotIntegerError()
+			}
+		}
+	case "LEN", "RESET":
+		if len(request.Args) != 1 {
+			return wrongNumberOfArgumentsError("SLOWLOG")
+		}
+	default:
+		return ErrSyntaxError()
+	}
+	return nil
+}
+
+func (e *Executor) slowlogEntries(limit int) []server.SlowlogEntry {
+	if e.slowlogRegistry == nil {
+		return nil
+	}
+	return e.slowlogRegistry.Entries(limit)
+}
+
+func slowlogEntriesResponse(entries []server.SlowlogEntry) protocol.Array {
+	elements := make([]protocol.Value, 0, len(entries))
+	for _, entry := range entries {
+		argv := make([]protocol.Value, 0, len(entry.Command))
+		for _, token := range entry.Command {
+			argv = append(argv, protocol.TextBulkString{Value: token})
+		}
+
+		elements = append(elements, protocol.Array{Elements: []protocol.Value{
+			protocol.Integer{Value: entry.ID},
+			protocol.Integer{Value: entry.Timestamp.Unix()},
+			protocol.Integer{Value: entry.Duration.Microseconds()},
+			protocol.Array{Elements: argv},
+			protocol.TextBulkString{Value: entry.ClientAddr},
+			protocol.TextBulkString{Value: ""},
+		}})
+	}
+
+	return protocol.Array{Elements: elements}
+}
+
+func requestTokens(request *Request) []string {
+	if request == nil {
+		return nil
+	}
+
+	tokens := make([]string, 0, len(request.Args)+1)
+	tokens = append(tokens, request.Name)
+	for _, arg := range request.Args {
+		tokens = append(tokens, string(arg))
+	}
+	return tokens
+}

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/maltemindedal/runedb/internal/protocol"
 	"github.com/maltemindedal/runedb/internal/server"
@@ -44,15 +45,19 @@ type executionEffectsContextKey struct{}
 
 // Executor routes protocol frames to concrete command handlers.
 type Executor struct {
-	store          *storage.Store
-	logger         *slog.Logger
-	watchRegistry  *server.WatchRegistry
-	pubSubRegistry *server.PubSubRegistry
-	requirePass    string
-	commands       map[string]commandSpec
-	replication    *server.ReplicationState
-	replicaPeers   *server.ReplicaRegistry
-	aofRewrite     func(context.Context) error
+	store               *storage.Store
+	logger              *slog.Logger
+	watchRegistry       *server.WatchRegistry
+	pubSubRegistry      *server.PubSubRegistry
+	requirePass         string
+	commands            map[string]commandSpec
+	replication         *server.ReplicationState
+	replicaPeers        *server.ReplicaRegistry
+	monitorRegistry     *server.MonitorRegistry
+	slowlogRegistry     *server.SlowlogRegistry
+	slowlogThreshold    time.Duration
+	serverStatsProvider func() server.ServerStats
+	aofRewrite          func(context.Context) error
 }
 
 // NewExecutor constructs a command executor with the currently supported command set.
@@ -97,6 +102,22 @@ func (e *Executor) SetAOFRewriteTrigger(trigger func(context.Context) error) {
 	e.aofRewrite = trigger
 }
 
+// SetSlowlogConfig injects the shared slowlog registry and execution threshold.
+func (e *Executor) SetSlowlogConfig(registry *server.SlowlogRegistry, threshold time.Duration) {
+	e.slowlogRegistry = registry
+	e.slowlogThreshold = threshold
+}
+
+// SetMonitorRegistry injects the shared MONITOR fan-out registry.
+func (e *Executor) SetMonitorRegistry(registry *server.MonitorRegistry) {
+	e.monitorRegistry = registry
+}
+
+// SetServerStatsProvider injects a snapshot provider used by INFO.
+func (e *Executor) SetServerStatsProvider(provider func() server.ServerStats) {
+	e.serverStatsProvider = provider
+}
+
 // Execute dispatches a parsed RESP frame to its command handler.
 func (e *Executor) Execute(ctx context.Context, value protocol.Value) (protocol.Value, error) {
 	result, err := e.ExecuteDetailed(ctx, value)
@@ -122,6 +143,10 @@ func (e *Executor) ExecuteDetailed(ctx context.Context, value protocol.Value) (s
 
 func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request, allowQueue bool) (server.ExecuteResult, error) {
 	ctx, effects := withExecutionEffects(ctx)
+	startedAt := time.Now()
+	defer func() {
+		e.recordSlowCommand(ctx, request, startedAt, time.Since(startedAt))
+	}()
 
 	if err := e.validateSubscriptionContext(ctx, request); err != nil {
 		return server.ExecuteResult{}, err
@@ -492,6 +517,19 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:  e.handleBGRewriteAOF,
 			validate: exactArgsValidator("BGREWRITEAOF", 0),
 		},
+		"INFO": {
+			handler:  e.handleInfo,
+			validate: validateInfoRequest,
+		},
+		"SLOWLOG": {
+			handler:  e.handleSlowlog,
+			validate: validateSlowlogRequest,
+		},
+		"MONITOR": {
+			handler:            e.handleMonitor,
+			validate:           exactArgsValidator("MONITOR", 0),
+			transactionControl: true,
+		},
 	}
 }
 
@@ -504,8 +542,28 @@ func (e *Executor) validateSubscriptionContext(ctx context.Context, request *Req
 	if state.IsSubscribed() && !isAllowedSubscribedModeCommand(request.Name) {
 		return ErrSubscribedModeOnlyError()
 	}
+	if state.IsMonitoring() && !isAllowedMonitoringModeCommand(request.Name) {
+		return ErrMonitorModeOnlyError()
+	}
 
 	return nil
+}
+
+func (e *Executor) recordSlowCommand(ctx context.Context, request *Request, timestamp time.Time, duration time.Duration) {
+	if e.slowlogRegistry == nil || request == nil || e.slowlogThreshold < 0 || duration < e.slowlogThreshold || server.IsReplicationOrigin(ctx) {
+		return
+	}
+
+	entry := server.SlowlogEntry{
+		Timestamp: timestamp,
+		Duration:  duration,
+		Command:   requestTokens(request),
+	}
+	if state, ok := server.ClientStateFromContext(ctx); ok && state != nil {
+		entry.ClientID = state.ID
+		entry.ClientAddr = state.RemoteAddress()
+	}
+	e.slowlogRegistry.Record(entry)
 }
 
 func (e *Executor) validateAuthContext(ctx context.Context, request *Request) error {
@@ -548,6 +606,10 @@ func isAllowedSubscribedModeCommand(name string) bool {
 	default:
 		return false
 	}
+}
+
+func isAllowedMonitoringModeCommand(name string) bool {
+	return name == "PING"
 }
 
 func exactArgsValidator(name string, count int) commandValidator {

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -143,10 +143,6 @@ func (e *Executor) ExecuteDetailed(ctx context.Context, value protocol.Value) (s
 
 func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request, allowQueue bool) (server.ExecuteResult, error) {
 	ctx, effects := withExecutionEffects(ctx)
-	startedAt := time.Now()
-	defer func() {
-		e.recordSlowCommand(ctx, request, startedAt, time.Since(startedAt))
-	}()
 
 	if err := e.validateSubscriptionContext(ctx, request); err != nil {
 		return server.ExecuteResult{}, err
@@ -168,11 +164,19 @@ func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request,
 	if !ok {
 		return server.ExecuteResult{}, ErrUnknownCommand(request.Name)
 	}
+	if spec.validate != nil {
+		if err := spec.validate(request); err != nil {
+			return server.ExecuteResult{}, err
+		}
+	}
+
+	startedAt := time.Now()
 	if spec.detailed != nil {
 		result, err := spec.detailed(ctx, request)
 		if err != nil {
 			return server.ExecuteResult{}, err
 		}
+		e.recordSlowCommand(ctx, request, startedAt, time.Since(startedAt))
 		result.Propagation = append(result.Propagation, effects.propagation...)
 		result.Durability = append(result.Durability, effects.durability...)
 		return result, nil
@@ -185,6 +189,7 @@ func (e *Executor) executeRequestDetailed(ctx context.Context, request *Request,
 	if err != nil {
 		return server.ExecuteResult{}, err
 	}
+	e.recordSlowCommand(ctx, request, startedAt, time.Since(startedAt))
 
 	propagation, durability := executionFrames(ctx, request, spec)
 	result := server.SingleResponse(response)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,42 +5,45 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 // Config contains the runtime settings for the RuneDB server.
 type Config struct {
-	Host               string
-	Port               int
-	LogLevel           string
-	EvictionInterval   time.Duration
-	EvictionSampleSize int
-	RDBPath            string
-	DumpPath           string
-	AOFPath            string
-	AppendFsync        string
-	ReplicaOf          string
-	MasterAuth         string
-	RequirePass        string
-	MaxMemory          int64
+	Host                 string
+	Port                 int
+	LogLevel             string
+	EvictionInterval     time.Duration
+	EvictionSampleSize   int
+	RDBPath              string
+	DumpPath             string
+	AOFPath              string
+	AppendFsync          string
+	ReplicaOf            string
+	MasterAuth           string
+	RequirePass          string
+	MaxMemory            int64
+	SlowlogLogSlowerThan time.Duration
 }
 
 // Default returns the default runtime configuration for local development.
 func Default() Config {
 	return Config{
-		Host:               "",
-		Port:               6379,
-		LogLevel:           "info",
-		EvictionInterval:   100 * time.Millisecond,
-		EvictionSampleSize: 20,
-		RDBPath:            "",
-		DumpPath:           "dump.rdb",
-		AOFPath:            "",
-		AppendFsync:        "everysec",
-		ReplicaOf:          "",
-		MasterAuth:         "",
-		MaxMemory:          0,
+		Host:                 "",
+		Port:                 6379,
+		LogLevel:             "info",
+		EvictionInterval:     100 * time.Millisecond,
+		EvictionSampleSize:   20,
+		RDBPath:              "",
+		DumpPath:             "dump.rdb",
+		AOFPath:              "",
+		AppendFsync:          "everysec",
+		ReplicaOf:            "",
+		MasterAuth:           "",
+		MaxMemory:            0,
+		SlowlogLogSlowerThan: 10 * time.Millisecond,
 	}
 }
 
@@ -71,6 +74,15 @@ func parseFlags(fs *flag.FlagSet, args []string) (Config, error) {
 	fs.StringVar(&cfg.ReplicaOf, "replicaof", cfg.ReplicaOf, "optional master address in host:port form for replica mode")
 	fs.StringVar(&cfg.MasterAuth, "masterauth", cfg.MasterAuth, "optional password used by replica mode to AUTH against a protected master")
 	fs.StringVar(&cfg.RequirePass, "requirepass", cfg.RequirePass, "optional password required for AUTH-protected client commands")
+	fs.Func("slowlog-log-slower-than", "slow query threshold in microseconds; 0 logs all commands and negative disables slowlog", func(value string) error {
+		threshold, err := parseSlowlogThreshold(value)
+		if err != nil {
+			return err
+		}
+
+		cfg.SlowlogLogSlowerThan = threshold
+		return nil
+	})
 	fs.Func("appendfsync", "appendfsync policy: always, everysec, no", func(value string) error {
 		normalized, err := normalizeAppendFsync(value)
 		if err != nil {
@@ -131,4 +143,16 @@ func normalizeAppendFsync(value string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid appendfsync policy %q: expected always, everysec, or no", value)
 	}
+}
+
+func parseSlowlogThreshold(value string) (time.Duration, error) {
+	micros, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid slowlog-log-slower-than %q: expected integer microseconds", value)
+	}
+	if micros < 0 {
+		return -1, nil
+	}
+
+	return time.Duration(micros) * time.Microsecond, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"io"
 	"testing"
+	"time"
 )
 
 func TestDefaultIncludesShutdownSnapshotPath(t *testing.T) {
@@ -20,6 +21,9 @@ func TestDefaultIncludesShutdownSnapshotPath(t *testing.T) {
 	}
 	if cfg.MaxMemory != 0 {
 		t.Fatalf("MaxMemory = %d, want 0", cfg.MaxMemory)
+	}
+	if cfg.SlowlogLogSlowerThan != 10*time.Millisecond {
+		t.Fatalf("SlowlogLogSlowerThan = %v, want %v", cfg.SlowlogLogSlowerThan, 10*time.Millisecond)
 	}
 }
 
@@ -43,6 +47,41 @@ func TestParseFlags(t *testing.T) {
 		}
 		if cfg.MaxMemory != 2048 {
 			t.Fatalf("MaxMemory = %d, want 2048", cfg.MaxMemory)
+		}
+	})
+
+	t.Run("parses slowlog threshold as microseconds", func(t *testing.T) {
+		fs := flag.NewFlagSet("runedb-test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+
+		cfg, err := parseFlags(fs, []string{"--slowlog-log-slower-than", "2500"})
+		if err != nil {
+			t.Fatalf("parseFlags() error = %v", err)
+		}
+		if cfg.SlowlogLogSlowerThan != 2500*time.Microsecond {
+			t.Fatalf("SlowlogLogSlowerThan = %v, want %v", cfg.SlowlogLogSlowerThan, 2500*time.Microsecond)
+		}
+	})
+
+	t.Run("accepts negative slowlog threshold to disable", func(t *testing.T) {
+		fs := flag.NewFlagSet("runedb-test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+
+		cfg, err := parseFlags(fs, []string{"--slowlog-log-slower-than", "-1"})
+		if err != nil {
+			t.Fatalf("parseFlags() error = %v", err)
+		}
+		if cfg.SlowlogLogSlowerThan >= 0 {
+			t.Fatalf("SlowlogLogSlowerThan = %v, want disabled negative duration", cfg.SlowlogLogSlowerThan)
+		}
+	})
+
+	t.Run("rejects non-integer slowlog threshold", func(t *testing.T) {
+		fs := flag.NewFlagSet("runedb-test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+
+		if _, err := parseFlags(fs, []string{"--slowlog-log-slower-than", "10ms"}); err == nil {
+			t.Fatal("parseFlags() error = nil, want invalid slowlog threshold failure")
 		}
 	})
 

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -19,7 +19,8 @@ type QueuedCommand struct {
 
 // ClientState holds connection-scoped state for auth and transaction features.
 type ClientState struct {
-	ID uint64
+	ID         uint64
+	RemoteAddr string
 
 	mu         sync.RWMutex
 	responseMu sync.Mutex
@@ -31,11 +32,13 @@ type ClientState struct {
 	// client-local subscribedChannels set via ClientState.mu.
 	pubSubRegistry     *PubSubRegistry
 	subscribedChannels map[string]struct{}
+	monitorRegistry    *MonitorRegistry
 	responseWriter     *bufio.Writer
 	writerClosed       bool
 
 	Authenticated     bool
 	Replica           bool
+	Monitoring        bool
 	ReplicaListenPort int
 	LastWriteOffset   int64
 	InTransaction     bool
@@ -97,6 +100,14 @@ func (s *ClientState) SetPubSubRegistry(registry *PubSubRegistry) {
 	}
 }
 
+// SetMonitorRegistry binds the shared MONITOR fan-out registry to the client state.
+func (s *ClientState) SetMonitorRegistry(registry *MonitorRegistry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.monitorRegistry = registry
+}
+
 // BindResponseWriter binds the connection-scoped writer used for command
 // replies, async push messages, and replica propagation. All writes for a
 // given connection must flow through this writer to avoid interleaving.
@@ -134,6 +145,7 @@ func (s *ClientState) Disconnect() {
 	s.responseMu.Unlock()
 
 	s.ResetTransaction()
+	s.StopMonitoring()
 	s.UnsubscribeAll()
 	s.UnwatchAll()
 }
@@ -144,6 +156,22 @@ func (s *ClientState) SetAuthenticated(authenticated bool) {
 	defer s.mu.Unlock()
 
 	s.Authenticated = authenticated
+}
+
+// SetRemoteAddr records the client's network address for observability output.
+func (s *ClientState) SetRemoteAddr(addr string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.RemoteAddr = addr
+}
+
+// RemoteAddress returns the client's recorded network address.
+func (s *ClientState) RemoteAddress() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.RemoteAddr
 }
 
 // IsAuthenticated reports whether the client has successfully authenticated.
@@ -220,6 +248,41 @@ func (s *ClientState) IsReplica() bool {
 	defer s.mu.RUnlock()
 
 	return s.Replica
+}
+
+// StartMonitoring registers the client for MONITOR event fan-out.
+func (s *ClientState) StartMonitoring() {
+	s.mu.RLock()
+	registry := s.monitorRegistry
+	s.mu.RUnlock()
+
+	if registry == nil {
+		return
+	}
+
+	registry.Subscribe(s)
+}
+
+// StopMonitoring unregisters the client from MONITOR event fan-out.
+func (s *ClientState) StopMonitoring() {
+	s.mu.RLock()
+	registry := s.monitorRegistry
+	s.mu.RUnlock()
+
+	if registry == nil {
+		s.setMonitoring(false)
+		return
+	}
+
+	registry.Unsubscribe(s)
+}
+
+// IsMonitoring reports whether the client is currently in MONITOR mode.
+func (s *ClientState) IsMonitoring() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Monitoring
 }
 
 // SetLastWriteReplicationOffset records the replication offset produced by the
@@ -420,6 +483,13 @@ func (s *ClientState) removeSubscribedChannel(channel string) {
 	defer s.mu.Unlock()
 
 	delete(s.subscribedChannels, channel)
+}
+
+func (s *ClientState) setMonitoring(monitoring bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Monitoring = monitoring
 }
 
 func (s *ClientState) drainWatchedKeys() []string {

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/maltemindedal/runedb/internal/protocol"
 )
@@ -34,6 +36,7 @@ type ClientState struct {
 	subscribedChannels map[string]struct{}
 	monitorRegistry    *MonitorRegistry
 	responseWriter     *bufio.Writer
+	responseConn       net.Conn
 	writerClosed       bool
 
 	Authenticated     bool
@@ -119,6 +122,15 @@ func (s *ClientState) BindResponseWriter(writer *bufio.Writer) {
 	s.writerClosed = writer == nil
 }
 
+// BindResponseConn records the underlying connection used by the response
+// writer when one is available.
+func (s *ClientState) BindResponseConn(conn net.Conn) {
+	s.responseMu.Lock()
+	defer s.responseMu.Unlock()
+
+	s.responseConn = conn
+}
+
 // HasActiveResponseWriter reports whether the client can currently receive
 // command replies or async push messages.
 func (s *ClientState) HasActiveResponseWriter() bool {
@@ -142,6 +154,7 @@ func (s *ClientState) Disconnect() {
 	s.responseMu.Lock()
 	s.writerClosed = true
 	s.responseWriter = nil
+	s.responseConn = nil
 	s.responseMu.Unlock()
 
 	s.ResetTransaction()
@@ -216,6 +229,35 @@ func (s *ClientState) WriteEncoded(payload []byte) error {
 	}
 
 	return s.responseWriter.Flush()
+}
+
+// WriteEncodedWithDeadline writes a pre-encoded RESP payload with a temporary
+// write deadline when the underlying connection is known.
+func (s *ClientState) WriteEncodedWithDeadline(payload []byte, timeout time.Duration) error {
+	s.responseMu.Lock()
+	defer s.responseMu.Unlock()
+
+	if s.writerClosed || s.responseWriter == nil {
+		return fmt.Errorf("client response writer unavailable")
+	}
+	deadlineSet := false
+	if s.responseConn != nil && timeout > 0 {
+		if err := s.responseConn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+			return err
+		}
+		deadlineSet = true
+	}
+	_, writeErr := s.responseWriter.Write(payload)
+	if writeErr == nil {
+		writeErr = s.responseWriter.Flush()
+	}
+	if deadlineSet {
+		if clearErr := s.responseConn.SetWriteDeadline(time.Time{}); writeErr == nil {
+			writeErr = clearErr
+		}
+	}
+
+	return writeErr
 }
 
 // SetReplicaListeningPort records the port announced during REPLCONF listening-port.

--- a/internal/server/client_state_test.go
+++ b/internal/server/client_state_test.go
@@ -219,6 +219,28 @@ func TestClientStateDisconnectClearsWriterAndPubSubState(t *testing.T) {
 	}
 }
 
+func TestClientStateWriteEncodedWithDeadlineTimesOut(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		if err := serverConn.Close(); err != nil {
+			t.Errorf("serverConn.Close() error = %v", err)
+		}
+	}()
+	defer func() {
+		if err := clientConn.Close(); err != nil {
+			t.Errorf("clientConn.Close() error = %v", err)
+		}
+	}()
+
+	state := &ClientState{ID: 6, Authenticated: true}
+	state.BindResponseWriter(bufio.NewWriter(serverConn))
+	state.BindResponseConn(serverConn)
+
+	if err := state.WriteEncodedWithDeadline([]byte("+OK\r\n"), 5*time.Millisecond); err == nil {
+		t.Fatal("WriteEncodedWithDeadline() error = nil, want timeout error")
+	}
+}
+
 func TestClientStateLifecycle(t *testing.T) {
 	cfg := config.Default()
 	cfg.RequirePass = "secret"

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -19,6 +19,9 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 
 	if state := s.getClientState(clientID); state != nil {
 		state.BindResponseWriter(writer)
+		if conn.RemoteAddr() != nil {
+			state.SetRemoteAddr(conn.RemoteAddr().String())
+		}
 		ctx = WithClientState(ctx, state)
 	}
 
@@ -59,6 +62,9 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			continue
 		}
 
+		if s.monitorRegistry.HasSubscribers() {
+			s.broadcastMonitorEvent(observeCommand(value, clientID, conn))
+		}
 		result, execErr := s.executor.ExecuteDetailed(ctx, value)
 		if execErr != nil {
 			if errors.Is(execErr, context.Canceled) || errors.Is(execErr, context.DeadlineExceeded) {
@@ -85,6 +91,7 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 			s.registerReplicaPeer(clientID, conn)
 		}
 		s.finalizeMutationEffects(ctx, result.Durability, durabilityPayload, result.Propagation, logger)
+		s.commandsProcessed.Add(1)
 	}
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -19,6 +19,7 @@ func (s *Server) handleConnection(ctx context.Context, clientID uint64, conn net
 
 	if state := s.getClientState(clientID); state != nil {
 		state.BindResponseWriter(writer)
+		state.BindResponseConn(conn)
 		if conn.RemoteAddr() != nil {
 			state.SetRemoteAddr(conn.RemoteAddr().String())
 		}

--- a/internal/server/monitor_registry.go
+++ b/internal/server/monitor_registry.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// MonitorRegistry tracks clients currently receiving MONITOR events.
+type MonitorRegistry struct {
+	mu              sync.RWMutex
+	subscriberCount atomic.Int64
+	subscribers     map[uint64]*ClientState
+}
+
+// NewMonitorRegistry constructs an empty MONITOR subscriber registry.
+func NewMonitorRegistry() *MonitorRegistry {
+	return &MonitorRegistry{subscribers: make(map[uint64]*ClientState)}
+}
+
+// Subscribe registers state for MONITOR fan-out.
+func (r *MonitorRegistry) Subscribe(state *ClientState) {
+	if r == nil || state == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.subscribers[state.ID]; !exists {
+		r.subscriberCount.Add(1)
+	}
+	r.subscribers[state.ID] = state
+	state.setMonitoring(true)
+}
+
+// Unsubscribe removes state from MONITOR fan-out.
+func (r *MonitorRegistry) Unsubscribe(state *ClientState) {
+	if r == nil || state == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.subscribers[state.ID]; exists {
+		delete(r.subscribers, state.ID)
+		r.subscriberCount.Add(-1)
+	}
+	state.setMonitoring(false)
+}
+
+// AppendSubscribers appends a snapshot of monitor clients to dst.
+func (r *MonitorRegistry) AppendSubscribers(dst []*ClientState) []*ClientState {
+	if r == nil {
+		return dst[:0]
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	dst = dst[:0]
+	if cap(dst) < len(r.subscribers) {
+		dst = make([]*ClientState, 0, len(r.subscribers))
+	}
+	for _, state := range r.subscribers {
+		dst = append(dst, state)
+	}
+
+	return dst
+}
+
+// Count reports the number of clients currently in MONITOR mode.
+func (r *MonitorRegistry) Count() int {
+	if r == nil {
+		return 0
+	}
+
+	return int(r.subscriberCount.Load())
+}
+
+// HasSubscribers reports whether any client is currently in MONITOR mode.
+func (r *MonitorRegistry) HasSubscribers() bool {
+	return r != nil && r.subscriberCount.Load() > 0
+}

--- a/internal/server/monitor_registry_test.go
+++ b/internal/server/monitor_registry_test.go
@@ -1,0 +1,69 @@
+package server
+
+import "testing"
+
+func TestMonitorRegistryMaintainsClientStateInvariants(t *testing.T) {
+	t.Run("duplicate subscribe keeps count stable and snapshots detached", func(t *testing.T) {
+		registry := NewMonitorRegistry()
+		state := &ClientState{ID: 1, Authenticated: true}
+		state.SetMonitorRegistry(registry)
+
+		registry.Subscribe(state)
+		registry.Subscribe(state)
+
+		if got := registry.Count(); got != 1 {
+			t.Fatalf("Count() = %d after duplicate Subscribe, want 1", got)
+		}
+		if !registry.HasSubscribers() {
+			t.Fatal("HasSubscribers() = false after Subscribe, want true")
+		}
+		if !state.IsMonitoring() {
+			t.Fatal("IsMonitoring() = false after Subscribe, want true")
+		}
+
+		snapshot := registry.AppendSubscribers(nil)
+		if len(snapshot) != 1 || snapshot[0] != state {
+			t.Fatalf("snapshot = %#v, want one subscribed state", snapshot)
+		}
+
+		snapshot[0] = nil
+		fresh := registry.AppendSubscribers(nil)
+		if len(fresh) != 1 || fresh[0] != state {
+			t.Fatalf("fresh snapshot = %#v, want detached original subscriber", fresh)
+		}
+	})
+
+	t.Run("unsubscribe missing client keeps count stable", func(t *testing.T) {
+		registry := NewMonitorRegistry()
+		state := &ClientState{ID: 2, Authenticated: true}
+		other := &ClientState{ID: 3, Authenticated: true}
+
+		registry.Subscribe(state)
+		registry.Unsubscribe(other)
+
+		if got := registry.Count(); got != 1 {
+			t.Fatalf("Count() = %d after missing Unsubscribe, want 1", got)
+		}
+		if !registry.HasSubscribers() {
+			t.Fatal("HasSubscribers() = false after missing Unsubscribe, want true")
+		}
+	})
+
+	t.Run("unsubscribe last client clears fast-path count", func(t *testing.T) {
+		registry := NewMonitorRegistry()
+		state := &ClientState{ID: 4, Authenticated: true}
+
+		registry.Subscribe(state)
+		registry.Unsubscribe(state)
+
+		if got := registry.Count(); got != 0 {
+			t.Fatalf("Count() = %d after Unsubscribe, want 0", got)
+		}
+		if registry.HasSubscribers() {
+			t.Fatal("HasSubscribers() = true after last Unsubscribe, want false")
+		}
+		if state.IsMonitoring() {
+			t.Fatal("IsMonitoring() = true after Unsubscribe, want false")
+		}
+	})
+}

--- a/internal/server/observability.go
+++ b/internal/server/observability.go
@@ -9,6 +9,8 @@ import (
 	"github.com/maltemindedal/runedb/internal/protocol"
 )
 
+const monitorWriteTimeout = 100 * time.Millisecond
+
 // ServerStats is a snapshot of server-level state used by INFO.
 type ServerStats struct {
 	ConnectedClients    int
@@ -93,7 +95,7 @@ func (s *Server) broadcastMonitorEvent(command observedCommand) {
 		if subscriber == nil {
 			continue
 		}
-		if err := subscriber.WriteEncoded(payload); err != nil {
+		if err := subscriber.WriteEncodedWithDeadline(payload, monitorWriteTimeout); err != nil {
 			s.logger.Warn("failed to deliver monitor event", "subscriber_id", subscriber.ID, "error", err)
 			subscriber.Disconnect()
 		}

--- a/internal/server/observability.go
+++ b/internal/server/observability.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/maltemindedal/runedb/internal/protocol"
+)
+
+// ServerStats is a snapshot of server-level state used by INFO.
+type ServerStats struct {
+	ConnectedClients    int
+	MonitoringClients   int
+	CommandsProcessed   int64
+	Role                string
+	MasterReplicationID string
+	MasterOffset        int64
+	ReplicaOffset       int64
+	Replicas            []ReplicaInfo
+}
+
+// ReplicaInfo describes one connected replica peer for INFO replication.
+type ReplicaInfo struct {
+	ID            uint64
+	ListeningPort int
+	AckOffset     int64
+}
+
+type observedCommand struct {
+	OK         bool
+	Parts      []string
+	ClientID   uint64
+	ClientAddr string
+	Timestamp  time.Time
+}
+
+func observeCommand(value protocol.Value, clientID uint64, conn net.Conn) observedCommand {
+	parts, ok := commandParts(value)
+	if !ok {
+		return observedCommand{}
+	}
+	if len(parts) > 0 {
+		parts[0] = strings.ToUpper(parts[0])
+	}
+
+	addr := ""
+	if conn != nil && conn.RemoteAddr() != nil {
+		addr = conn.RemoteAddr().String()
+	}
+
+	return observedCommand{
+		OK:         true,
+		Parts:      parts,
+		ClientID:   clientID,
+		ClientAddr: addr,
+		Timestamp:  time.Now(),
+	}
+}
+
+func commandParts(value protocol.Value) ([]string, bool) {
+	array, ok := value.(protocol.Array)
+	if !ok || array.Null || len(array.Elements) == 0 {
+		return nil, false
+	}
+
+	parts := make([]string, 0, len(array.Elements))
+	for _, element := range array.Elements {
+		raw, err := protocol.Bytes(element)
+		if err != nil {
+			return nil, false
+		}
+		parts = append(parts, string(raw))
+	}
+
+	return parts, true
+}
+
+func (s *Server) broadcastMonitorEvent(command observedCommand) {
+	if s == nil || s.monitorRegistry == nil || !command.OK {
+		return
+	}
+
+	payload, err := protocol.Encode(protocol.SimpleString{Value: monitorLine(command)})
+	if err != nil {
+		s.logger.Warn("failed to encode monitor event", "error", err)
+		return
+	}
+
+	subscribers := s.monitorRegistry.AppendSubscribers(nil)
+	for _, subscriber := range subscribers {
+		if subscriber == nil {
+			continue
+		}
+		if err := subscriber.WriteEncoded(payload); err != nil {
+			s.logger.Warn("failed to deliver monitor event", "subscriber_id", subscriber.ID, "error", err)
+			subscriber.Disconnect()
+		}
+	}
+}
+
+func monitorLine(command observedCommand) string {
+	seconds := command.Timestamp.Unix()
+	micros := command.Timestamp.Nanosecond() / int(time.Microsecond)
+	var b strings.Builder
+	b.WriteString(strconv.FormatInt(seconds, 10))
+	b.WriteByte('.')
+	microText := strconv.Itoa(micros)
+	for i := len(microText); i < 6; i++ {
+		b.WriteByte('0')
+	}
+	b.WriteString(microText)
+	b.WriteString(" [")
+	b.WriteString(strconv.FormatUint(command.ClientID, 10))
+	b.WriteByte(' ')
+	b.WriteString(command.ClientAddr)
+	b.WriteByte(']')
+	for _, part := range command.Parts {
+		b.WriteByte(' ')
+		b.WriteString(strconv.QuoteToASCII(part))
+	}
+
+	return b.String()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/maltemindedal/runedb/internal/aof"
 	"github.com/maltemindedal/runedb/internal/config"
@@ -43,6 +45,18 @@ type aofRewriteTriggerSetter interface {
 	SetAOFRewriteTrigger(func(context.Context) error)
 }
 
+type slowlogConfigSetter interface {
+	SetSlowlogConfig(*SlowlogRegistry, time.Duration)
+}
+
+type monitorRegistrySetter interface {
+	SetMonitorRegistry(*MonitorRegistry)
+}
+
+type serverStatsProviderSetter interface {
+	SetServerStatsProvider(func() ServerStats)
+}
+
 type temporaryError interface {
 	error
 	Temporary() bool
@@ -50,17 +64,20 @@ type temporaryError interface {
 
 // Server owns the TCP listener, active clients, and command execution pipeline.
 type Server struct {
-	cfg            config.Config
-	logger         *slog.Logger
-	store          *storage.Store
-	executor       executor
-	registry       *Registry
-	replicaPeers   *ReplicaRegistry
-	watchRegistry  *WatchRegistry
-	pubSubRegistry *PubSubRegistry
-	replication    *ReplicationState
-	aofWriter      *aof.Writer
-	runtimeCtx     context.Context
+	cfg               config.Config
+	logger            *slog.Logger
+	store             *storage.Store
+	executor          executor
+	registry          *Registry
+	replicaPeers      *ReplicaRegistry
+	watchRegistry     *WatchRegistry
+	pubSubRegistry    *PubSubRegistry
+	monitorRegistry   *MonitorRegistry
+	slowlogRegistry   *SlowlogRegistry
+	replication       *ReplicationState
+	aofWriter         *aof.Writer
+	runtimeCtx        context.Context
+	commandsProcessed atomic.Int64
 
 	clientStates   map[uint64]*ClientState
 	clientStatesMu sync.RWMutex
@@ -77,14 +94,16 @@ type Server struct {
 // New constructs a server ready to listen for TCP clients.
 func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor executor) *Server {
 	srv := &Server{
-		cfg:          cfg,
-		logger:       logger,
-		store:        store,
-		executor:     executor,
-		registry:     NewRegistry(),
-		replicaPeers: NewReplicaRegistry(),
-		replication:  newReplicationState(),
-		clientStates: make(map[uint64]*ClientState),
+		cfg:             cfg,
+		logger:          logger,
+		store:           store,
+		executor:        executor,
+		registry:        NewRegistry(),
+		replicaPeers:    NewReplicaRegistry(),
+		monitorRegistry: NewMonitorRegistry(),
+		slowlogRegistry: NewSlowlogRegistry(),
+		replication:     newReplicationState(),
+		clientStates:    make(map[uint64]*ClientState),
 	}
 	if store != nil {
 		store.SetLogger(logger)
@@ -106,6 +125,15 @@ func New(cfg config.Config, logger *slog.Logger, store *storage.Store, executor 
 	}
 	if setter, ok := executor.(aofRewriteTriggerSetter); ok {
 		setter.SetAOFRewriteTrigger(srv.beginAOFRewrite)
+	}
+	if setter, ok := executor.(slowlogConfigSetter); ok {
+		setter.SetSlowlogConfig(srv.slowlogRegistry, cfg.SlowlogLogSlowerThan)
+	}
+	if setter, ok := executor.(monitorRegistrySetter); ok {
+		setter.SetMonitorRegistry(srv.monitorRegistry)
+	}
+	if setter, ok := executor.(serverStatsProviderSetter); ok {
+		setter.SetServerStatsProvider(srv.ServerStats)
 	}
 
 	return srv
@@ -267,6 +295,7 @@ func (s *Server) createClientState(clientID uint64) *ClientState {
 	}
 	state.SetWatchRegistry(s.watchRegistry)
 	state.SetPubSubRegistry(s.pubSubRegistry)
+	state.SetMonitorRegistry(s.monitorRegistry)
 
 	s.clientStatesMu.Lock()
 	defer s.clientStatesMu.Unlock()
@@ -316,4 +345,37 @@ func (s *Server) clearClientStates() {
 // ReplicaCount returns the number of replica peers connected to this server.
 func (s *Server) ReplicaCount() int {
 	return s.replicaPeers.Count()
+}
+
+// ServerStats returns a snapshot of server-level observability data.
+func (s *Server) ServerStats() ServerStats {
+	if s == nil {
+		return ServerStats{}
+	}
+
+	role := "master"
+	if s.cfg.IsReplica() {
+		role = "slave"
+	}
+
+	replicaPeers := s.replicaPeers.Snapshot()
+	replicas := make([]ReplicaInfo, 0, len(replicaPeers))
+	for _, peer := range replicaPeers {
+		replicas = append(replicas, ReplicaInfo{
+			ID:            peer.ID,
+			ListeningPort: peer.ListeningPort,
+			AckOffset:     peer.AckOffset,
+		})
+	}
+
+	return ServerStats{
+		ConnectedClients:    s.registry.Count(),
+		MonitoringClients:   s.monitorRegistry.Count(),
+		CommandsProcessed:   s.commandsProcessed.Load(),
+		Role:                role,
+		MasterReplicationID: s.replication.MasterReplicationID,
+		MasterOffset:        s.replication.MasterOffset(),
+		ReplicaOffset:       s.replication.ReplicaOffset(),
+		Replicas:            replicas,
+	}
 }

--- a/internal/server/slowlog.go
+++ b/internal/server/slowlog.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const defaultSlowlogCapacity = 128
+
+// SlowlogEntry stores metadata for one command whose execution exceeded the
+// configured slowlog threshold.
+type SlowlogEntry struct {
+	ID         int64
+	Timestamp  time.Time
+	Duration   time.Duration
+	Command    []string
+	ClientID   uint64
+	ClientAddr string
+}
+
+// SlowlogRegistry stores a bounded, thread-safe log of slow commands.
+type SlowlogRegistry struct {
+	mu      sync.RWMutex
+	entries []SlowlogEntry
+	start   int
+	count   int
+	nextID  atomic.Int64
+}
+
+// NewSlowlogRegistry constructs a slowlog registry with Redis' default length.
+func NewSlowlogRegistry() *SlowlogRegistry {
+	return &SlowlogRegistry{entries: make([]SlowlogEntry, defaultSlowlogCapacity)}
+}
+
+// Record appends entry to the bounded log, assigning its monotonic ID.
+func (r *SlowlogRegistry) Record(entry SlowlogEntry) {
+	if r == nil || len(r.entries) == 0 {
+		return
+	}
+
+	entry.ID = r.nextID.Add(1) - 1
+	entry.Command = cloneStringSlice(entry.Command)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	idx := (r.start + r.count) % len(r.entries)
+	if r.count == len(r.entries) {
+		idx = r.start
+		r.start = (r.start + 1) % len(r.entries)
+	} else {
+		r.count++
+	}
+	r.entries[idx] = entry
+}
+
+// Entries returns up to limit entries ordered newest-first. A negative limit
+// returns all retained entries.
+func (r *SlowlogRegistry) Entries(limit int) []SlowlogEntry {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	count := r.count
+	if limit >= 0 && limit < count {
+		count = limit
+	}
+	entries := make([]SlowlogEntry, 0, count)
+	for i := 0; i < count; i++ {
+		idx := (r.start + r.count - 1 - i + len(r.entries)) % len(r.entries)
+		entry := r.entries[idx]
+		entry.Command = cloneStringSlice(entry.Command)
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// Len reports the number of retained slowlog entries.
+func (r *SlowlogRegistry) Len() int {
+	if r == nil {
+		return 0
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.count
+}
+
+// Reset clears all retained slowlog entries while preserving monotonic IDs.
+func (r *SlowlogRegistry) Reset() {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := range r.entries {
+		r.entries[i] = SlowlogEntry{}
+	}
+	r.start = 0
+	r.count = 0
+}
+
+func cloneStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}

--- a/internal/server/slowlog_test.go
+++ b/internal/server/slowlog_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSlowlogRegistry(t *testing.T) {
+	t.Run("retains entries newest first and clones commands", func(t *testing.T) {
+		registry := NewSlowlogRegistry()
+		command := []string{"SET", "name", "RuneDB"}
+		registry.Record(SlowlogEntry{Timestamp: time.Unix(1, 0), Duration: time.Millisecond, Command: command})
+		command[1] = "mutated"
+
+		entries := registry.Entries(-1)
+		if len(entries) != 1 {
+			t.Fatalf("len(entries) = %d, want 1", len(entries))
+		}
+		if entries[0].ID != 0 {
+			t.Fatalf("entry ID = %d, want 0", entries[0].ID)
+		}
+		if got := entries[0].Command[1]; got != "name" {
+			t.Fatalf("command token = %q, want cloned original", got)
+		}
+
+		entries[0].Command[1] = "changed-again"
+		if got := registry.Entries(-1)[0].Command[1]; got != "name" {
+			t.Fatalf("stored command token = %q after caller mutation, want name", got)
+		}
+	})
+
+	t.Run("wraps at fixed capacity", func(t *testing.T) {
+		registry := NewSlowlogRegistry()
+		for i := 0; i < defaultSlowlogCapacity+3; i++ {
+			registry.Record(SlowlogEntry{Command: []string{"PING", fmt.Sprintf("%d", i)}})
+		}
+
+		if got := registry.Len(); got != defaultSlowlogCapacity {
+			t.Fatalf("Len() = %d, want %d", got, defaultSlowlogCapacity)
+		}
+		entries := registry.Entries(2)
+		if len(entries) != 2 {
+			t.Fatalf("len(Entries(2)) = %d, want 2", len(entries))
+		}
+		if entries[0].ID != int64(defaultSlowlogCapacity+2) || entries[1].ID != int64(defaultSlowlogCapacity+1) {
+			t.Fatalf("entry IDs = %d,%d, want newest retained IDs", entries[0].ID, entries[1].ID)
+		}
+	})
+
+	t.Run("reset clears entries", func(t *testing.T) {
+		registry := NewSlowlogRegistry()
+		registry.Record(SlowlogEntry{Command: []string{"PING"}})
+		registry.Reset()
+
+		if got := registry.Len(); got != 0 {
+			t.Fatalf("Len() = %d after Reset, want 0", got)
+		}
+		if got := len(registry.Entries(-1)); got != 0 {
+			t.Fatalf("len(Entries) = %d after Reset, want 0", got)
+		}
+
+		registry.Record(SlowlogEntry{Command: []string{"PING"}})
+		entries := registry.Entries(-1)
+		if len(entries) != 1 {
+			t.Fatalf("len(Entries) = %d after post-reset record, want 1", len(entries))
+		}
+		if got := entries[0].ID; got != 1 {
+			t.Fatalf("post-reset entry ID = %d, want monotonic ID 1", got)
+		}
+	})
+}

--- a/internal/storage/hash.go
+++ b/internal/storage/hash.go
@@ -52,7 +52,7 @@ func (s *Store) HSet(key string, pairs []HashFieldValue) (int64, error) {
 		}
 	} else {
 		newValue := newHashValue(fields, 0)
-		shard.data[key] = newValue
+		s.setKeyLocked(shard, key, newValue)
 		if accounting {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
 		}

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -97,7 +97,7 @@ func (s *Store) SetWithEviction(key string, value []byte, expiresAt int64) ([]st
 		return nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return evicted, nil
 }
@@ -121,7 +121,7 @@ func (s *Store) IncrementWithEviction(key string) (int64, []string, error) {
 			return 0, nil, err
 		}
 
-		shard.data[key] = newValue
+		s.setKeyLocked(shard, key, newValue)
 		s.usedMemory.Add(newSize)
 		return 1, evicted, nil
 	}
@@ -146,7 +146,7 @@ func (s *Store) IncrementWithEviction(key string) (int64, []string, error) {
 		return 0, nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return parsed, evicted, nil
 }
@@ -205,7 +205,7 @@ func (s *Store) ZAddWithEviction(key string, entries []ZSetEntry) (int64, []stri
 		return 0, nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return added, evicted, nil
 }
@@ -254,7 +254,7 @@ func (s *Store) XAddWithEviction(key, rawID string, values [][]byte) (string, []
 		return "", nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return id, evicted, nil
 }
@@ -303,7 +303,7 @@ func (s *Store) HSetWithEviction(key string, pairs []HashFieldValue) (int64, []s
 		return 0, nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return added, evicted, nil
 }
@@ -353,7 +353,7 @@ func (s *Store) SAddWithEviction(key string, members [][]byte) (int64, []string,
 		return 0, nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	return added, evicted, nil
 }
@@ -406,7 +406,7 @@ func (s *Store) pushListWithEviction(key string, values [][]byte, left bool) (in
 		return 0, nil, err
 	}
 
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	s.usedMemory.Add(newSize - oldSize)
 	s.waiters.notifyOne(key)
 	return int64(len(list)), evicted, nil
@@ -470,7 +470,7 @@ func (s *Store) recalculateUsedMemoryLocked(now int64) int64 {
 		shard := &s.shards[i]
 		for key, value := range shard.data {
 			if isExpired(value, now) {
-				delete(shard.data, key)
+				s.removeKeyLocked(shard, key)
 				continue
 			}
 			used += s.approximateValueObjectSize(key, value)
@@ -615,7 +615,7 @@ func (s *Store) deleteKeyWithSizeLocked(shard *Shard, key string, size int64) bo
 	if s.maxMemoryEnabled() {
 		s.usedMemory.Add(-size)
 	}
-	delete(shard.data, key)
+	s.removeKeyLocked(shard, key)
 	return true
 }
 

--- a/internal/storage/set.go
+++ b/internal/storage/set.go
@@ -55,7 +55,7 @@ func (s *Store) SAdd(key string, members [][]byte) (int64, error) {
 		}
 	} else {
 		newValue := newSetValue(set, 0)
-		shard.data[key] = newValue
+		s.setKeyLocked(shard, key, newValue)
 		if accounting {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
 		}

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -1,0 +1,33 @@
+package storage
+
+import "time"
+
+// KeyStats is an approximate snapshot of key counts by value kind.
+type KeyStats struct {
+	TotalKeys int
+	ByKind    map[ValueKind]int
+}
+
+// KeyStats returns a snapshot of non-expired key counts by value kind.
+func (s *Store) KeyStats() KeyStats {
+	stats := KeyStats{ByKind: make(map[ValueKind]int)}
+	if s == nil {
+		return stats
+	}
+
+	now := time.Now().UnixMilli()
+	s.readLockAllShards()
+	defer s.readUnlockAllShards()
+
+	for i := range s.shards {
+		for _, value := range s.shards[i].data {
+			if isExpired(value, now) {
+				continue
+			}
+			stats.TotalKeys++
+			stats.ByKind[value.Kind]++
+		}
+	}
+
+	return stats
+}

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -1,6 +1,15 @@
 package storage
 
-import "time"
+const keyStatsKindCount = 6
+
+var keyStatsKinds = [...]ValueKind{
+	ValueKindString,
+	ValueKindList,
+	ValueKindHash,
+	ValueKindSet,
+	ValueKindZSet,
+	ValueKindStream,
+}
 
 // KeyStats is an approximate snapshot of key counts by value kind.
 type KeyStats struct {
@@ -8,26 +17,76 @@ type KeyStats struct {
 	ByKind    map[ValueKind]int
 }
 
-// KeyStats returns a snapshot of non-expired key counts by value kind.
+// KeyStats returns an approximate snapshot of resident key counts by value kind.
+// Expired keys are reflected once passive or active expiry removes them.
 func (s *Store) KeyStats() KeyStats {
 	stats := KeyStats{ByKind: make(map[ValueKind]int)}
 	if s == nil {
 		return stats
 	}
 
-	now := time.Now().UnixMilli()
-	s.readLockAllShards()
-	defer s.readUnlockAllShards()
-
-	for i := range s.shards {
-		for _, value := range s.shards[i].data {
-			if isExpired(value, now) {
-				continue
-			}
-			stats.TotalKeys++
-			stats.ByKind[value.Kind]++
-		}
+	for i, kind := range keyStatsKinds {
+		count := int(s.keyKindCounts[i].Load())
+		stats.TotalKeys += count
+		stats.ByKind[kind] = count
 	}
 
 	return stats
+}
+
+func (s *Store) setKeyLocked(shard *Shard, key string, value *ValueObject) {
+	if shard == nil || value == nil {
+		return
+	}
+
+	previous := shard.data[key]
+	if previous == nil || previous.Kind != value.Kind {
+		s.adjustKeyKindCount(previous, -1)
+		s.adjustKeyKindCount(value, 1)
+	}
+	shard.data[key] = value
+}
+
+func (s *Store) removeKeyLocked(shard *Shard, key string) {
+	if shard == nil {
+		return
+	}
+
+	previous := shard.data[key]
+	if previous != nil {
+		s.adjustKeyKindCount(previous, -1)
+	}
+	delete(shard.data, key)
+}
+
+func (s *Store) adjustKeyKindCount(value *ValueObject, delta int64) {
+	if s == nil || value == nil || delta == 0 {
+		return
+	}
+	if index, ok := keyStatsKindIndex(value.Kind); ok {
+		s.keyKindCounts[index].Add(delta)
+	}
+}
+
+func (s *Store) recalculateKeyStatsLocked() {
+	var counts [keyStatsKindCount]int64
+	for i := range s.shards {
+		for _, value := range s.shards[i].data {
+			if index, ok := keyStatsKindIndex(value.Kind); ok {
+				counts[index]++
+			}
+		}
+	}
+	for i := range counts {
+		s.keyKindCounts[i].Store(counts[i])
+	}
+}
+
+func keyStatsKindIndex(kind ValueKind) (int, bool) {
+	for i, candidate := range keyStatsKinds {
+		if kind == candidate {
+			return i, true
+		}
+	}
+	return 0, false
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -40,6 +40,7 @@ type Store struct {
 	loggerMu                 sync.RWMutex
 	logger                   *slog.Logger
 	usedMemory               atomic.Int64
+	keyKindCounts            [keyStatsKindCount]atomic.Int64
 	maxMemory                atomic.Int64
 	memoryEvictionSampleSize int
 }
@@ -75,7 +76,7 @@ func (s *Store) Set(key string, value []byte, expiresAt int64) {
 
 	oldSize := s.approximateValueObjectSize(key, current)
 	newValue := newStringValue(value, expiresAt)
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	if s.maxMemoryEnabled() {
 		newSize := s.approximateValueObjectSize(key, newValue)
 		s.usedMemory.Add(newSize - oldSize)
@@ -222,7 +223,7 @@ func (s *Store) Increment(key string) (int64, error) {
 
 	if !ok {
 		newValue := newStringValue([]byte("1"), 0)
-		shard.data[key] = newValue
+		s.setKeyLocked(shard, key, newValue)
 		if s.maxMemoryEnabled() {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
 		}
@@ -515,7 +516,7 @@ func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
 	}
 
 	newValue := newZSetValue(set, expiresAt)
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	if accounting {
 		newSize := s.approximateValueObjectSize(key, newValue)
 		s.usedMemory.Add(newSize - oldSize)
@@ -603,7 +604,7 @@ func (s *Store) XAdd(key, rawID string, values [][]byte) (string, error) {
 	}
 
 	newValue := newStreamValue(stream, expiresAt)
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	if s.maxMemoryEnabled() {
 		newSize := s.approximateValueObjectSize(key, newValue)
 		s.usedMemory.Add(newSize - oldSize)
@@ -756,6 +757,7 @@ func (s *Store) ReplaceWith(other *Store) {
 	for i := range s.shards {
 		s.shards[i].data = replacement[i].data
 	}
+	s.recalculateKeyStatsLocked()
 	if s.maxMemoryEnabled() {
 		s.recalculateUsedMemoryLocked(time.Now().UnixMilli())
 	}
@@ -958,7 +960,7 @@ func (s *Store) pushList(key string, values [][]byte, left bool) (int64, error) 
 	}
 
 	newValue := newListValue(list, expiresAt)
-	shard.data[key] = newValue
+	s.setKeyLocked(shard, key, newValue)
 	if s.maxMemoryEnabled() {
 		newSize := s.approximateValueObjectSize(key, newValue)
 		s.usedMemory.Add(newSize - oldSize)

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -608,6 +608,97 @@ func TestStoreActiveEvictionRemovesExpiredKeys(t *testing.T) {
 	t.Fatalf("Len() = %d, want 0 after active eviction", store.Len())
 }
 
+func TestStoreKeyStatsTracksMutations(t *testing.T) {
+	store := NewStore()
+	store.Set("name", []byte("RuneDB"), 0)
+	if _, err := store.RightPush("jobs", [][]byte{[]byte("build")}); err != nil {
+		t.Fatalf("RightPush() error = %v", err)
+	}
+	if _, err := store.HSet("profile", []HashFieldValue{{Field: "lang", Value: []byte("go")}}); err != nil {
+		t.Fatalf("HSet() error = %v", err)
+	}
+	if _, err := store.SAdd("tags", [][]byte{[]byte("fast")}); err != nil {
+		t.Fatalf("SAdd() error = %v", err)
+	}
+	if _, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("alpha"), Score: 1}}); err != nil {
+		t.Fatalf("ZAdd() error = %v", err)
+	}
+	if _, err := store.XAdd("events", "1-0", [][]byte{[]byte("field"), []byte("value")}); err != nil {
+		t.Fatalf("XAdd() error = %v", err)
+	}
+
+	assertKeyStats(t, store, 6, map[ValueKind]int{
+		ValueKindString: 1,
+		ValueKindList:   1,
+		ValueKindHash:   1,
+		ValueKindSet:    1,
+		ValueKindZSet:   1,
+		ValueKindStream: 1,
+	})
+
+	store.Set("name", []byte("database"), 0)
+	store.Delete("jobs")
+	if _, err := store.HDel("profile", []string{"lang"}); err != nil {
+		t.Fatalf("HDel() error = %v", err)
+	}
+	if _, err := store.SRem("tags", [][]byte{[]byte("fast")}); err != nil {
+		t.Fatalf("SRem() error = %v", err)
+	}
+
+	assertKeyStats(t, store, 3, map[ValueKind]int{
+		ValueKindString: 1,
+		ValueKindZSet:   1,
+		ValueKindStream: 1,
+	})
+
+	store.Set("soon-gone", []byte("ttl"), time.Now().Add(-time.Millisecond).UnixMilli())
+	if _, ok, err := store.Get("soon-gone"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	} else if ok {
+		t.Fatal("Get() ok = true for expired key, want false")
+	}
+
+	assertKeyStats(t, store, 3, map[ValueKind]int{
+		ValueKindString: 1,
+		ValueKindZSet:   1,
+		ValueKindStream: 1,
+	})
+}
+
+func TestStoreKeyStatsRecalculatesAfterReplaceWith(t *testing.T) {
+	store := NewStore()
+	store.Set("old", []byte("value"), 0)
+
+	replacement := NewStore()
+	if _, err := replacement.RightPush("jobs", [][]byte{[]byte("build")}); err != nil {
+		t.Fatalf("RightPush() error = %v", err)
+	}
+	if _, err := replacement.SAdd("tags", [][]byte{[]byte("fast")}); err != nil {
+		t.Fatalf("SAdd() error = %v", err)
+	}
+
+	store.ReplaceWith(replacement)
+
+	assertKeyStats(t, store, 2, map[ValueKind]int{
+		ValueKindList: 1,
+		ValueKindSet:  1,
+	})
+}
+
+func assertKeyStats(t *testing.T, store *Store, total int, byKind map[ValueKind]int) {
+	t.Helper()
+
+	stats := store.KeyStats()
+	if stats.TotalKeys != total {
+		t.Fatalf("KeyStats().TotalKeys = %d, want %d", stats.TotalKeys, total)
+	}
+	for _, kind := range keyStatsKinds {
+		if stats.ByKind[kind] != byKind[kind] {
+			t.Fatalf("KeyStats().ByKind[%s] = %d, want %d (all stats: %+v)", kind, stats.ByKind[kind], byKind[kind], stats.ByKind)
+		}
+	}
+}
+
 func TestStoreSnapshotStrings(t *testing.T) {
 	t.Run("returns defensive copies for supported string keys", func(t *testing.T) {
 		store := NewStore()

--- a/internal/storage/store_test_helpers_test.go
+++ b/internal/storage/store_test_helpers_test.go
@@ -5,7 +5,7 @@ func (s *Store) setValueObjectForTest(key string, value *ValueObject) {
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
-	shard.data[key] = value
+	s.setKeyLocked(shard, key, value)
 }
 
 func (s *Store) expireKeyForTest(key string, expiresAt int64) bool {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -822,6 +823,70 @@ func TestServerPubSubDisconnectCleanup(t *testing.T) {
 		}
 
 		time.Sleep(20 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ListenAndServe() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestServerMonitorStreamsCommands(t *testing.T) {
+	cfg := config.Default()
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 0
+	cfg.LogLevel = "error"
+	cfg.EvictionInterval = 5 * time.Millisecond
+	cfg.EvictionSampleSize = 10
+	cfg.DumpPath = ""
+
+	logger := runedblogger.New(cfg.LogLevel)
+	store := storage.NewStore()
+	executor := command.NewExecutor(store, logger)
+	srv := server.New(cfg, logger, store, executor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe(ctx)
+	}()
+
+	addr := waitForAddr(t, srv)
+	monitorConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) monitor error = %v", addr, err)
+	}
+	defer func() { _ = monitorConn.Close() }()
+	monitorParser := protocol.NewParser(monitorConn)
+	assertCommandResponse(t, monitorConn, monitorParser, protocol.SimpleString{Value: "OK"}, "MONITOR")
+
+	clientConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial(%q) client error = %v", addr, err)
+	}
+	defer func() { _ = clientConn.Close() }()
+	clientParser := protocol.NewParser(clientConn)
+
+	assertCommandResponse(t, clientConn, clientParser, protocol.SimpleString{Value: "OK"}, "SET", "observed", "value")
+	message, err := monitorParser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() monitor message error = %v", err)
+	}
+	line, ok := message.(protocol.SimpleString)
+	if !ok {
+		t.Fatalf("monitor message type = %T, want SimpleString", message)
+	}
+	for _, want := range []string{"\"SET\"", "\"observed\"", "\"value\""} {
+		if !strings.Contains(line.Value, want) {
+			t.Fatalf("monitor line = %q, missing %q", line.Value, want)
+		}
 	}
 
 	cancel()


### PR DESCRIPTION
Implement MONITOR command to allow clients to observe server commands, along with a slowlog feature to track slow commands. Introduce MonitorRegistry and SlowlogRegistry for managing monitoring clients and slow command tracking, respectively. Enhance ClientState and ServerStats to support these features and provide server statistics via the INFO command. Include tests to ensure functionality correctness.