### PR TITLE
Implement transparent encoding upgrades

### DIFF
--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -18,6 +18,8 @@ import (
 	"github.com/maltemindedal/runedb/internal/storage"
 )
 
+const pubSubWriteTimeout = 100 * time.Millisecond
+
 var cachedReplConfGetAckPayload = sync.OnceValues(func() ([]byte, error) {
 	return protocol.Encode(propagationFrame(&Request{
 		Name: "REPLCONF",
@@ -867,7 +869,7 @@ func (e *Executor) deliverPubSubMessageToSubscriber(channel string, payload []by
 	if subscriber == nil {
 		return false
 	}
-	if err := subscriber.WriteEncoded(payload); err != nil {
+	if err := subscriber.WriteEncodedWithDeadline(payload, pubSubWriteTimeout); err != nil {
 		e.logger.Warn(
 			"failed to deliver pub/sub message",
 			"channel", channel,

--- a/internal/server/client_state.go
+++ b/internal/server/client_state.go
@@ -198,6 +198,15 @@ func (s *ClientState) IsAuthenticated() bool {
 // WriteResponses writes RESP values to the bound client writer without allowing
 // interleaving with other goroutines writing to the same connection.
 func (s *ClientState) WriteResponses(values []protocol.Value) error {
+	var payload []byte
+	if len(values) > 1 {
+		var err error
+		payload, err = protocol.EncodeValues(values)
+		if err != nil {
+			return err
+		}
+	}
+
 	s.responseMu.Lock()
 	defer s.responseMu.Unlock()
 
@@ -205,12 +214,16 @@ func (s *ClientState) WriteResponses(values []protocol.Value) error {
 		return fmt.Errorf("client response writer unavailable")
 	}
 
-	for _, value := range values {
-		if err := protocol.WriteValue(s.responseWriter, value); err != nil {
+	if len(values) == 1 {
+		if err := protocol.WriteValue(s.responseWriter, values[0]); err != nil {
 			return err
 		}
+		return s.responseWriter.Flush()
 	}
 
+	if _, err := s.responseWriter.Write(payload); err != nil {
+		return err
+	}
 	return s.responseWriter.Flush()
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -105,12 +105,20 @@ func (s *Server) writeClientResponses(ctx context.Context, writer *bufio.Writer,
 }
 
 func (s *Server) writeResponses(writer *bufio.Writer, values []protocol.Value) error {
-	for _, value := range values {
-		if err := protocol.WriteValue(writer, value); err != nil {
+	if len(values) == 1 {
+		if err := protocol.WriteValue(writer, values[0]); err != nil {
 			return err
 		}
+		return writer.Flush()
 	}
 
+	payload, err := protocol.EncodeValues(values)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write(payload); err != nil {
+		return err
+	}
 	return writer.Flush()
 }
 

--- a/internal/storage/collection_value.go
+++ b/internal/storage/collection_value.go
@@ -53,6 +53,10 @@ func (v *ValueObject) hashSet(pairs []HashFieldValue) (int64, error) {
 		if v.CompactHash == nil {
 			return 0, errInvalidValueObjectState
 		}
+		if !compactHashCanSet(v.CompactHash, pairs) {
+			v.upgradeCompactHash()
+			return v.hashSet(pairs)
+		}
 		for _, pair := range pairs {
 			if v.CompactHash.set(pair.Field, pair.Value) {
 				added++
@@ -64,13 +68,7 @@ func (v *ValueObject) hashSet(pairs []HashFieldValue) (int64, error) {
 	if v.Hash == nil {
 		return 0, errInvalidValueObjectState
 	}
-	for _, pair := range pairs {
-		if _, exists := v.Hash[pair.Field]; !exists {
-			added++
-		}
-		v.Hash[pair.Field] = cloneBytes(pair.Value)
-	}
-	return added, nil
+	return hashSetGeneral(v.Hash, pairs), nil
 }
 
 func (v *ValueObject) hashDel(fields []string) (int64, error) {
@@ -186,6 +184,10 @@ func (v *ValueObject) zsetAdd(entries []ZSetEntry) (int64, error) {
 		if v.CompactZSet == nil {
 			return 0, errInvalidValueObjectState
 		}
+		if !compactZSetCanAdd(v.CompactZSet, entries) {
+			v.upgradeCompactZSet()
+			return v.zsetAdd(entries)
+		}
 		for _, entry := range entries {
 			if v.CompactZSet.add(entry.Member, entry.Score) {
 				added++
@@ -197,12 +199,7 @@ func (v *ValueObject) zsetAdd(entries []ZSetEntry) (int64, error) {
 	if v.ZSet == nil {
 		return 0, errInvalidValueObjectState
 	}
-	for _, entry := range entries {
-		if v.ZSet.add(string(entry.Member), entry.Score) {
-			added++
-		}
-	}
-	return added, nil
+	return zsetAddGeneral(v.ZSet, entries), nil
 }
 
 func (v *ValueObject) zsetRangeByRank(start, stop int) ([]ZSetRangeEntry, error) {
@@ -415,29 +412,171 @@ func mustAddSetMembers(set map[string]struct{}, members [][]byte) int64 {
 	return added
 }
 
+func hashSetGeneral(hash map[string][]byte, pairs []HashFieldValue) int64 {
+	added := int64(0)
+	for _, pair := range pairs {
+		if _, exists := hash[pair.Field]; !exists {
+			added++
+		}
+		hash[pair.Field] = cloneBytes(pair.Value)
+	}
+	return added
+}
+
 func newHashValueForPairs(pairs []HashFieldValue, expiresAt int64) *ValueObject {
-	compact := newCompactHash(pairs)
-	if compact.len() <= compactHashMaxEntries {
-		return newCompactHashValue(compact, expiresAt)
+	fields, compactEligible := hashMapForPairs(pairs)
+	if compactEligible && len(fields) <= compactHashMaxEntries {
+		return newCompactHashValue(newCompactHashFromMap(fields), expiresAt)
 	}
 
-	entries := compact.all()
-	fields := make(map[string][]byte, len(entries))
-	for _, entry := range entries {
-		fields[entry.Field] = cloneBytes(entry.Value)
-	}
 	return newHashValue(fields, expiresAt)
 }
 
+func hashMapForPairs(pairs []HashFieldValue) (map[string][]byte, bool) {
+	fields := make(map[string][]byte, len(pairs))
+	compactEligible := true
+	for _, pair := range pairs {
+		if len(pair.Field) > compactHashMaxStringSize || len(pair.Value) > compactHashMaxStringSize {
+			compactEligible = false
+		}
+		fields[pair.Field] = cloneBytes(pair.Value)
+	}
+	return fields, compactEligible
+}
+
+func newCompactHashFromMap(fields map[string][]byte) *CompactHash {
+	hash := &CompactHash{entries: make([]compactHashEntry, 0, len(fields))}
+	for field, value := range fields {
+		hash.set(field, value)
+	}
+	return hash
+}
+
+func compactHashCanSet(hash *CompactHash, pairs []HashFieldValue) bool {
+	projectedLen := hash.len()
+	newFields := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		if len(pair.Field) > compactHashMaxStringSize || len(pair.Value) > compactHashMaxStringSize {
+			return false
+		}
+		if _, exists := hash.get(pair.Field); exists {
+			continue
+		}
+		if _, exists := newFields[pair.Field]; exists {
+			continue
+		}
+		newFields[pair.Field] = struct{}{}
+		projectedLen++
+		if projectedLen > compactHashMaxEntries {
+			return false
+		}
+	}
+	return true
+}
+
+func (v *ValueObject) upgradeCompactHash() {
+	v.Hash = compactHashGeneralMap(v.CompactHash)
+	v.CompactHash = nil
+	v.HashEncoding = ValueEncodingGeneral
+}
+
+func compactHashGeneralMap(hash *CompactHash) map[string][]byte {
+	fields := make(map[string][]byte, hash.len())
+	for _, entry := range hash.entries {
+		fields[hash.field(entry)] = cloneBytes(hash.value(entry))
+	}
+	return fields
+}
+
+func zsetAddGeneral(set *SortedSet, entries []ZSetEntry) int64 {
+	added := int64(0)
+	for _, entry := range entries {
+		if set.add(string(entry.Member), entry.Score) {
+			added++
+		}
+	}
+	return added
+}
+
 func newZSetValueForEntries(entries []ZSetEntry, expiresAt int64) *ValueObject {
-	compact := newCompactZSet(entries)
-	if compact.len() <= compactZSetMaxEntries {
-		return newCompactZSetValue(compact, expiresAt)
+	members, compactEligible := zsetMapForEntries(entries)
+	if compactEligible && len(members) <= compactZSetMaxEntries {
+		return newCompactZSetValue(newCompactZSetFromMap(members), expiresAt)
 	}
 
-	set := newSortedSet()
+	return newZSetValue(newSortedSetFromMap(members), expiresAt)
+}
+
+func zsetMapForEntries(entries []ZSetEntry) (map[string]float64, bool) {
+	members := make(map[string]float64, len(entries))
+	compactEligible := true
 	for _, entry := range entries {
-		set.add(string(entry.Member), entry.Score)
+		if len(entry.Member) > compactZSetMaxMemberLen {
+			compactEligible = false
+		}
+		members[string(entry.Member)] = entry.Score
 	}
-	return newZSetValue(set, expiresAt)
+	return members, compactEligible
+}
+
+func newCompactZSetFromMap(members map[string]float64) *CompactZSet {
+	set := &CompactZSet{entries: make([]compactZSetEntry, 0, len(members))}
+	for member, score := range members {
+		set.add([]byte(member), score)
+	}
+	return set
+}
+
+func newSortedSetFromMap(members map[string]float64) *SortedSet {
+	set := newSortedSet()
+	for member, score := range members {
+		set.add(member, score)
+	}
+	return set
+}
+
+func compactZSetCanAdd(set *CompactZSet, entries []ZSetEntry) bool {
+	projectedLen := set.len()
+	newMembers := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if len(entry.Member) > compactZSetMaxMemberLen {
+			return false
+		}
+		member := string(entry.Member)
+		if compactZSetContains(set, entry.Member) {
+			continue
+		}
+		if _, exists := newMembers[member]; exists {
+			continue
+		}
+		newMembers[member] = struct{}{}
+		projectedLen++
+		if projectedLen > compactZSetMaxEntries {
+			return false
+		}
+	}
+	return true
+}
+
+func compactZSetContains(set *CompactZSet, member []byte) bool {
+	for _, entry := range set.entries {
+		if set.memberEqual(entry, member) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *ValueObject) upgradeCompactZSet() {
+	v.ZSet = compactZSetGeneralSet(v.CompactZSet)
+	v.CompactZSet = nil
+	v.ZSetEncoding = ValueEncodingGeneral
+}
+
+func compactZSetGeneralSet(compact *CompactZSet) *SortedSet {
+	set := newSortedSet()
+	for _, entry := range compact.entries {
+		set.add(compact.member(entry), entry.score)
+	}
+	return set
 }

--- a/internal/storage/compact_hash.go
+++ b/internal/storage/compact_hash.go
@@ -1,6 +1,9 @@
 package storage
 
-const compactHashMaxEntries = 8
+const (
+	compactHashMaxEntries    = 8
+	compactHashMaxStringSize = 64
+)
 
 type compactHashEntry struct {
 	fieldStart int

--- a/internal/storage/compact_zset.go
+++ b/internal/storage/compact_zset.go
@@ -5,7 +5,10 @@ import (
 	"slices"
 )
 
-const compactZSetMaxEntries = 8
+const (
+	compactZSetMaxEntries   = 8
+	compactZSetMaxMemberLen = 64
+)
 
 type compactZSetEntry struct {
 	memberStart int

--- a/internal/storage/hashset_test.go
+++ b/internal/storage/hashset_test.go
@@ -303,6 +303,94 @@ func TestStoreHash(t *testing.T) {
 			t.Fatalf("stored hash = %#v, want compact hash for one distinct field", stored)
 		}
 	})
+
+	t.Run("Compact hash upgrades when entry count exceeds threshold", func(t *testing.T) {
+		store := NewStore()
+		for i := 0; i < compactHashMaxEntries; i++ {
+			if _, err := store.HSet("h", []HashFieldValue{{Field: string(rune('a' + i)), Value: []byte("v")}}); err != nil {
+				t.Fatalf("HSet() seed error = %v", err)
+			}
+		}
+		expiresAt := time.Now().Add(time.Hour).UnixMilli()
+		if ok := store.expireKeyForTest("h", expiresAt); !ok {
+			t.Fatal("expireKeyForTest() ok = false, want true")
+		}
+
+		added, err := store.HSet("h", []HashFieldValue{{Field: "overflow", Value: []byte("v")}})
+		if err != nil || added != 1 {
+			t.Fatalf("HSet() overflow = (%d, %v), want (1, nil)", added, err)
+		}
+		stored := store.valueObjectForTest("h")
+		if stored == nil || stored.Kind != ValueKindHash || stored.HashEncoding != ValueEncodingGeneral || stored.Hash == nil {
+			t.Fatalf("stored hash = %#v, want upgraded general hash", stored)
+		}
+		if stored.ExpiresAt != expiresAt {
+			t.Fatalf("upgraded hash ExpiresAt = %d, want %d", stored.ExpiresAt, expiresAt)
+		}
+		got, ok, err := store.HGet("h", "a")
+		if err != nil || !ok || string(got) != "v" {
+			t.Fatalf("HGet(a) after upgrade = (%q, %v, %v), want (v, true, nil)", string(got), ok, err)
+		}
+		got, ok, err = store.HGet("h", "overflow")
+		if err != nil || !ok || string(got) != "v" {
+			t.Fatalf("HGet(overflow) after upgrade = (%q, %v, %v), want (v, true, nil)", string(got), ok, err)
+		}
+	})
+
+	t.Run("Compact hash upgrades when string length exceeds threshold", func(t *testing.T) {
+		longText := make([]byte, compactHashMaxStringSize+1)
+		for i := range longText {
+			longText[i] = 'x'
+		}
+
+		tests := []struct {
+			name      string
+			seed      HashFieldValue
+			update    HashFieldValue
+			wantAdded int64
+			wantField string
+			wantLen   int
+		}{
+			{
+				name:      "field length",
+				seed:      HashFieldValue{Field: "f", Value: []byte("v")},
+				update:    HashFieldValue{Field: string(longText), Value: []byte("v")},
+				wantAdded: 1,
+				wantField: string(longText),
+				wantLen:   1,
+			},
+			{
+				name:      "value length",
+				seed:      HashFieldValue{Field: "f", Value: []byte("v")},
+				update:    HashFieldValue{Field: "f", Value: longText},
+				wantAdded: 0,
+				wantField: "f",
+				wantLen:   len(longText),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				store := NewStore()
+				if _, err := store.HSet("h", []HashFieldValue{tt.seed}); err != nil {
+					t.Fatalf("HSet() seed error = %v", err)
+				}
+
+				added, err := store.HSet("h", []HashFieldValue{tt.update})
+				if err != nil || added != tt.wantAdded {
+					t.Fatalf("HSet() long update = (%d, %v), want (%d, nil)", added, err, tt.wantAdded)
+				}
+				stored := store.valueObjectForTest("h")
+				if stored == nil || stored.HashEncoding != ValueEncodingGeneral || stored.Hash == nil {
+					t.Fatalf("stored hash = %#v, want upgraded general hash", stored)
+				}
+				got, ok, err := store.HGet("h", tt.wantField)
+				if err != nil || !ok || len(got) != tt.wantLen {
+					t.Fatalf("HGet(%q) after long update = (len %d, %v, %v), want len %d", tt.wantField, len(got), ok, err, tt.wantLen)
+				}
+			})
+		}
+	})
 }
 
 func TestStoreSet(t *testing.T) {
@@ -484,6 +572,35 @@ func TestStoreSet(t *testing.T) {
 		}
 		if got := store.Len(); got != 0 {
 			t.Fatalf("Len() = %d, want 0", got)
+		}
+	})
+
+	t.Run("Integer set upgrades when non-integer member is added", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.SAdd("s", [][]byte{[]byte("1"), []byte("2")}); err != nil {
+			t.Fatalf("SAdd() seed error = %v", err)
+		}
+		expiresAt := time.Now().Add(time.Hour).UnixMilli()
+		if ok := store.expireKeyForTest("s", expiresAt); !ok {
+			t.Fatal("expireKeyForTest() ok = false, want true")
+		}
+
+		added, err := store.SAdd("s", [][]byte{[]byte("2"), []byte("three")})
+		if err != nil || added != 1 {
+			t.Fatalf("SAdd() mixed update = (%d, %v), want (1, nil)", added, err)
+		}
+		stored := store.valueObjectForTest("s")
+		if stored == nil || stored.Kind != ValueKindSet || stored.SetEncoding != ValueEncodingGeneral || stored.Set == nil {
+			t.Fatalf("stored set = %#v, want upgraded general set", stored)
+		}
+		if stored.ExpiresAt != expiresAt {
+			t.Fatalf("upgraded set ExpiresAt = %d, want %d", stored.ExpiresAt, expiresAt)
+		}
+		for _, member := range []string{"1", "2", "three"} {
+			exists, err := store.SIsMember("s", []byte(member))
+			if err != nil || !exists {
+				t.Fatalf("SIsMember(%q) after upgrade = (%v, %v), want (true, nil)", member, exists, err)
+			}
 		}
 	})
 }

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1192,6 +1192,66 @@ func TestStoreSortedSetBehavior(t *testing.T) {
 			t.Fatalf("stored zset = %#v, want compact zset for one distinct member", stored)
 		}
 	})
+
+	t.Run("Compact sorted set upgrades when member count exceeds threshold", func(t *testing.T) {
+		store := NewStore()
+		for i := 0; i < compactZSetMaxEntries; i++ {
+			member := []byte(fmt.Sprintf("m%d", i))
+			if _, err := store.ZAdd("leaders", []ZSetEntry{{Member: member, Score: float64(i)}}); err != nil {
+				t.Fatalf("ZAdd() seed error = %v", err)
+			}
+		}
+		expiresAt := time.Now().Add(time.Hour).UnixMilli()
+		if ok := store.expireKeyForTest("leaders", expiresAt); !ok {
+			t.Fatal("expireKeyForTest() ok = false, want true")
+		}
+
+		added, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("overflow"), Score: 99}})
+		if err != nil || added != 1 {
+			t.Fatalf("ZAdd() overflow = (%d, %v), want (1, nil)", added, err)
+		}
+		stored := store.valueObjectForTest("leaders")
+		if stored == nil || stored.Kind != ValueKindZSet || stored.ZSetEncoding != ValueEncodingGeneral || stored.ZSet == nil {
+			t.Fatalf("stored zset = %#v, want upgraded general zset", stored)
+		}
+		if stored.ExpiresAt != expiresAt {
+			t.Fatalf("upgraded zset ExpiresAt = %d, want %d", stored.ExpiresAt, expiresAt)
+		}
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() after upgrade error = %v", err)
+		}
+		if len(values) != compactZSetMaxEntries+1 || values[len(values)-1].Member != "overflow" {
+			t.Fatalf("ZRange() after upgrade = %#v, want preserved members plus overflow", values)
+		}
+	})
+
+	t.Run("Compact sorted set upgrades when member length exceeds threshold", func(t *testing.T) {
+		store := NewStore()
+		if _, err := store.ZAdd("leaders", []ZSetEntry{{Member: []byte("short"), Score: 1}}); err != nil {
+			t.Fatalf("ZAdd() seed error = %v", err)
+		}
+		longMember := make([]byte, compactZSetMaxMemberLen+1)
+		for i := range longMember {
+			longMember[i] = 'x'
+		}
+
+		added, err := store.ZAdd("leaders", []ZSetEntry{{Member: longMember, Score: 2}})
+		if err != nil || added != 1 {
+			t.Fatalf("ZAdd() long member = (%d, %v), want (1, nil)", added, err)
+		}
+		stored := store.valueObjectForTest("leaders")
+		if stored == nil || stored.ZSetEncoding != ValueEncodingGeneral || stored.ZSet == nil {
+			t.Fatalf("stored zset = %#v, want upgraded general zset", stored)
+		}
+		values, err := store.ZRange("leaders", 0, -1)
+		if err != nil {
+			t.Fatalf("ZRange() after long member error = %v", err)
+		}
+		if len(values) != 2 || values[1].Member != string(longMember) {
+			t.Fatalf("ZRange() after long member = %#v, want long member preserved", values)
+		}
+	})
 }
 
 func keysInDistinctShards(t *testing.T, store *Store, count int) []string {


### PR DESCRIPTION
## Summary
- Upgrade compact hashes and sorted sets to general encodings when count or string/member length limits are exceeded
- Preserve logical behavior, data, and TTL state across upgrades
- Avoid compact-first construction overhead for large batched creations
- Bound pub/sub writes and batch multi-response writes to reduce hot-path blocking/IO overhead

Closes #14

## Validation
- go test ./...
- go vet ./...
- golangci-lint run
- go test -race ./...