### PR TITLE
Add compact intset encoding for integer-only sets

### DIFF
--- a/internal/storage/collection_value.go
+++ b/internal/storage/collection_value.go
@@ -243,6 +243,178 @@ func (v *ValueObject) cloneZSetValue(expiresAt int64) (*ValueObject, error) {
 	return newZSetValue(cloneSortedSet(v.ZSet), expiresAt), nil
 }
 
+func (v *ValueObject) setLen() (int, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return 0, ErrWrongType
+	}
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return 0, errInvalidValueObjectState
+		}
+		return v.IntSet.len(), nil
+	}
+	if v.Set == nil {
+		return 0, errInvalidValueObjectState
+	}
+	return len(v.Set), nil
+}
+
+func (v *ValueObject) setAdd(members [][]byte) (int64, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return 0, ErrWrongType
+	}
+
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return 0, errInvalidValueObjectState
+		}
+		added, ok := v.IntSet.addMany(members)
+		if !ok {
+			set := v.IntSet.generalSet()
+			v.IntSet = nil
+			v.Set = set
+			v.SetEncoding = ValueEncodingGeneral
+			return mustAddSetMembers(set, members), nil
+		}
+		return added, nil
+	}
+
+	if v.Set == nil {
+		return 0, errInvalidValueObjectState
+	}
+	return mustAddSetMembers(v.Set, members), nil
+}
+
+func (v *ValueObject) setContains(member []byte) (bool, error) {
+	if v == nil {
+		return false, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return false, ErrWrongType
+	}
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return false, errInvalidValueObjectState
+		}
+		return v.IntSet.contains(member), nil
+	}
+	if v.Set == nil {
+		return false, errInvalidValueObjectState
+	}
+	_, exists := v.Set[string(member)]
+	return exists, nil
+}
+
+func (v *ValueObject) setRemove(members [][]byte) (int64, error) {
+	if v == nil {
+		return 0, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return 0, ErrWrongType
+	}
+
+	removed := int64(0)
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return 0, errInvalidValueObjectState
+		}
+		for _, member := range members {
+			if v.IntSet.remove(member) {
+				removed++
+			}
+		}
+		return removed, nil
+	}
+
+	if v.Set == nil {
+		return 0, errInvalidValueObjectState
+	}
+	for _, member := range members {
+		if _, exists := v.Set[string(member)]; !exists {
+			continue
+		}
+		delete(v.Set, string(member))
+		removed++
+	}
+	return removed, nil
+}
+
+func (v *ValueObject) setMembers() ([][]byte, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return nil, ErrWrongType
+	}
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return v.IntSet.members(), nil
+	}
+	if v.Set == nil {
+		return nil, errInvalidValueObjectState
+	}
+
+	members := make([][]byte, 0, len(v.Set))
+	for member := range v.Set {
+		members = append(members, []byte(member))
+	}
+	return members, nil
+}
+
+func (v *ValueObject) cloneSetValue(expiresAt int64) (*ValueObject, error) {
+	if v == nil {
+		return nil, errInvalidValueObjectState
+	}
+	if v.Kind != ValueKindSet {
+		return nil, ErrWrongType
+	}
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return newIntSetValue(cloneIntSet(v.IntSet), expiresAt), nil
+	}
+	if v.Set == nil {
+		return nil, errInvalidValueObjectState
+	}
+
+	members := make(map[string]struct{}, len(v.Set))
+	for member := range v.Set {
+		members[member] = struct{}{}
+	}
+	return newSetValue(members, expiresAt), nil
+}
+
+func newSetValueForMembers(members [][]byte, expiresAt int64) *ValueObject {
+	if set, ok := newIntSet(members); ok {
+		return newIntSetValue(set, expiresAt)
+	}
+
+	set := make(map[string]struct{}, len(members))
+	mustAddSetMembers(set, members)
+	return newSetValue(set, expiresAt)
+}
+
+func mustAddSetMembers(set map[string]struct{}, members [][]byte) int64 {
+	added := int64(0)
+	for _, member := range members {
+		if _, exists := set[string(member)]; exists {
+			continue
+		}
+		set[string(member)] = struct{}{}
+		added++
+	}
+	return added
+}
+
 func newHashValueForPairs(pairs []HashFieldValue, expiresAt int64) *ValueObject {
 	compact := newCompactHash(pairs)
 	if compact.len() <= compactHashMaxEntries {

--- a/internal/storage/hashset_test.go
+++ b/internal/storage/hashset_test.go
@@ -402,4 +402,97 @@ func TestStoreSet(t *testing.T) {
 			t.Fatalf("SMembers() error = %v, want ErrWrongType", err)
 		}
 	})
+
+	t.Run("Integer-only set uses intset encoding across commands and snapshots", func(t *testing.T) {
+		store := NewStore()
+		added, err := store.SAdd("s", [][]byte{[]byte("2"), []byte("1"), []byte("2"), []byte("-5")})
+		if err != nil {
+			t.Fatalf("SAdd() error = %v", err)
+		}
+		if added != 3 {
+			t.Fatalf("SAdd() added = %d, want 3", added)
+		}
+		stored := store.valueObjectForTest("s")
+		if stored == nil || stored.Kind != ValueKindSet || stored.SetEncoding != ValueEncodingCompact || stored.IntSet == nil {
+			t.Fatalf("stored set = %#v, want compact intset", stored)
+		}
+
+		exists, err := store.SIsMember("s", []byte("1"))
+		if err != nil || !exists {
+			t.Fatalf("SIsMember(1) = (%v, %v), want (true, nil)", exists, err)
+		}
+		exists, err = store.SIsMember("s", []byte("3"))
+		if err != nil || exists {
+			t.Fatalf("SIsMember(3) = (%v, %v), want (false, nil)", exists, err)
+		}
+
+		removed, err := store.SRem("s", [][]byte{[]byte("2"), []byte("missing")})
+		if err != nil || removed != 1 {
+			t.Fatalf("SRem() = (%d, %v), want (1, nil)", removed, err)
+		}
+		members, err := store.SMembers("s")
+		if err != nil {
+			t.Fatalf("SMembers() error = %v", err)
+		}
+		got := sortedStrings(members)
+		want := []string{"-5", "1"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("SMembers() = %v, want %v", got, want)
+		}
+
+		snapshot, stats := store.SnapshotAll()
+		if stats.TotalKeys != 1 || stats.ExportedKeys != 1 {
+			t.Fatalf("SnapshotAll() stats = %+v, want total/exported 1", stats)
+		}
+		if len(snapshot) != 1 || snapshot[0].Kind != ValueKindSet {
+			t.Fatalf("SnapshotAll() = %#v, want one logical set", snapshot)
+		}
+		got = sortedStrings(snapshot[0].Set)
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("SnapshotAll().Set = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Non-integer and mixed sets use general encoding", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.SAdd("strings", [][]byte{[]byte("a"), []byte("b")}); err != nil {
+			t.Fatalf("SAdd(strings) error = %v", err)
+		}
+		if _, err := store.SAdd("mixed", [][]byte{[]byte("1"), []byte("b")}); err != nil {
+			t.Fatalf("SAdd(mixed) error = %v", err)
+		}
+		if _, err := store.SAdd("noncanonical", [][]byte{[]byte("01")}); err != nil {
+			t.Fatalf("SAdd(noncanonical) error = %v", err)
+		}
+
+		for _, key := range []string{"strings", "mixed", "noncanonical"} {
+			stored := store.valueObjectForTest(key)
+			if stored == nil || stored.SetEncoding != ValueEncodingGeneral || stored.Set == nil {
+				t.Fatalf("stored set %q = %#v, want general set", key, stored)
+			}
+		}
+	})
+
+	t.Run("SRem deletes empty intset", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.SAdd("s", [][]byte{[]byte("1")}); err != nil {
+			t.Fatalf("SAdd() error = %v", err)
+		}
+		removed, err := store.SRem("s", [][]byte{[]byte("1")})
+		if err != nil || removed != 1 {
+			t.Fatalf("SRem() = (%d, %v), want (1, nil)", removed, err)
+		}
+		if got := store.Len(); got != 0 {
+			t.Fatalf("Len() = %d, want 0", got)
+		}
+	})
+}
+
+func sortedStrings(values [][]byte) []string {
+	items := make([]string, 0, len(values))
+	for _, value := range values {
+		items = append(items, string(value))
+	}
+	sort.Strings(items)
+	return items
 }

--- a/internal/storage/intset.go
+++ b/internal/storage/intset.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"slices"
+	"strconv"
+)
+
+// IntSet stores integer-only set members in sorted int64 order.
+type IntSet struct {
+	values []int64
+}
+
+func newIntSet(members [][]byte) (*IntSet, bool) {
+	values, ok := parseIntSetMembers(members)
+	if !ok {
+		return nil, false
+	}
+	slices.Sort(values)
+	values = compactUniqueInts(values)
+	return &IntSet{values: values}, true
+}
+
+func cloneIntSet(src *IntSet) *IntSet {
+	if src == nil {
+		return nil
+	}
+	return &IntSet{values: append([]int64(nil), src.values...)}
+}
+
+func (s *IntSet) len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.values)
+}
+
+func (s *IntSet) addMany(members [][]byte) (int64, bool) {
+	values, ok := parseIntSetMembers(members)
+	if !ok {
+		return 0, false
+	}
+	if len(values) == 0 {
+		return 0, true
+	}
+	slices.Sort(values)
+	values = compactUniqueInts(values)
+	if len(s.values) == 0 {
+		s.values = values
+		return int64(len(values)), true
+	}
+
+	merged := make([]int64, 0, len(s.values)+len(values))
+	added := int64(0)
+	i, j := 0, 0
+	for i < len(s.values) && j < len(values) {
+		left, right := s.values[i], values[j]
+		switch {
+		case left < right:
+			merged = append(merged, left)
+			i++
+		case left > right:
+			merged = append(merged, right)
+			j++
+			added++
+		default:
+			merged = append(merged, left)
+			i++
+			j++
+		}
+	}
+	merged = append(merged, s.values[i:]...)
+	if j < len(values) {
+		added += int64(len(values) - j)
+		merged = append(merged, values[j:]...)
+	}
+	s.values = merged
+	return added, true
+}
+
+func (s *IntSet) contains(member []byte) bool {
+	if s == nil {
+		return false
+	}
+	value, ok := parseIntSetMember(member)
+	if !ok {
+		return false
+	}
+	_, exists := slices.BinarySearch(s.values, value)
+	return exists
+}
+
+func (s *IntSet) remove(member []byte) bool {
+	if s == nil {
+		return false
+	}
+	value, ok := parseIntSetMember(member)
+	if !ok {
+		return false
+	}
+	index, exists := slices.BinarySearch(s.values, value)
+	if !exists {
+		return false
+	}
+	s.values = slices.Delete(s.values, index, index+1)
+	return true
+}
+
+func (s *IntSet) members() [][]byte {
+	if s == nil {
+		return nil
+	}
+	members := make([][]byte, 0, len(s.values))
+	for _, value := range s.values {
+		members = append(members, []byte(strconv.FormatInt(value, 10)))
+	}
+	return members
+}
+
+func (s *IntSet) generalSet() map[string]struct{} {
+	members := make(map[string]struct{}, s.len())
+	if s == nil {
+		return members
+	}
+	for _, value := range s.values {
+		members[strconv.FormatInt(value, 10)] = struct{}{}
+	}
+	return members
+}
+
+func parseIntSetMembers(members [][]byte) ([]int64, bool) {
+	values := make([]int64, 0, len(members))
+	for _, member := range members {
+		value, ok := parseIntSetMember(member)
+		if !ok {
+			return nil, false
+		}
+		values = append(values, value)
+	}
+	return values, true
+}
+
+func parseIntSetMember(member []byte) (int64, bool) {
+	text := string(member)
+	value, err := strconv.ParseInt(text, 10, 64)
+	if err != nil || strconv.FormatInt(value, 10) != text {
+		return 0, false
+	}
+	return value, true
+}
+
+func compactUniqueInts(values []int64) []int64 {
+	if len(values) < 2 {
+		return values
+	}
+	write := 1
+	for _, value := range values[1:] {
+		if value == values[write-1] {
+			continue
+		}
+		values[write] = value
+		write++
+	}
+	return values[:write]
+}

--- a/internal/storage/intset.go
+++ b/internal/storage/intset.go
@@ -111,7 +111,7 @@ func (s *IntSet) members() [][]byte {
 	}
 	members := make([][]byte, 0, len(s.values))
 	for _, value := range s.values {
-		members = append(members, []byte(strconv.FormatInt(value, 10)))
+		members = append(members, strconv.AppendInt(make([]byte, 0, 20), value, 10))
 	}
 	return members
 }

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -305,29 +305,28 @@ func (s *Store) SAddWithEviction(key string, members [][]byte) (int64, []string,
 	defer s.writeUnlockAllShards()
 
 	shard, current := s.prepareExistingValueLocked(key, now)
-	set := make(map[string]struct{}, len(members))
-	expiresAt := int64(0)
+	var (
+		newValue *ValueObject
+		added    int64
+		err      error
+	)
 	if current != nil {
-		existing, err := current.SetValue()
+		newValue, err = current.cloneSetValue(current.ExpiresAt)
 		if err != nil {
 			return 0, nil, err
 		}
-		for member := range existing {
-			set[member] = struct{}{}
+		added, err = newValue.setAdd(members)
+		if err != nil {
+			return 0, nil, err
 		}
-		expiresAt = current.ExpiresAt
-	}
-
-	added := int64(0)
-	for _, member := range members {
-		if _, ok := set[string(member)]; ok {
-			continue
+	} else {
+		newValue = newSetValueForMembers(members, 0)
+		newLen, err := newValue.setLen()
+		if err != nil {
+			return 0, nil, err
 		}
-		set[string(member)] = struct{}{}
-		added++
+		added = int64(newLen)
 	}
-
-	newValue := newSetValue(set, expiresAt)
 	evicted, err := s.commitValueWithEvictionLocked(shard, key, current, newValue)
 	if err != nil {
 		return 0, nil, err
@@ -416,7 +415,14 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 			size += int64(len(field) + len(raw))
 		}
 	case ValueKindSet:
-		size += approxCollectionOverhead + int64(len(value.Set))*approxSetEntryOverhead
+		size += approxCollectionOverhead
+		if value.SetEncoding == ValueEncodingCompact {
+			if value.IntSet != nil {
+				size += int64(value.IntSet.len()) * 8
+			}
+			break
+		}
+		size += int64(len(value.Set)) * approxSetEntryOverhead
 		for member := range value.Set {
 			size += int64(len(member))
 		}

--- a/internal/storage/set.go
+++ b/internal/storage/set.go
@@ -97,8 +97,9 @@ func (s *Store) SRem(key string, members [][]byte) (int64, error) {
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
+	now := time.Now().UnixMilli()
 	value, ok := shard.data[key]
-	if ok && isExpired(value, time.Now().UnixMilli()) {
+	if ok && isExpired(value, now) {
 		s.deleteKeyLocked(shard, key)
 		ok = false
 	}
@@ -116,7 +117,7 @@ func (s *Store) SRem(key string, members [][]byte) (int64, error) {
 		return 0, err
 	}
 
-	value.touch(time.Now().UnixMilli())
+	value.touch(now)
 	setLen, err := value.setLen()
 	if err != nil {
 		return 0, err

--- a/internal/storage/set.go
+++ b/internal/storage/set.go
@@ -25,36 +25,25 @@ func (s *Store) SAdd(key string, members [][]byte) (int64, error) {
 		oldSize = s.approximateValueObjectSize(key, value)
 	}
 
-	var set map[string]struct{}
+	var added int64
 	if ok {
 		var err error
-		set, err = value.SetValue()
+		added, err = value.setAdd(members)
 		if err != nil {
 			return 0, err
 		}
-	} else {
-		set = make(map[string]struct{}, len(members))
-	}
-
-	added := int64(0)
-	for _, member := range members {
-		// Compiler elides the string allocation for map[string(b)] in read
-		// context, so duplicate members avoid the heap allocation entirely.
-		if _, exists := set[string(member)]; exists {
-			continue
-		}
-		set[string(member)] = struct{}{}
-		added++
-	}
-
-	if ok {
 		value.touch(now)
 		if accounting {
 			newSize := s.approximateValueObjectSize(key, value)
 			s.usedMemory.Add(newSize - oldSize)
 		}
 	} else {
-		newValue := newSetValue(set, 0)
+		newValue := newSetValueForMembers(members, 0)
+		newLen, err := newValue.setLen()
+		if err != nil {
+			return 0, err
+		}
+		added = int64(newLen)
 		s.setKeyLocked(shard, key, newValue)
 		if accounting {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
@@ -86,13 +75,12 @@ func (s *Store) SIsMember(key string, member []byte) (bool, error) {
 		shard.mu.Unlock()
 		return false, nil
 	}
-	set, err := value.SetValue()
+	exists, err := value.setContains(member)
 	if err != nil {
 		shard.mu.RUnlock()
 		return false, err
 	}
 	value.touch(now)
-	_, exists := set[string(member)]
 	shard.mu.RUnlock()
 
 	return exists, nil
@@ -117,29 +105,23 @@ func (s *Store) SRem(key string, members [][]byte) (int64, error) {
 	if !ok {
 		return 0, nil
 	}
-	set, err := value.SetValue()
-	if err != nil {
-		return 0, err
-	}
 	accounting := s.maxMemoryEnabled()
 	var oldSize int64
 	if accounting {
 		oldSize = s.approximateValueObjectSize(key, value)
 	}
 
-	removed := int64(0)
-	for _, member := range members {
-		// Both map[string(b)] and delete(m, string(b)) are compiler-optimized
-		// to avoid allocating a []byte->string copy.
-		if _, exists := set[string(member)]; !exists {
-			continue
-		}
-		delete(set, string(member))
-		removed++
+	removed, err := value.setRemove(members)
+	if err != nil {
+		return 0, err
 	}
 
 	value.touch(time.Now().UnixMilli())
-	if len(set) == 0 {
+	setLen, err := value.setLen()
+	if err != nil {
+		return 0, err
+	}
+	if setLen == 0 {
 		s.deleteKeyWithSizeLocked(shard, key, oldSize)
 		return removed, nil
 	}
@@ -174,17 +156,12 @@ func (s *Store) SMembers(key string) ([][]byte, error) {
 		shard.mu.Unlock()
 		return [][]byte{}, nil
 	}
-	set, err := value.SetValue()
+	members, err := value.setMembers()
 	if err != nil {
 		shard.mu.RUnlock()
 		return nil, err
 	}
 	value.touch(now)
-
-	members := make([][]byte, 0, len(set))
-	for member := range set {
-		members = append(members, []byte(member))
-	}
 	shard.mu.RUnlock()
 
 	return members, nil

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -787,13 +787,25 @@ func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 					entry.Hash = append(entry.Hash, HashFieldValue{Field: hashEntry.Field, Value: clonedValue})
 				}
 			case ValueKindSet:
-				setMembers, err := value.setMembers()
-				if err != nil {
+				if value.SetEncoding == ValueEncodingCompact {
+					setMembers, err := value.setMembers()
+					if err != nil {
+						continue
+					}
+					entry.Set = make([][]byte, len(setMembers))
+					for j, member := range setMembers {
+						valueArena, entry.Set[j] = appendClonedBytesArena(valueArena, member)
+					}
+					break
+				}
+				if value.Set == nil {
 					continue
 				}
-				entry.Set = make([][]byte, len(setMembers))
-				for j, member := range setMembers {
-					valueArena, entry.Set[j] = appendClonedBytesArena(valueArena, member)
+				entry.Set = make([][]byte, 0, len(value.Set))
+				for member := range value.Set {
+					var clonedMember []byte
+					valueArena, clonedMember = appendClonedStringBytesArena(valueArena, member)
+					entry.Set = append(entry.Set, clonedMember)
 				}
 			}
 
@@ -929,6 +941,13 @@ func appendClonedBytesArena(arena []byte, src []byte) ([]byte, []byte) {
 		return arena, nil
 	}
 
+	start := len(arena)
+	arena = append(arena, src...)
+	cloned := arena[start:len(arena):len(arena)]
+	return arena, cloned
+}
+
+func appendClonedStringBytesArena(arena []byte, src string) ([]byte, []byte) {
 	start := len(arena)
 	arena = append(arena, src...)
 	cloned := arena[start:len(arena):len(arena)]

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -787,11 +787,13 @@ func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 					entry.Hash = append(entry.Hash, HashFieldValue{Field: hashEntry.Field, Value: clonedValue})
 				}
 			case ValueKindSet:
-				entry.Set = make([][]byte, 0, len(value.Set))
-				for member := range value.Set {
-					var clonedMember []byte
-					valueArena, clonedMember = appendClonedStringBytesArena(valueArena, member)
-					entry.Set = append(entry.Set, clonedMember)
+				setMembers, err := value.setMembers()
+				if err != nil {
+					continue
+				}
+				entry.Set = make([][]byte, len(setMembers))
+				for j, member := range setMembers {
+					valueArena, entry.Set[j] = appendClonedBytesArena(valueArena, member)
 				}
 			}
 
@@ -927,13 +929,6 @@ func appendClonedBytesArena(arena []byte, src []byte) ([]byte, []byte) {
 		return arena, nil
 	}
 
-	start := len(arena)
-	arena = append(arena, src...)
-	cloned := arena[start:len(arena):len(arena)]
-	return arena, cloned
-}
-
-func appendClonedStringBytesArena(arena []byte, src string) ([]byte, []byte) {
 	start := len(arena)
 	arena = append(arena, src...)
 	cloned := arena[start:len(arena):len(arena)]

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -116,6 +116,8 @@ type ValueObject struct {
 	CompactHash    *CompactHash
 	HashEncoding   ValueEncoding
 	Set            map[string]struct{}
+	IntSet         *IntSet
+	SetEncoding    ValueEncoding
 	ExpiresAt      int64
 	LastAccessedAt int64
 	Kind           ValueKind
@@ -277,13 +279,20 @@ func (v *ValueObject) HashValue() (map[string][]byte, error) {
 	return v.Hash, nil
 }
 
-// SetValue returns the set payload for a set value.
+// SetValue returns the general set payload for a set value. Integer sets are
+// materialized as detached general set maps.
 func (v *ValueObject) SetValue() (map[string]struct{}, error) {
 	if v == nil {
 		return nil, errInvalidValueObjectState
 	}
 	if v.Kind != ValueKindSet {
 		return nil, ErrWrongType
+	}
+	if v.SetEncoding == ValueEncodingCompact {
+		if v.IntSet == nil {
+			return nil, errInvalidValueObjectState
+		}
+		return v.IntSet.generalSet(), nil
 	}
 	if v.Set == nil {
 		return nil, errInvalidValueObjectState
@@ -314,6 +323,16 @@ func newCompactHashValue(hash *CompactHash, expiresAt int64) *ValueObject {
 func newSetValue(members map[string]struct{}, expiresAt int64) *ValueObject {
 	return &ValueObject{
 		Set:            members,
+		ExpiresAt:      expiresAt,
+		LastAccessedAt: time.Now().UnixMilli(),
+		Kind:           ValueKindSet,
+	}
+}
+
+func newIntSetValue(members *IntSet, expiresAt int64) *ValueObject {
+	return &ValueObject{
+		IntSet:         members,
+		SetEncoding:    ValueEncodingCompact,
 		ExpiresAt:      expiresAt,
 		LastAccessedAt: time.Now().UnixMilli(),
 		Kind:           ValueKindSet,

--- a/internal/storage/types_test.go
+++ b/internal/storage/types_test.go
@@ -60,6 +60,20 @@ func TestValueObjectAccessorsMaterializeCompactValues(t *testing.T) {
 	if len(entries) != 1 || entries[0].Member != "m" || entries[0].Score != 1 {
 		t.Fatalf("ZSetValue().rangeByRank() = %#v, want m/1", entries)
 	}
+
+	setValue := newIntSetValue(&IntSet{values: []int64{1}}, 0)
+	set, err := setValue.SetValue()
+	if err != nil {
+		t.Fatalf("SetValue() error = %v", err)
+	}
+	if _, ok := set["1"]; !ok {
+		t.Fatalf("SetValue()[1] missing")
+	}
+	set["2"] = struct{}{}
+	contains, err := setValue.setContains([]byte("2"))
+	if err != nil || contains {
+		t.Fatalf("compact set after materialized mutation = (%v, %v), want (false, nil)", contains, err)
+	}
 }
 
 func TestStoreRejectsInvalidTaggedUnionState(t *testing.T) {


### PR DESCRIPTION
## Summary
- add sorted int64 intset storage for canonical integer-only Set values
- route SADD, SISMEMBER, SREM, SMEMBERS, snapshots, and maxmemory accounting through set encoding helpers
- keep non-integer, mixed, and non-canonical integer string Sets on the general representation

## Validation
- go test ./...
- go vet ./...
- golangci-lint run
- go test -race ./...

Closes #13