### PR TITLE
Add compact hash and sorted set encodings

### DIFF
--- a/internal/storage/collection_value.go
+++ b/internal/storage/collection_value.go
@@ -1,0 +1,268 @@
+package storage
+
+func (v *ValueObject) hashLen() (int, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return 0, ErrWrongType
+	}
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return 0, errInvalidValueObjectState
+		}
+		return v.CompactHash.len(), nil
+	}
+	if v.Hash == nil {
+		return 0, errInvalidValueObjectState
+	}
+	return len(v.Hash), nil
+}
+
+func (v *ValueObject) hashGet(field string) ([]byte, bool, error) {
+	if v == nil {
+		return nil, false, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return nil, false, ErrWrongType
+	}
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return nil, false, errInvalidValueObjectState
+		}
+		value, ok := v.CompactHash.get(field)
+		return value, ok, nil
+	}
+	if v.Hash == nil {
+		return nil, false, errInvalidValueObjectState
+	}
+	value, ok := v.Hash[field]
+	return value, ok, nil
+}
+
+func (v *ValueObject) hashSet(pairs []HashFieldValue) (int64, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return 0, ErrWrongType
+	}
+
+	added := int64(0)
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return 0, errInvalidValueObjectState
+		}
+		for _, pair := range pairs {
+			if v.CompactHash.set(pair.Field, pair.Value) {
+				added++
+			}
+		}
+		return added, nil
+	}
+
+	if v.Hash == nil {
+		return 0, errInvalidValueObjectState
+	}
+	for _, pair := range pairs {
+		if _, exists := v.Hash[pair.Field]; !exists {
+			added++
+		}
+		v.Hash[pair.Field] = cloneBytes(pair.Value)
+	}
+	return added, nil
+}
+
+func (v *ValueObject) hashDel(fields []string) (int64, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return 0, ErrWrongType
+	}
+
+	removed := int64(0)
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return 0, errInvalidValueObjectState
+		}
+		for _, field := range fields {
+			if v.CompactHash.del(field) {
+				removed++
+			}
+		}
+		return removed, nil
+	}
+
+	if v.Hash == nil {
+		return 0, errInvalidValueObjectState
+	}
+	for _, field := range fields {
+		if _, exists := v.Hash[field]; exists {
+			delete(v.Hash, field)
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+func (v *ValueObject) hashEntries() ([]HashFieldValue, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return nil, ErrWrongType
+	}
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return v.CompactHash.all(), nil
+	}
+	if v.Hash == nil {
+		return nil, errInvalidValueObjectState
+	}
+
+	entries := make([]HashFieldValue, 0, len(v.Hash))
+	for field, raw := range v.Hash {
+		entries = append(entries, HashFieldValue{Field: field, Value: raw})
+	}
+	return entries, nil
+}
+
+func (v *ValueObject) cloneHashValue(expiresAt int64) (*ValueObject, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindHash {
+		return nil, ErrWrongType
+	}
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return newCompactHashValue(cloneCompactHash(v.CompactHash), expiresAt), nil
+	}
+	if v.Hash == nil {
+		return nil, errInvalidValueObjectState
+	}
+
+	fields := make(map[string][]byte, len(v.Hash))
+	for field, raw := range v.Hash {
+		fields[field] = cloneBytes(raw)
+	}
+	return newHashValue(fields, expiresAt), nil
+}
+
+func (v *ValueObject) zsetLen() (int, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindZSet {
+		return 0, ErrWrongType
+	}
+	if v.ZSetEncoding == ValueEncodingCompact {
+		if v.CompactZSet == nil {
+			return 0, errInvalidValueObjectState
+		}
+		return v.CompactZSet.len(), nil
+	}
+	if v.ZSet == nil {
+		return 0, errInvalidValueObjectState
+	}
+	return v.ZSet.len(), nil
+}
+
+func (v *ValueObject) zsetAdd(entries []ZSetEntry) (int64, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindZSet {
+		return 0, ErrWrongType
+	}
+
+	added := int64(0)
+	if v.ZSetEncoding == ValueEncodingCompact {
+		if v.CompactZSet == nil {
+			return 0, errInvalidValueObjectState
+		}
+		for _, entry := range entries {
+			if v.CompactZSet.add(entry.Member, entry.Score) {
+				added++
+			}
+		}
+		return added, nil
+	}
+
+	if v.ZSet == nil {
+		return 0, errInvalidValueObjectState
+	}
+	for _, entry := range entries {
+		if v.ZSet.add(string(entry.Member), entry.Score) {
+			added++
+		}
+	}
+	return added, nil
+}
+
+func (v *ValueObject) zsetRangeByRank(start, stop int) ([]ZSetRangeEntry, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindZSet {
+		return nil, ErrWrongType
+	}
+	if v.ZSetEncoding == ValueEncodingCompact {
+		if v.CompactZSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return v.CompactZSet.rangeByRank(start, stop), nil
+	}
+	if v.ZSet == nil {
+		return nil, errInvalidValueObjectState
+	}
+	return v.ZSet.rangeByRank(start, stop), nil
+}
+
+func (v *ValueObject) cloneZSetValue(expiresAt int64) (*ValueObject, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindZSet {
+		return nil, ErrWrongType
+	}
+	if v.ZSetEncoding == ValueEncodingCompact {
+		if v.CompactZSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return newCompactZSetValue(cloneCompactZSet(v.CompactZSet), expiresAt), nil
+	}
+	if v.ZSet == nil {
+		return nil, errInvalidValueObjectState
+	}
+	return newZSetValue(cloneSortedSet(v.ZSet), expiresAt), nil
+}
+
+func newHashValueForPairs(pairs []HashFieldValue, expiresAt int64) *ValueObject {
+	if len(pairs) <= compactHashMaxEntries {
+		return newCompactHashValue(newCompactHash(pairs), expiresAt)
+	}
+
+	fields := make(map[string][]byte, len(pairs))
+	for _, pair := range pairs {
+		fields[pair.Field] = cloneBytes(pair.Value)
+	}
+	return newHashValue(fields, expiresAt)
+}
+
+func newZSetValueForEntries(entries []ZSetEntry, expiresAt int64) *ValueObject {
+	if len(entries) <= compactZSetMaxEntries {
+		return newCompactZSetValue(newCompactZSet(entries), expiresAt)
+	}
+
+	set := newSortedSet()
+	for _, entry := range entries {
+		set.add(string(entry.Member), entry.Score)
+	}
+	return newZSetValue(set, expiresAt)
+}

--- a/internal/storage/collection_value.go
+++ b/internal/storage/collection_value.go
@@ -244,20 +244,23 @@ func (v *ValueObject) cloneZSetValue(expiresAt int64) (*ValueObject, error) {
 }
 
 func newHashValueForPairs(pairs []HashFieldValue, expiresAt int64) *ValueObject {
-	if len(pairs) <= compactHashMaxEntries {
-		return newCompactHashValue(newCompactHash(pairs), expiresAt)
+	compact := newCompactHash(pairs)
+	if compact.len() <= compactHashMaxEntries {
+		return newCompactHashValue(compact, expiresAt)
 	}
 
-	fields := make(map[string][]byte, len(pairs))
-	for _, pair := range pairs {
-		fields[pair.Field] = cloneBytes(pair.Value)
+	entries := compact.all()
+	fields := make(map[string][]byte, len(entries))
+	for _, entry := range entries {
+		fields[entry.Field] = cloneBytes(entry.Value)
 	}
 	return newHashValue(fields, expiresAt)
 }
 
 func newZSetValueForEntries(entries []ZSetEntry, expiresAt int64) *ValueObject {
-	if len(entries) <= compactZSetMaxEntries {
-		return newCompactZSetValue(newCompactZSet(entries), expiresAt)
+	compact := newCompactZSet(entries)
+	if compact.len() <= compactZSetMaxEntries {
+		return newCompactZSetValue(compact, expiresAt)
 	}
 
 	set := newSortedSet()

--- a/internal/storage/compact_hash.go
+++ b/internal/storage/compact_hash.go
@@ -1,0 +1,141 @@
+package storage
+
+const compactHashMaxEntries = 8
+
+type compactHashEntry struct {
+	fieldStart int
+	fieldLen   int
+	valueStart int
+	valueLen   int
+}
+
+// CompactHash stores small hash values as contiguous field/value bytes plus
+// compact entry metadata. It is selected internally without changing the
+// client-visible hash value kind.
+type CompactHash struct {
+	entries []compactHashEntry
+	arena   []byte
+}
+
+func newCompactHash(pairs []HashFieldValue) *CompactHash {
+	h := &CompactHash{entries: make([]compactHashEntry, 0, len(pairs))}
+	for _, pair := range pairs {
+		h.set(pair.Field, pair.Value)
+	}
+	return h
+}
+
+func cloneCompactHash(src *CompactHash) *CompactHash {
+	if src == nil {
+		return nil
+	}
+
+	return &CompactHash{
+		entries: append([]compactHashEntry(nil), src.entries...),
+		arena:   cloneBytes(src.arena),
+	}
+}
+
+func (h *CompactHash) len() int {
+	if h == nil {
+		return 0
+	}
+	return len(h.entries)
+}
+
+func (h *CompactHash) get(field string) ([]byte, bool) {
+	if h == nil {
+		return nil, false
+	}
+	for _, entry := range h.entries {
+		if h.fieldEqual(entry, field) {
+			return h.value(entry), true
+		}
+	}
+	return nil, false
+}
+
+func (h *CompactHash) set(field string, value []byte) bool {
+	for i, entry := range h.entries {
+		if h.fieldEqual(entry, field) {
+			if len(value) <= entry.valueLen {
+				copy(h.arena[entry.valueStart:entry.valueStart+entry.valueLen], value)
+				h.entries[i].valueLen = len(value)
+			} else {
+				h.rebuild(i, HashFieldValue{Field: field, Value: value})
+			}
+			return false
+		}
+	}
+
+	fieldStart := len(h.arena)
+	h.arena = append(h.arena, field...)
+	valueStart := len(h.arena)
+	h.arena = append(h.arena, value...)
+	h.entries = append(h.entries, compactHashEntry{
+		fieldStart: fieldStart,
+		fieldLen:   len(field),
+		valueStart: valueStart,
+		valueLen:   len(value),
+	})
+	return true
+}
+
+func (h *CompactHash) del(field string) bool {
+	if h == nil {
+		return false
+	}
+	for i, entry := range h.entries {
+		if !h.fieldEqual(entry, field) {
+			continue
+		}
+		h.rebuild(i)
+		return true
+	}
+	return false
+}
+
+func (h *CompactHash) all() []HashFieldValue {
+	if h == nil {
+		return nil
+	}
+	entries := make([]HashFieldValue, 0, len(h.entries))
+	for _, entry := range h.entries {
+		entries = append(entries, HashFieldValue{Field: h.field(entry), Value: h.value(entry)})
+	}
+	return entries
+}
+
+func (h *CompactHash) rebuild(skip int, replacements ...HashFieldValue) {
+	pairs := make([]HashFieldValue, 0, len(h.entries)+len(replacements))
+	pairs = append(pairs, replacements...)
+	for i, entry := range h.entries {
+		if i == skip {
+			continue
+		}
+		pairs = append(pairs, HashFieldValue{Field: h.field(entry), Value: h.value(entry)})
+	}
+	rebuilt := newCompactHash(pairs)
+	h.entries = rebuilt.entries
+	h.arena = rebuilt.arena
+}
+
+func (h *CompactHash) field(entry compactHashEntry) string {
+	return string(h.arena[entry.fieldStart : entry.fieldStart+entry.fieldLen])
+}
+
+func (h *CompactHash) fieldEqual(entry compactHashEntry, field string) bool {
+	if entry.fieldLen != len(field) {
+		return false
+	}
+	for i, b := range h.arena[entry.fieldStart : entry.fieldStart+entry.fieldLen] {
+		if b != field[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *CompactHash) value(entry compactHashEntry) []byte {
+	return h.arena[entry.valueStart : entry.valueStart+entry.valueLen]
+}

--- a/internal/storage/compact_zset.go
+++ b/internal/storage/compact_zset.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"bytes"
+	"slices"
+)
+
+const compactZSetMaxEntries = 8
+
+type compactZSetEntry struct {
+	memberStart int
+	memberLen   int
+	score       float64
+}
+
+// CompactZSet stores small sorted sets as contiguous member bytes plus compact
+// score metadata kept sorted by score and member.
+type CompactZSet struct {
+	entries []compactZSetEntry
+	arena   []byte
+}
+
+func newCompactZSet(entries []ZSetEntry) *CompactZSet {
+	set := &CompactZSet{entries: make([]compactZSetEntry, 0, len(entries))}
+	for _, entry := range entries {
+		set.add(entry.Member, entry.Score)
+	}
+	return set
+}
+
+func cloneCompactZSet(src *CompactZSet) *CompactZSet {
+	if src == nil {
+		return nil
+	}
+
+	return &CompactZSet{
+		entries: append([]compactZSetEntry(nil), src.entries...),
+		arena:   cloneBytes(src.arena),
+	}
+}
+
+func (s *CompactZSet) len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.entries)
+}
+
+func (s *CompactZSet) add(member []byte, score float64) bool {
+	for i, entry := range s.entries {
+		if s.memberEqual(entry, member) {
+			if entry.score == score {
+				return false
+			}
+			s.entries[i].score = score
+			s.sort()
+			return false
+		}
+	}
+
+	start := len(s.arena)
+	s.arena = append(s.arena, member...)
+	s.entries = append(s.entries, compactZSetEntry{memberStart: start, memberLen: len(member), score: score})
+	s.sort()
+	return true
+}
+
+func (s *CompactZSet) rangeByRank(start, stop int) []ZSetRangeEntry {
+	if s == nil || start < 0 || stop < start || start >= len(s.entries) {
+		return nil
+	}
+	if stop >= len(s.entries) {
+		stop = len(s.entries) - 1
+	}
+
+	items := make([]ZSetRangeEntry, 0, stop-start+1)
+	for _, entry := range s.entries[start : stop+1] {
+		items = append(items, ZSetRangeEntry{Member: s.member(entry), Score: entry.score})
+	}
+	return items
+}
+
+func (s *CompactZSet) sort() {
+	slices.SortFunc(s.entries, func(left, right compactZSetEntry) int {
+		if left.score < right.score {
+			return -1
+		}
+		if left.score > right.score {
+			return 1
+		}
+		return bytes.Compare(s.memberBytes(left), s.memberBytes(right))
+	})
+}
+
+func (s *CompactZSet) member(entry compactZSetEntry) string {
+	return string(s.memberBytes(entry))
+}
+
+func (s *CompactZSet) memberBytes(entry compactZSetEntry) []byte {
+	return s.arena[entry.memberStart : entry.memberStart+entry.memberLen]
+}
+
+func (s *CompactZSet) memberEqual(entry compactZSetEntry, member []byte) bool {
+	return bytes.Equal(s.memberBytes(entry), member)
+}

--- a/internal/storage/hash.go
+++ b/internal/storage/hash.go
@@ -85,9 +85,10 @@ func (s *Store) HGet(key, field string) ([]byte, bool, error) {
 		shard.mu.RUnlock()
 		return nil, false, nil
 	}
+	cloned := cloneBytes(raw)
 	shard.mu.RUnlock()
 
-	return cloneBytes(raw), true, nil
+	return cloned, true, nil
 }
 
 // HDel removes the named fields from the hash stored at key and returns the
@@ -166,11 +167,10 @@ func (s *Store) HGetAll(key string) ([]HashFieldValue, error) {
 		return nil, err
 	}
 	value.touch(now)
-	shard.mu.RUnlock()
-
 	for i := range entries {
 		entries[i].Value = cloneBytes(entries[i].Value)
 	}
+	shard.mu.RUnlock()
 
 	return entries, nil
 }

--- a/internal/storage/hash.go
+++ b/internal/storage/hash.go
@@ -25,33 +25,25 @@ func (s *Store) HSet(key string, pairs []HashFieldValue) (int64, error) {
 		oldSize = s.approximateValueObjectSize(key, value)
 	}
 
-	var fields map[string][]byte
+	var added int64
 	if ok {
 		var err error
-		fields, err = value.HashValue()
+		added, err = value.hashSet(pairs)
 		if err != nil {
 			return 0, err
 		}
-	} else {
-		fields = make(map[string][]byte, len(pairs))
-	}
-
-	added := int64(0)
-	for _, pair := range pairs {
-		if _, exists := fields[pair.Field]; !exists {
-			added++
-		}
-		fields[pair.Field] = cloneBytes(pair.Value)
-	}
-
-	if ok {
 		value.touch(now)
 		if accounting {
 			newSize := s.approximateValueObjectSize(key, value)
 			s.usedMemory.Add(newSize - oldSize)
 		}
 	} else {
-		newValue := newHashValue(fields, 0)
+		newValue := newHashValueForPairs(pairs, 0)
+		newLen, err := newValue.hashLen()
+		if err != nil {
+			return 0, err
+		}
+		added = int64(newLen)
 		s.setKeyLocked(shard, key, newValue)
 		if accounting {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
@@ -83,13 +75,12 @@ func (s *Store) HGet(key, field string) ([]byte, bool, error) {
 		shard.mu.Unlock()
 		return nil, false, nil
 	}
-	fields, err := value.HashValue()
+	raw, exists, err := value.hashGet(field)
 	if err != nil {
 		shard.mu.RUnlock()
 		return nil, false, err
 	}
 	value.touch(now)
-	raw, exists := fields[field]
 	if !exists {
 		shard.mu.RUnlock()
 		return nil, false, nil
@@ -118,26 +109,23 @@ func (s *Store) HDel(key string, fields []string) (int64, error) {
 	if !ok {
 		return 0, nil
 	}
-	hash, err := value.HashValue()
-	if err != nil {
-		return 0, err
-	}
 	accounting := s.maxMemoryEnabled()
 	var oldSize int64
 	if accounting {
 		oldSize = s.approximateValueObjectSize(key, value)
 	}
 
-	removed := int64(0)
-	for _, field := range fields {
-		if _, exists := hash[field]; exists {
-			delete(hash, field)
-			removed++
-		}
+	removed, err := value.hashDel(fields)
+	if err != nil {
+		return 0, err
 	}
 
 	value.touch(time.Now().UnixMilli())
-	if len(hash) == 0 {
+	hashLen, err := value.hashLen()
+	if err != nil {
+		return 0, err
+	}
+	if hashLen == 0 {
 		s.deleteKeyWithSizeLocked(shard, key, oldSize)
 		return removed, nil
 	}
@@ -172,17 +160,12 @@ func (s *Store) HGetAll(key string) ([]HashFieldValue, error) {
 		shard.mu.Unlock()
 		return []HashFieldValue{}, nil
 	}
-	hash, err := value.HashValue()
+	entries, err := value.hashEntries()
 	if err != nil {
 		shard.mu.RUnlock()
 		return nil, err
 	}
 	value.touch(now)
-
-	entries := make([]HashFieldValue, 0, len(hash))
-	for field, raw := range hash {
-		entries = append(entries, HashFieldValue{Field: field, Value: raw})
-	}
 	shard.mu.RUnlock()
 
 	for i := range entries {

--- a/internal/storage/hashset_test.go
+++ b/internal/storage/hashset_test.go
@@ -287,6 +287,22 @@ func TestStoreHash(t *testing.T) {
 			t.Fatalf("SnapshotAll() hash = %#v, want a/one", snapshot[0].Hash)
 		}
 	})
+
+	t.Run("Hash creation chooses compact encoding by distinct fields", func(t *testing.T) {
+		store := NewStore()
+		pairs := make([]HashFieldValue, compactHashMaxEntries+1)
+		for i := range pairs {
+			pairs[i] = HashFieldValue{Field: "same", Value: []byte("value")}
+		}
+
+		if _, err := store.HSet("h", pairs); err != nil {
+			t.Fatalf("HSet() error = %v", err)
+		}
+		stored := store.valueObjectForTest("h")
+		if stored == nil || stored.HashEncoding != ValueEncodingCompact {
+			t.Fatalf("stored hash = %#v, want compact hash for one distinct field", stored)
+		}
+	})
 }
 
 func TestStoreSet(t *testing.T) {

--- a/internal/storage/hashset_test.go
+++ b/internal/storage/hashset_test.go
@@ -238,6 +238,55 @@ func TestStoreHash(t *testing.T) {
 			t.Fatalf("HGet() after expiry = (%v, %v)", ok, err)
 		}
 	})
+
+	t.Run("Small hash uses compact encoding across commands and snapshots", func(t *testing.T) {
+		store := NewStore()
+		added, err := store.HSet("h", []HashFieldValue{
+			{Field: "a", Value: []byte("1")},
+			{Field: "b", Value: []byte("2")},
+		})
+		if err != nil {
+			t.Fatalf("HSet() error = %v", err)
+		}
+		if added != 2 {
+			t.Fatalf("HSet() added = %d, want 2", added)
+		}
+		stored := store.valueObjectForTest("h")
+		if stored == nil || stored.Kind != ValueKindHash || stored.HashEncoding != ValueEncodingCompact || stored.CompactHash == nil {
+			t.Fatalf("stored hash = %#v, want compact hash", stored)
+		}
+
+		added, err = store.HSet("h", []HashFieldValue{{Field: "a", Value: []byte("one")}})
+		if err != nil || added != 0 {
+			t.Fatalf("HSet() update = (%d, %v), want (0, nil)", added, err)
+		}
+		got, ok, err := store.HGet("h", "a")
+		if err != nil || !ok || string(got) != "one" {
+			t.Fatalf("HGet() = (%q, %v, %v), want (one, true, nil)", string(got), ok, err)
+		}
+		removed, err := store.HDel("h", []string{"b"})
+		if err != nil || removed != 1 {
+			t.Fatalf("HDel() = (%d, %v), want (1, nil)", removed, err)
+		}
+		entries, err := store.HGetAll("h")
+		if err != nil {
+			t.Fatalf("HGetAll() error = %v", err)
+		}
+		if len(entries) != 1 || entries[0].Field != "a" || string(entries[0].Value) != "one" {
+			t.Fatalf("HGetAll() = %#v, want a/one", entries)
+		}
+
+		snapshot, stats := store.SnapshotAll()
+		if stats.TotalKeys != 1 || stats.ExportedKeys != 1 {
+			t.Fatalf("SnapshotAll() stats = %+v, want total/exported 1", stats)
+		}
+		if len(snapshot) != 1 || snapshot[0].Kind != ValueKindHash || len(snapshot[0].Hash) != 1 {
+			t.Fatalf("SnapshotAll() = %#v, want one logical hash", snapshot)
+		}
+		if snapshot[0].Hash[0].Field != "a" || string(snapshot[0].Hash[0].Value) != "one" {
+			t.Fatalf("SnapshotAll() hash = %#v, want a/one", snapshot[0].Hash)
+		}
+	})
 }
 
 func TestStoreSet(t *testing.T) {

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -174,29 +174,27 @@ func (s *Store) ZAddWithEviction(key string, entries []ZSetEntry) (int64, []stri
 
 	shard, current := s.prepareExistingValueLocked(key, now)
 	var (
-		set       *SortedSet
-		expiresAt int64
+		newValue *ValueObject
+		added    int64
+		err      error
 	)
 	if current != nil {
-		var err error
-		set, err = current.ZSetValue()
+		newValue, err = current.cloneZSetValue(current.ExpiresAt)
 		if err != nil {
 			return 0, nil, err
 		}
-		expiresAt = current.ExpiresAt
-		set = cloneSortedSet(set)
-	} else {
-		set = newSortedSet()
-	}
-
-	added := int64(0)
-	for _, entry := range entries {
-		if set.add(string(entry.Member), entry.Score) {
-			added++
+		added, err = newValue.zsetAdd(entries)
+		if err != nil {
+			return 0, nil, err
 		}
+	} else {
+		newValue = newZSetValueForEntries(entries, 0)
+		newLen, err := newValue.zsetLen()
+		if err != nil {
+			return 0, nil, err
+		}
+		added = int64(newLen)
 	}
-
-	newValue := newZSetValue(set, expiresAt)
 	evicted, err := s.commitValueWithEvictionLocked(shard, key, current, newValue)
 	if err != nil {
 		return 0, nil, err
@@ -263,28 +261,28 @@ func (s *Store) HSetWithEviction(key string, pairs []HashFieldValue) (int64, []s
 	defer s.writeUnlockAllShards()
 
 	shard, current := s.prepareExistingValueLocked(key, now)
-	fields := make(map[string][]byte, len(pairs))
-	expiresAt := int64(0)
+	var (
+		newValue *ValueObject
+		added    int64
+		err      error
+	)
 	if current != nil {
-		existing, err := current.HashValue()
+		newValue, err = current.cloneHashValue(current.ExpiresAt)
 		if err != nil {
 			return 0, nil, err
 		}
-		for field, raw := range existing {
-			fields[field] = cloneBytes(raw)
+		added, err = newValue.hashSet(pairs)
+		if err != nil {
+			return 0, nil, err
 		}
-		expiresAt = current.ExpiresAt
-	}
-
-	added := int64(0)
-	for _, pair := range pairs {
-		if _, ok := fields[pair.Field]; !ok {
-			added++
+	} else {
+		newValue = newHashValueForPairs(pairs, 0)
+		newLen, err := newValue.hashLen()
+		if err != nil {
+			return 0, nil, err
 		}
-		fields[pair.Field] = cloneBytes(pair.Value)
+		added = int64(newLen)
 	}
-
-	newValue := newHashValue(fields, expiresAt)
 	evicted, err := s.commitValueWithEvictionLocked(shard, key, current, newValue)
 	if err != nil {
 		return 0, nil, err
@@ -406,7 +404,14 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 			size += int64(len(item))
 		}
 	case ValueKindHash:
-		size += approxCollectionOverhead + int64(len(value.Hash))*approxHashEntryOverhead
+		size += approxCollectionOverhead
+		if value.HashEncoding == ValueEncodingCompact {
+			if value.CompactHash != nil {
+				size += int64(len(value.CompactHash.entries))*approxHashEntryOverhead + int64(len(value.CompactHash.arena))
+			}
+			break
+		}
+		size += int64(len(value.Hash)) * approxHashEntryOverhead
 		for field, raw := range value.Hash {
 			size += int64(len(field) + len(raw))
 		}
@@ -417,6 +422,12 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 		}
 	case ValueKindZSet:
 		size += approxCollectionOverhead
+		if value.ZSetEncoding == ValueEncodingCompact {
+			if value.CompactZSet != nil {
+				size += int64(len(value.CompactZSet.entries))*approxZSetEntryOverhead + int64(len(value.CompactZSet.arena))
+			}
+			break
+		}
 		if value.ZSet != nil {
 			size += int64(len(value.ZSet.index)) * approxZSetEntryOverhead
 			for member := range value.ZSet.index {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -458,28 +458,25 @@ func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
 	}
 
 	var (
-		set       *SortedSet
-		expiresAt int64
+		newValue *ValueObject
+		added    int64
+		err      error
 	)
 	if ok {
-		var err error
-		set, err = value.ZSetValue()
+		added, err = value.zsetAdd(entries)
 		if err != nil {
 			return 0, err
 		}
-		expiresAt = value.ExpiresAt
+		newValue = value
 	} else {
-		set = newSortedSet()
-	}
-
-	added := int64(0)
-	for _, entry := range entries {
-		if set.add(string(entry.Member), entry.Score) {
-			added++
+		newValue = newZSetValueForEntries(entries, 0)
+		newLen, err := newValue.zsetLen()
+		if err != nil {
+			return 0, err
 		}
+		added = int64(newLen)
 	}
 
-	newValue := newZSetValue(set, expiresAt)
 	s.setKeyLocked(shard, key, newValue)
 	if accounting {
 		newSize := s.approximateValueObjectSize(key, newValue)
@@ -510,20 +507,24 @@ func (s *Store) ZRange(key string, start, stop int64) ([]ZSetRangeEntry, error) 
 		shard.mu.Unlock()
 		return []ZSetRangeEntry{}, nil
 	}
-	set, err := value.ZSetValue()
+	setLen, err := value.zsetLen()
 	if err != nil {
 		shard.mu.RUnlock()
 		return nil, err
 	}
 	value.touch(now)
 
-	from, to, ok := normalizeListRange(set.len(), start, stop)
+	from, to, ok := normalizeListRange(setLen, start, stop)
 	if !ok {
 		shard.mu.RUnlock()
 		return []ZSetRangeEntry{}, nil
 	}
 
-	entries := set.rangeByRank(from, to)
+	entries, err := value.zsetRangeByRank(from, to)
+	if err != nil {
+		shard.mu.RUnlock()
+		return nil, err
+	}
 	shard.mu.RUnlock()
 
 	return entries, nil
@@ -752,8 +753,15 @@ func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 					valueArena, entry.List[j] = appendClonedBytesArena(valueArena, item)
 				}
 			case ValueKindZSet:
-				if value.ZSet != nil {
-					entry.ZSet = value.ZSet.rangeByRank(0, value.ZSet.len()-1)
+				setLen, err := value.zsetLen()
+				if err != nil {
+					continue
+				}
+				if setLen > 0 {
+					entry.ZSet, err = value.zsetRangeByRank(0, setLen-1)
+					if err != nil {
+						continue
+					}
 				}
 			case ValueKindStream:
 				if value.Stream != nil {
@@ -767,11 +775,15 @@ func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 					}
 				}
 			case ValueKindHash:
-				entry.Hash = make([]HashFieldValue, 0, len(value.Hash))
-				for field, raw := range value.Hash {
+				hashEntries, err := value.hashEntries()
+				if err != nil {
+					continue
+				}
+				entry.Hash = make([]HashFieldValue, 0, len(hashEntries))
+				for _, hashEntry := range hashEntries {
 					var clonedValue []byte
-					valueArena, clonedValue = appendClonedBytesArena(valueArena, raw)
-					entry.Hash = append(entry.Hash, HashFieldValue{Field: field, Value: clonedValue})
+					valueArena, clonedValue = appendClonedBytesArena(valueArena, hashEntry.Value)
+					entry.Hash = append(entry.Hash, HashFieldValue{Field: hashEntry.Field, Value: clonedValue})
 				}
 			case ValueKindSet:
 				entry.Set = make([][]byte, 0, len(value.Set))

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -467,6 +467,7 @@ func (s *Store) ZAdd(key string, entries []ZSetEntry) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
+		value.touch(now)
 		newValue = value
 	} else {
 		newValue = newZSetValueForEntries(entries, 0)

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1176,6 +1176,22 @@ func TestStoreSortedSetBehavior(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Sorted set creation chooses compact encoding by distinct members", func(t *testing.T) {
+		store := NewStore()
+		entries := make([]ZSetEntry, compactZSetMaxEntries+1)
+		for i := range entries {
+			entries[i] = ZSetEntry{Member: []byte("same"), Score: float64(i)}
+		}
+
+		if _, err := store.ZAdd("leaders", entries); err != nil {
+			t.Fatalf("ZAdd() error = %v", err)
+		}
+		stored := store.valueObjectForTest("leaders")
+		if stored == nil || stored.ZSetEncoding != ValueEncodingCompact {
+			t.Fatalf("stored zset = %#v, want compact zset for one distinct member", stored)
+		}
+	})
 }
 
 func keysInDistinctShards(t *testing.T, store *Store, count int) []string {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1129,6 +1129,53 @@ func TestStoreSortedSetBehavior(t *testing.T) {
 			t.Fatalf("ZRange() = %#v, want fresh member", values)
 		}
 	})
+
+	t.Run("Small sorted set uses compact encoding across commands and snapshots", func(t *testing.T) {
+		store := NewStore()
+		added, err := store.ZAdd("leaders", []ZSetEntry{
+			{Member: []byte("beta"), Score: 2},
+			{Member: []byte("alpha"), Score: 1},
+			{Member: []byte("aardvark"), Score: 2},
+		})
+		if err != nil {
+			t.Fatalf("ZAdd() error = %v", err)
+		}
+		if added != 3 {
+			t.Fatalf("ZAdd() added = %d, want 3", added)
+		}
+		stored := store.valueObjectForTest("leaders")
+		if stored == nil || stored.Kind != ValueKindZSet || stored.ZSetEncoding != ValueEncodingCompact || stored.CompactZSet == nil {
+			t.Fatalf("stored zset = %#v, want compact zset", stored)
+		}
+
+		added, err = store.ZAdd("leaders", []ZSetEntry{{Member: []byte("beta"), Score: 0.5}})
+		if err != nil || added != 0 {
+			t.Fatalf("ZAdd() update = (%d, %v), want (0, nil)", added, err)
+		}
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() error = %v", err)
+		}
+		want := []string{"beta", "alpha", "aardvark"}
+		for i, value := range values {
+			if value.Member != want[i] {
+				t.Fatalf("ZRange()[%d].Member = %q, want %q", i, value.Member, want[i])
+			}
+		}
+
+		snapshot, stats := store.SnapshotAll()
+		if stats.TotalKeys != 1 || stats.ExportedKeys != 1 {
+			t.Fatalf("SnapshotAll() stats = %+v, want total/exported 1", stats)
+		}
+		if len(snapshot) != 1 || snapshot[0].Kind != ValueKindZSet || len(snapshot[0].ZSet) != 3 {
+			t.Fatalf("SnapshotAll() = %#v, want one logical sorted set", snapshot)
+		}
+		for i, entry := range snapshot[0].ZSet {
+			if entry.Member != want[i] {
+				t.Fatalf("SnapshotAll().ZSet[%d].Member = %q, want %q", i, entry.Member, want[i])
+			}
+		}
+	})
 }
 
 func keysInDistinctShards(t *testing.T, store *Store, count int) []string {

--- a/internal/storage/store_test_helpers_test.go
+++ b/internal/storage/store_test_helpers_test.go
@@ -34,3 +34,11 @@ func (s *Store) lastAccessedAtForTest(key string) int64 {
 
 	return value.lastAccessed()
 }
+
+func (s *Store) valueObjectForTest(key string) *ValueObject {
+	shard := s.shardForKey(key)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	return shard.data[key]
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -11,6 +11,16 @@ var errInvalidValueObjectState = errors.New("storage: invalid value object state
 // ValueKind identifies the logical data shape of a stored value.
 type ValueKind string
 
+// ValueEncoding identifies the internal physical representation of a stored value.
+type ValueEncoding uint8
+
+const (
+	// ValueEncodingGeneral stores a value in its general-purpose representation.
+	ValueEncodingGeneral ValueEncoding = iota
+	// ValueEncodingCompact stores a small collection in a contiguous compact representation.
+	ValueEncodingCompact
+)
+
 const (
 	// ValueKindString is the Phase 1 string storage type used by SET/GET.
 	ValueKindString ValueKind = "string"
@@ -99,8 +109,12 @@ type ValueObject struct {
 	String         []byte
 	List           [][]byte
 	ZSet           *SortedSet
+	CompactZSet    *CompactZSet
+	ZSetEncoding   ValueEncoding
 	Stream         *StreamValue
 	Hash           map[string][]byte
+	CompactHash    *CompactHash
+	HashEncoding   ValueEncoding
 	Set            map[string]struct{}
 	ExpiresAt      int64
 	LastAccessedAt int64
@@ -207,6 +221,16 @@ func newZSetValue(set *SortedSet, expiresAt int64) *ValueObject {
 	}
 }
 
+func newCompactZSetValue(set *CompactZSet, expiresAt int64) *ValueObject {
+	return &ValueObject{
+		CompactZSet:    set,
+		ZSetEncoding:   ValueEncodingCompact,
+		ExpiresAt:      expiresAt,
+		LastAccessedAt: time.Now().UnixMilli(),
+		Kind:           ValueKindZSet,
+	}
+}
+
 func newStreamValue(stream *StreamValue, expiresAt int64) *ValueObject {
 	return &ValueObject{
 		Stream:         stream,
@@ -249,6 +273,16 @@ func (v *ValueObject) SetValue() (map[string]struct{}, error) {
 func newHashValue(fields map[string][]byte, expiresAt int64) *ValueObject {
 	return &ValueObject{
 		Hash:           fields,
+		ExpiresAt:      expiresAt,
+		LastAccessedAt: time.Now().UnixMilli(),
+		Kind:           ValueKindHash,
+	}
+}
+
+func newCompactHashValue(hash *CompactHash, expiresAt int64) *ValueObject {
+	return &ValueObject{
+		CompactHash:    hash,
+		HashEncoding:   ValueEncodingCompact,
 		ExpiresAt:      expiresAt,
 		LastAccessedAt: time.Now().UnixMilli(),
 		Kind:           ValueKindHash,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -161,13 +161,24 @@ func (v *ValueObject) ListValue() ([][]byte, error) {
 	return v.List, nil
 }
 
-// ZSetValue returns the sorted-set payload for a sorted-set value.
+// ZSetValue returns the general sorted-set payload for a sorted-set value.
+// Compact sorted sets are materialized as detached general sorted sets.
 func (v *ValueObject) ZSetValue() (*SortedSet, error) {
 	if v == nil {
 		return nil, errInvalidValueObjectState
 	}
 	if v.Kind != ValueKindZSet {
 		return nil, ErrWrongType
+	}
+	if v.ZSetEncoding == ValueEncodingCompact {
+		if v.CompactZSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		set := newSortedSet()
+		for _, entry := range v.CompactZSet.rangeByRank(0, v.CompactZSet.len()-1) {
+			set.add(entry.Member, entry.Score)
+		}
+		return set, nil
 	}
 	if v.ZSet == nil {
 		return nil, errInvalidValueObjectState
@@ -240,13 +251,24 @@ func newStreamValue(stream *StreamValue, expiresAt int64) *ValueObject {
 	}
 }
 
-// HashValue returns the hash payload for a hash value.
+// HashValue returns the general hash payload for a hash value. Compact hashes
+// are materialized as detached general hash maps.
 func (v *ValueObject) HashValue() (map[string][]byte, error) {
 	if v == nil {
 		return nil, errInvalidValueObjectState
 	}
 	if v.Kind != ValueKindHash {
 		return nil, ErrWrongType
+	}
+	if v.HashEncoding == ValueEncodingCompact {
+		if v.CompactHash == nil {
+			return nil, errInvalidValueObjectState
+		}
+		fields := make(map[string][]byte, v.CompactHash.len())
+		for _, entry := range v.CompactHash.all() {
+			fields[entry.Field] = cloneBytes(entry.Value)
+		}
+		return fields, nil
 	}
 	if v.Hash == nil {
 		return nil, errInvalidValueObjectState

--- a/internal/storage/types_test.go
+++ b/internal/storage/types_test.go
@@ -36,6 +36,32 @@ func TestValueObjectAccessorsRejectInvalidTaggedUnionState(t *testing.T) {
 	}
 }
 
+func TestValueObjectAccessorsMaterializeCompactValues(t *testing.T) {
+	hashValue := newCompactHashValue(newCompactHash([]HashFieldValue{{Field: "f", Value: []byte("v")}}), 0)
+	hash, err := hashValue.HashValue()
+	if err != nil {
+		t.Fatalf("HashValue() error = %v", err)
+	}
+	if string(hash["f"]) != "v" {
+		t.Fatalf("HashValue()[f] = %q, want v", string(hash["f"]))
+	}
+	hash["f"][0] = 'V'
+	got, ok, err := hashValue.hashGet("f")
+	if err != nil || !ok || string(got) != "v" {
+		t.Fatalf("compact hash after materialized mutation = (%q, %v, %v), want (v, true, nil)", string(got), ok, err)
+	}
+
+	zsetValue := newCompactZSetValue(newCompactZSet([]ZSetEntry{{Member: []byte("m"), Score: 1}}), 0)
+	zset, err := zsetValue.ZSetValue()
+	if err != nil {
+		t.Fatalf("ZSetValue() error = %v", err)
+	}
+	entries := zset.rangeByRank(0, 0)
+	if len(entries) != 1 || entries[0].Member != "m" || entries[0].Score != 1 {
+		t.Fatalf("ZSetValue().rangeByRank() = %#v, want m/1", entries)
+	}
+}
+
 func TestStoreRejectsInvalidTaggedUnionState(t *testing.T) {
 	store := NewStore()
 	store.setValueObjectForTest("leaders", &ValueObject{Kind: ValueKindZSet})


### PR DESCRIPTION
## Summary
- add compact contiguous internal encodings for small Hash and Sorted Set values
- route HSET/HGET/HDEL/HGETALL and ZADD/ZRANGE through encoding-aware storage helpers
- preserve logical snapshot/AOF rewrite output and update memory accounting for compact payloads

## Validation
- go test ./...
- go vet ./...
- golangci-lint run
- go test -race ./...

Closes #12