### PR TITLE
Add bitmap string commands

### DIFF
--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -522,6 +522,76 @@ func (e *Executor) handleGet(_ context.Context, request *Request) (protocol.Valu
 	return protocol.BulkString{Data: value}, nil
 }
 
+func (e *Executor) handleSetBit(ctx context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 3 {
+		return nil, wrongNumberOfArgumentsError("SETBIT")
+	}
+
+	offset, err := parseBitmapOffsetArgument(request.Args[1])
+	if err != nil {
+		return nil, err
+	}
+	bit, err := parseBitValueArgument(request.Args[2])
+	if err != nil {
+		return nil, err
+	}
+
+	key := string(request.Args[0])
+	previous, evicted, err := e.store.SetBitWithEviction(key, offset, bit)
+	if err != nil {
+		return nil, storageCommandError(err)
+	}
+
+	e.recordWriteEffects(ctx, key, evicted)
+	return protocol.Integer{Value: previous}, nil
+}
+
+func (e *Executor) handleGetBit(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 2 {
+		return nil, wrongNumberOfArgumentsError("GETBIT")
+	}
+
+	offset, err := parseBitmapOffsetArgument(request.Args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	bit, _, err := e.store.GetBit(string(request.Args[0]), offset)
+	if err != nil {
+		return nil, storageCommandError(err)
+	}
+
+	return protocol.Integer{Value: bit}, nil
+}
+
+func (e *Executor) handleBitCount(_ context.Context, request *Request) (protocol.Value, error) {
+	if len(request.Args) != 1 && len(request.Args) != 3 {
+		return nil, wrongNumberOfArgumentsError("BITCOUNT")
+	}
+
+	var start *int64
+	var end *int64
+	if len(request.Args) == 3 {
+		parsedStart, err := parseIntegerArgument(request.Args[1])
+		if err != nil {
+			return nil, err
+		}
+		parsedEnd, err := parseIntegerArgument(request.Args[2])
+		if err != nil {
+			return nil, err
+		}
+		start = &parsedStart
+		end = &parsedEnd
+	}
+
+	count, _, err := e.store.BitCount(string(request.Args[0]), start, end)
+	if err != nil {
+		return nil, storageCommandError(err)
+	}
+
+	return protocol.Integer{Value: count}, nil
+}
+
 func (e *Executor) handleDel(_ context.Context, request *Request) (protocol.Value, error) {
 	if len(request.Args) < 1 {
 		return nil, wrongNumberOfArgumentsError("DEL")
@@ -890,6 +960,30 @@ func parseIntegerArgument(raw []byte) (int64, error) {
 	}
 
 	return value, nil
+}
+
+func parseBitmapOffsetArgument(raw []byte) (int64, error) {
+	offset, err := parseIntegerArgument(raw)
+	if err != nil {
+		return 0, err
+	}
+	if offset < 0 || offset > storage.MaxBitmapOffset {
+		return 0, ErrValueNotIntegerError()
+	}
+
+	return offset, nil
+}
+
+func parseBitValueArgument(raw []byte) (int64, error) {
+	bit, err := parseIntegerArgument(raw)
+	if err != nil {
+		return 0, err
+	}
+	if bit != 0 && bit != 1 {
+		return 0, ErrValueNotIntegerError()
+	}
+
+	return bit, nil
 }
 
 func parseFloatArgument(raw []byte) (float64, error) {

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -113,6 +113,142 @@ func TestExecutorExecute(t *testing.T) {
 			},
 		},
 		{
+			name:    "GETBIT returns zero for missing keys",
+			request: requestValue("GETBIT", "missing", "12"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 0})
+			},
+		},
+		{
+			name: "SETBIT sets sparse bits and returns previous bit",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				value, err := executor.Execute(context.Background(), requestValue("SETBIT", "bitmap", "16", "1"))
+				if err != nil {
+					t.Fatalf("SETBIT error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 0})
+			},
+			request: requestValue("GET", "bitmap"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.BulkString{Data: []byte{0, 0, 0x80}})
+			},
+		},
+		{
+			name: "SETBIT returns overwritten bit",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("SETBIT", "bitmap", "7", "1")); err != nil {
+					t.Fatalf("SETBIT setup error = %v", err)
+				}
+			},
+			request: requestValue("SETBIT", "bitmap", "7", "0"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 1})
+			},
+		},
+		{
+			name: "GETBIT reads existing and unset bits",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("SETBIT", "bitmap", "0", "1")); err != nil {
+					t.Fatalf("SETBIT setup error = %v", err)
+				}
+			},
+			request: requestValue("GETBIT", "bitmap", "1"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 0})
+			},
+		},
+		{
+			name: "BITCOUNT counts full and ranged strings",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				executor.store.Set("bitmap", []byte{0xff, 0x00, 0x0f}, 0)
+			},
+			request: requestValue("BITCOUNT", "bitmap", "1", "2"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 4})
+			},
+		},
+		{
+			name:    "BITCOUNT returns zero for missing keys",
+			request: requestValue("BITCOUNT", "missing"),
+			assert: func(t *testing.T, value protocol.Value, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				assertValueEqual(t, value, protocol.Integer{Value: 0})
+			},
+		},
+		{
+			name:    "SETBIT rejects invalid bit value",
+			request: requestValue("SETBIT", "bitmap", "0", "2"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("Execute() error = %v, want ErrValueNotInteger", err)
+				}
+			},
+		},
+		{
+			name:    "GETBIT rejects negative offset",
+			request: requestValue("GETBIT", "bitmap", "-1"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("Execute() error = %v, want ErrValueNotInteger", err)
+				}
+			},
+		},
+		{
+			name:    "BITCOUNT rejects invalid range argument",
+			request: requestValue("BITCOUNT", "bitmap", "0", "bad"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("Execute() error = %v, want ErrValueNotInteger", err)
+				}
+			},
+		},
+		{
+			name: "Bitmap commands reject wrong value type",
+			setup: func(t *testing.T, executor *Executor) {
+				t.Helper()
+				if _, err := executor.Execute(context.Background(), requestValue("RPUSH", "queue", "job-1")); err != nil {
+					t.Fatalf("RPUSH error = %v", err)
+				}
+			},
+			request: requestValue("BITCOUNT", "queue"),
+			assert: func(t *testing.T, _ protocol.Value, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrWrongType) {
+					t.Fatalf("Execute() error = %v, want ErrWrongType", err)
+				}
+			},
+		},
+		{
 			name: "DEL removes existing keys and returns count",
 			setup: func(t *testing.T, executor *Executor) {
 				t.Helper()
@@ -483,6 +619,22 @@ func TestExecutorDetailedPropagation(t *testing.T) {
 
 		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 1})
 		assertPropagationFrames(t, result.Propagation, requestValue("INCR", "counter"))
+	})
+
+	t.Run("SETBIT returns propagation frame", func(t *testing.T) {
+		executor := newTestExecutor()
+
+		result, err := executor.ExecuteDetailed(context.Background(), requestValue("SETBIT", "bitmap", "0", "1"))
+		if err != nil {
+			t.Fatalf("ExecuteDetailed() error = %v", err)
+		}
+		if len(result.Responses) != 1 {
+			t.Fatalf("len(result.Responses) = %d, want 1", len(result.Responses))
+		}
+
+		assertValueEqual(t, result.Responses[0], protocol.Integer{Value: 0})
+		assertPropagationFrames(t, result.Propagation, requestValue("SETBIT", "bitmap", "0", "1"))
+		assertPropagationFrames(t, result.Durability, requestValue("SETBIT", "bitmap", "0", "1"))
 	})
 
 	t.Run("PUBLISH returns propagation frame", func(t *testing.T) {

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -398,6 +398,20 @@ func (e *Executor) commandSpecs() map[string]commandSpec {
 			handler:  e.handleGet,
 			validate: exactArgsValidator("GET", 1),
 		},
+		"SETBIT": {
+			handler:    e.handleSetBit,
+			validate:   validateSetBitRequest,
+			propagates: true,
+			durable:    true,
+		},
+		"GETBIT": {
+			handler:  e.handleGetBit,
+			validate: validateGetBitRequest,
+		},
+		"BITCOUNT": {
+			handler:  e.handleBitCount,
+			validate: validateBitCountRequest,
+		},
 		"DEL": {
 			handler:    e.handleDel,
 			validate:   minArgsValidator("DEL", 1),
@@ -696,6 +710,44 @@ func validateSetRequest(request *Request) error {
 		case errors.Is(err, storage.ErrInvalidExpireTime):
 			return ErrInvalidExpireTimeError()
 		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSetBitRequest(request *Request) error {
+	if len(request.Args) != 3 {
+		return wrongNumberOfArgumentsError("SETBIT")
+	}
+	if _, err := parseBitmapOffsetArgument(request.Args[1]); err != nil {
+		return err
+	}
+	if _, err := parseBitValueArgument(request.Args[2]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateGetBitRequest(request *Request) error {
+	if len(request.Args) != 2 {
+		return wrongNumberOfArgumentsError("GETBIT")
+	}
+	if _, err := parseBitmapOffsetArgument(request.Args[1]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateBitCountRequest(request *Request) error {
+	if len(request.Args) != 1 && len(request.Args) != 3 {
+		return wrongNumberOfArgumentsError("BITCOUNT")
+	}
+	if len(request.Args) == 3 {
+		if _, err := parseIntegerArgument(request.Args[1]); err != nil {
+			return err
+		}
+		if _, err := parseIntegerArgument(request.Args[2]); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/bitmap.go
+++ b/internal/storage/bitmap.go
@@ -10,6 +10,10 @@ const MaxBitmapOffset = (1 << 32) - 1
 
 // GetBit returns the bit stored at offset for a string value.
 func (s *Store) GetBit(key string, offset int64) (int64, bool, error) {
+	if err := validateBitmapOffset(offset); err != nil {
+		return 0, false, err
+	}
+
 	now := time.Now().UnixMilli()
 	shard := s.shardForKey(key)
 
@@ -44,12 +48,20 @@ func (s *Store) GetBit(key string, offset int64) (int64, bool, error) {
 
 // SetBit sets the bit stored at offset for a string value and returns the previous bit.
 func (s *Store) SetBit(key string, offset int64, bit int64) (int64, error) {
+	if err := validateBitmapArguments(offset, bit); err != nil {
+		return 0, err
+	}
+
 	previous, _, err := s.setBit(key, offset, bit)
 	return previous, err
 }
 
 // SetBitWithEviction sets a bit and evicts keys first if maxmemory requires it.
 func (s *Store) SetBitWithEviction(key string, offset int64, bit int64) (int64, []string, error) {
+	if err := validateBitmapArguments(offset, bit); err != nil {
+		return 0, nil, err
+	}
+
 	if !s.maxMemoryEnabled() {
 		previous, err := s.SetBit(key, offset, bit)
 		return previous, nil, err
@@ -85,7 +97,11 @@ func (s *Store) setBitInShardLocked(shard *Shard, key string, offset int64, bit 
 		value = nil
 	}
 
-	oldSize := s.approximateValueObjectSize(key, value)
+	accounting := s.maxMemoryEnabled()
+	var oldSize int64
+	if accounting {
+		oldSize = s.approximateValueObjectSize(key, value)
+	}
 	var data []byte
 	var expiresAt int64
 	if ok {
@@ -106,6 +122,23 @@ func (s *Store) setBitInShardLocked(shard *Shard, key string, offset int64, bit 
 		return previous, nil, nil
 	}
 
+	if accounting {
+		newSize := s.approximateStringValueObjectSize(key, byteIndex+1, expiresAt)
+		evicted, err := s.ensureMemoryAvailableLocked(newSize-oldSize, protectedKeys(key))
+		if err != nil {
+			return 0, nil, err
+		}
+
+		extended := make([]byte, byteIndex+1)
+		copy(extended, data)
+		setBitInByte(&extended[byteIndex], mask, bit)
+		newValue := newOwnedStringValue(extended, expiresAt)
+		newValue.touch(now)
+		s.setKeyLocked(shard, key, newValue)
+		s.usedMemory.Add(newSize - oldSize)
+		return previous, evicted, nil
+	}
+
 	extended := make([]byte, byteIndex+1)
 	copy(extended, data)
 	data = extended
@@ -113,19 +146,25 @@ func (s *Store) setBitInShardLocked(shard *Shard, key string, offset int64, bit 
 
 	newValue := newOwnedStringValue(data, expiresAt)
 	newValue.touch(now)
-	if s.maxMemoryEnabled() {
-		newSize := s.approximateValueObjectSize(key, newValue)
-		evicted, err := s.ensureMemoryAvailableLocked(newSize-oldSize, protectedKeys(key))
-		if err != nil {
-			return 0, nil, err
-		}
-		s.setKeyLocked(shard, key, newValue)
-		s.usedMemory.Add(newSize - oldSize)
-		return previous, evicted, nil
-	}
-
 	s.setKeyLocked(shard, key, newValue)
 	return previous, nil, nil
+}
+
+func validateBitmapArguments(offset int64, bit int64) error {
+	if err := validateBitmapOffset(offset); err != nil {
+		return err
+	}
+	if bit != 0 && bit != 1 {
+		return ErrValueNotInteger
+	}
+	return nil
+}
+
+func validateBitmapOffset(offset int64) error {
+	if offset < 0 || offset > MaxBitmapOffset {
+		return ErrValueNotInteger
+	}
+	return nil
 }
 
 func setBitInByte(dst *byte, mask byte, bit int64) {

--- a/internal/storage/bitmap.go
+++ b/internal/storage/bitmap.go
@@ -1,0 +1,227 @@
+package storage
+
+import (
+	"math/bits"
+	"time"
+)
+
+// MaxBitmapOffset is the largest supported Redis-compatible bitmap bit offset.
+const MaxBitmapOffset = (1 << 32) - 1
+
+// GetBit returns the bit stored at offset for a string value.
+func (s *Store) GetBit(key string, offset int64) (int64, bool, error) {
+	now := time.Now().UnixMilli()
+	shard := s.shardForKey(key)
+
+	shard.mu.RLock()
+	value, ok := shard.data[key]
+	if !ok {
+		shard.mu.RUnlock()
+		return 0, false, nil
+	}
+	if isExpired(value, now) {
+		shard.mu.RUnlock()
+
+		shard.mu.Lock()
+		value, ok = shard.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			s.deleteKeyLocked(shard, key)
+		}
+		shard.mu.Unlock()
+		return 0, false, nil
+	}
+	data, err := value.StringValue()
+	if err != nil {
+		shard.mu.RUnlock()
+		return 0, true, err
+	}
+	value.touch(now)
+	bit := bitAt(data, offset)
+	shard.mu.RUnlock()
+
+	return bit, true, nil
+}
+
+// SetBit sets the bit stored at offset for a string value and returns the previous bit.
+func (s *Store) SetBit(key string, offset int64, bit int64) (int64, error) {
+	previous, _, err := s.setBit(key, offset, bit)
+	return previous, err
+}
+
+// SetBitWithEviction sets a bit and evicts keys first if maxmemory requires it.
+func (s *Store) SetBitWithEviction(key string, offset int64, bit int64) (int64, []string, error) {
+	if !s.maxMemoryEnabled() {
+		previous, err := s.SetBit(key, offset, bit)
+		return previous, nil, err
+	}
+
+	return s.setBit(key, offset, bit)
+}
+
+func (s *Store) setBit(key string, offset int64, bit int64) (int64, []string, error) {
+	now := time.Now().UnixMilli()
+	if s.maxMemoryEnabled() {
+		s.writeLockAllShards()
+		defer s.writeUnlockAllShards()
+		return s.setBitLocked(key, offset, bit, now)
+	}
+
+	shard := s.shardForKey(key)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	return s.setBitInShardLocked(shard, key, offset, bit, now)
+}
+
+func (s *Store) setBitLocked(key string, offset int64, bit int64, now int64) (int64, []string, error) {
+	shard := s.shardForKey(key)
+	return s.setBitInShardLocked(shard, key, offset, bit, now)
+}
+
+func (s *Store) setBitInShardLocked(shard *Shard, key string, offset int64, bit int64, now int64) (int64, []string, error) {
+	value, ok := shard.data[key]
+	if ok && isExpired(value, now) {
+		s.deleteKeyLocked(shard, key)
+		ok = false
+		value = nil
+	}
+
+	oldSize := s.approximateValueObjectSize(key, value)
+	var data []byte
+	var expiresAt int64
+	if ok {
+		current, err := value.StringValue()
+		if err != nil {
+			return 0, nil, err
+		}
+		data = current
+		expiresAt = value.ExpiresAt
+	}
+
+	previous := bitAt(data, offset)
+	byteIndex := int(offset / 8)
+	mask := byte(1 << uint(7-(offset%8)))
+	if ok && byteIndex < len(data) {
+		setBitInByte(&value.String[byteIndex], mask, bit)
+		value.touch(now)
+		return previous, nil, nil
+	}
+
+	extended := make([]byte, byteIndex+1)
+	copy(extended, data)
+	data = extended
+	setBitInByte(&data[byteIndex], mask, bit)
+
+	newValue := newOwnedStringValue(data, expiresAt)
+	newValue.touch(now)
+	if s.maxMemoryEnabled() {
+		newSize := s.approximateValueObjectSize(key, newValue)
+		evicted, err := s.ensureMemoryAvailableLocked(newSize-oldSize, protectedKeys(key))
+		if err != nil {
+			return 0, nil, err
+		}
+		s.setKeyLocked(shard, key, newValue)
+		s.usedMemory.Add(newSize - oldSize)
+		return previous, evicted, nil
+	}
+
+	s.setKeyLocked(shard, key, newValue)
+	return previous, nil, nil
+}
+
+func setBitInByte(dst *byte, mask byte, bit int64) {
+	if bit == 1 {
+		*dst |= mask
+	} else {
+		*dst &^= mask
+	}
+}
+
+// BitCount counts set bits in a string value, optionally over an inclusive byte range.
+func (s *Store) BitCount(key string, start *int64, end *int64) (int64, bool, error) {
+	now := time.Now().UnixMilli()
+	shard := s.shardForKey(key)
+
+	shard.mu.RLock()
+	value, ok := shard.data[key]
+	if !ok {
+		shard.mu.RUnlock()
+		return 0, false, nil
+	}
+	if isExpired(value, now) {
+		shard.mu.RUnlock()
+
+		shard.mu.Lock()
+		value, ok = shard.data[key]
+		if ok && isExpired(value, time.Now().UnixMilli()) {
+			s.deleteKeyLocked(shard, key)
+		}
+		shard.mu.Unlock()
+		return 0, false, nil
+	}
+	data, err := value.StringValue()
+	if err != nil {
+		shard.mu.RUnlock()
+		return 0, true, err
+	}
+	value.touch(now)
+	count := countBits(data, start, end)
+	shard.mu.RUnlock()
+
+	return count, true, nil
+}
+
+func bitAt(data []byte, offset int64) int64 {
+	byteIndex := int(offset / 8)
+	if byteIndex >= len(data) {
+		return 0
+	}
+
+	mask := byte(1 << uint(7-(offset%8)))
+	if data[byteIndex]&mask == 0 {
+		return 0
+	}
+	return 1
+}
+
+func countBits(data []byte, start *int64, end *int64) int64 {
+	if len(data) == 0 {
+		return 0
+	}
+
+	from, to, ok := normalizeBitmapRange(len(data), start, end)
+	if !ok {
+		return 0
+	}
+
+	count := int64(0)
+	for _, b := range data[from : to+1] {
+		count += int64(bits.OnesCount8(b))
+	}
+	return count
+}
+
+func normalizeBitmapRange(length int, start *int64, end *int64) (int, int, bool) {
+	if start == nil || end == nil {
+		return 0, length - 1, true
+	}
+
+	from := *start
+	to := *end
+	if from < 0 {
+		from = int64(length) + from
+	}
+	if to < 0 {
+		to = int64(length) + to
+	}
+	if from < 0 {
+		from = 0
+	}
+	if to < 0 || from >= int64(length) || from > to {
+		return 0, 0, false
+	}
+	if to >= int64(length) {
+		to = int64(length) - 1
+	}
+
+	return int(from), int(to), true
+}

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -114,7 +114,7 @@ func (s *Store) IncrementWithEviction(key string) (int64, []string, error) {
 
 	shard, current := s.prepareExistingValueLocked(key, now)
 	if current == nil {
-		newValue := newStringValue([]byte("1"), 0)
+		newValue := newOwnedStringValue([]byte("1"), 0)
 		newSize := s.approximateValueObjectSize(key, newValue)
 		evicted, err := s.ensureMemoryAvailableLocked(newSize, protectedKeys(key))
 		if err != nil {
@@ -137,7 +137,7 @@ func (s *Store) IncrementWithEviction(key string) (int64, []string, error) {
 	parsed++
 
 	oldSize := s.approximateValueObjectSize(key, current)
-	newValue := newStringValue([]byte(strconv.FormatInt(parsed, 10)), current.ExpiresAt)
+	newValue := newOwnedStringValue([]byte(strconv.FormatInt(parsed, 10)), current.ExpiresAt)
 	newValue.touch(now)
 	newSize := s.approximateValueObjectSize(key, newValue)
 

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -389,50 +389,52 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 		return 0
 	}
 
-	size := approxValueObjectOverhead + int64(len(key))
-	if value.ExpiresAt > 0 {
-		size += 8
-	}
-
 	switch value.Kind {
 	case ValueKindString:
-		size += int64(len(value.String))
+		return s.approximateStringValueObjectSize(key, len(value.String), value.ExpiresAt)
 	case ValueKindList:
+		size := approximateBaseValueObjectSize(key, value.ExpiresAt)
 		size += approxCollectionOverhead + int64(len(value.List))*approxListEntryOverhead
 		for _, item := range value.List {
 			size += int64(len(item))
 		}
+		return size
 	case ValueKindHash:
+		size := approximateBaseValueObjectSize(key, value.ExpiresAt)
 		size += approxCollectionOverhead
 		if value.HashEncoding == ValueEncodingCompact {
 			if value.CompactHash != nil {
 				size += int64(len(value.CompactHash.entries))*approxHashEntryOverhead + int64(len(value.CompactHash.arena))
 			}
-			break
+			return size
 		}
 		size += int64(len(value.Hash)) * approxHashEntryOverhead
 		for field, raw := range value.Hash {
 			size += int64(len(field) + len(raw))
 		}
+		return size
 	case ValueKindSet:
+		size := approximateBaseValueObjectSize(key, value.ExpiresAt)
 		size += approxCollectionOverhead
 		if value.SetEncoding == ValueEncodingCompact {
 			if value.IntSet != nil {
 				size += int64(value.IntSet.len()) * 8
 			}
-			break
+			return size
 		}
 		size += int64(len(value.Set)) * approxSetEntryOverhead
 		for member := range value.Set {
 			size += int64(len(member))
 		}
+		return size
 	case ValueKindZSet:
+		size := approximateBaseValueObjectSize(key, value.ExpiresAt)
 		size += approxCollectionOverhead
 		if value.ZSetEncoding == ValueEncodingCompact {
 			if value.CompactZSet != nil {
 				size += int64(len(value.CompactZSet.entries))*approxZSetEntryOverhead + int64(len(value.CompactZSet.arena))
 			}
-			break
+			return size
 		}
 		if value.ZSet != nil {
 			size += int64(len(value.ZSet.index)) * approxZSetEntryOverhead
@@ -440,7 +442,9 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 				size += int64(len(member))
 			}
 		}
+		return size
 	case ValueKindStream:
+		size := approximateBaseValueObjectSize(key, value.ExpiresAt)
 		size += approxCollectionOverhead
 		if value.Stream != nil {
 			size += int64(len(value.Stream.entries)) * approxStreamEntryOverhead
@@ -451,8 +455,21 @@ func (s *Store) approximateValueObjectSize(key string, value *ValueObject) int64
 				}
 			}
 		}
+		return size
 	}
 
+	return approximateBaseValueObjectSize(key, value.ExpiresAt)
+}
+
+func (s *Store) approximateStringValueObjectSize(key string, length int, expiresAt int64) int64 {
+	return approximateBaseValueObjectSize(key, expiresAt) + int64(length)
+}
+
+func approximateBaseValueObjectSize(key string, expiresAt int64) int64 {
+	size := approxValueObjectOverhead + int64(len(key))
+	if expiresAt > 0 {
+		size += 8
+	}
 	return size
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -5,7 +5,6 @@ import (
 	"hash/maphash"
 	"log/slog"
 	"math"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -186,7 +185,7 @@ func (s *Store) Increment(key string) (int64, error) {
 	}
 
 	if !ok {
-		newValue := newStringValue([]byte("1"), 0)
+		newValue := newOwnedStringValue([]byte("1"), 0)
 		s.setKeyLocked(shard, key, newValue)
 		if s.maxMemoryEnabled() {
 			s.usedMemory.Add(s.approximateValueObjectSize(key, newValue))
@@ -648,12 +647,11 @@ func (s *Store) SnapshotStrings() ([]StringSnapshotEntry, StringSnapshotStats) {
 	defer s.readUnlockAllShards()
 
 	stats := StringSnapshotStats{}
-	entries := make([]StringSnapshotEntry, 0)
+	entries := make([]StringSnapshotEntry, 0, s.totalKeyCountLocked())
 	valueArena := make([]byte, 0)
 	for i := range s.shards {
 		shard := &s.shards[i]
 		stats.TotalKeys += len(shard.data)
-		entries = slices.Grow(entries, len(shard.data))
 		for key, value := range shard.data {
 			if isExpired(value, now) {
 				stats.SkippedExpiredKeys++
@@ -732,12 +730,11 @@ func (s *Store) ReplaceWith(other *Store) {
 
 func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 	stats := SnapshotStats{}
-	entries := make([]SnapshotEntry, 0)
+	entries := make([]SnapshotEntry, 0, s.totalKeyCountLocked())
 	valueArena := make([]byte, 0)
 	for i := range s.shards {
 		shard := &s.shards[i]
 		stats.TotalKeys += len(shard.data)
-		entries = slices.Grow(entries, len(shard.data))
 		for key, value := range shard.data {
 			if isExpired(value, now) {
 				stats.SkippedExpiredKeys++
@@ -815,6 +812,14 @@ func (s *Store) snapshotAllLocked(now int64) ([]SnapshotEntry, SnapshotStats) {
 	}
 
 	return entries, stats
+}
+
+func (s *Store) totalKeyCountLocked() int {
+	total := 0
+	for i := range s.shards {
+		total += len(s.shards[i].data)
+	}
+	return total
 }
 
 func (s *Store) logDebug(msg string, args ...any) {

--- a/internal/storage/store_benchmark_test.go
+++ b/internal/storage/store_benchmark_test.go
@@ -29,6 +29,17 @@ func BenchmarkStore(b *testing.B) {
 		}
 	})
 
+	b.Run("SetBit same key", func(b *testing.B) {
+		store := NewStore()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			if _, err := store.SetBit("bitmap", int64(i%64), 1); err != nil {
+				b.Fatalf("SetBit() error = %v", err)
+			}
+		}
+	})
+
 	b.Run("Get hit", func(b *testing.B) {
 		store := NewStore()
 		store.Set("hot", payload, 0)

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -137,6 +138,143 @@ func TestStoreValueBehavior(t *testing.T) {
 
 				if _, _, err := store.Get("numbers"); !errors.Is(err, ErrWrongType) {
 					t.Fatalf("Get() error = %v, want ErrWrongType", err)
+				}
+			},
+		},
+		{
+			name: "SetBit expands sparse strings and GetBit reads unset bits",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+
+				previous, err := store.SetBit("bitmap", 16, 1)
+				if err != nil {
+					t.Fatalf("SetBit() error = %v", err)
+				}
+				if previous != 0 {
+					t.Fatalf("SetBit() previous = %d, want 0", previous)
+				}
+
+				got, ok, err := store.Get("bitmap")
+				if err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
+				if !ok {
+					t.Fatal("Get() ok = false, want true")
+				}
+				if want := []byte{0, 0, 0x80}; !bytes.Equal(got, want) {
+					t.Fatalf("Get() value = %v, want %v", got, want)
+				}
+
+				bit, _, err := store.GetBit("bitmap", 15)
+				if err != nil {
+					t.Fatalf("GetBit() error = %v", err)
+				}
+				if bit != 0 {
+					t.Fatalf("GetBit(15) = %d, want 0", bit)
+				}
+
+				bit, _, err = store.GetBit("bitmap", 16)
+				if err != nil {
+					t.Fatalf("GetBit() error = %v", err)
+				}
+				if bit != 1 {
+					t.Fatalf("GetBit(16) = %d, want 1", bit)
+				}
+			},
+		},
+		{
+			name: "SetBit returns previous bit when overwriting",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+
+				if previous, err := store.SetBit("bitmap", 7, 1); err != nil || previous != 0 {
+					t.Fatalf("first SetBit() previous = %d, error = %v, want 0 nil", previous, err)
+				}
+				if previous, err := store.SetBit("bitmap", 7, 0); err != nil || previous != 1 {
+					t.Fatalf("second SetBit() previous = %d, error = %v, want 1 nil", previous, err)
+				}
+			},
+		},
+		{
+			name: "GetBit and BitCount return zero for missing keys",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+
+				bit, ok, err := store.GetBit("missing", 12)
+				if err != nil {
+					t.Fatalf("GetBit() error = %v", err)
+				}
+				if ok || bit != 0 {
+					t.Fatalf("GetBit() = %d, %v, want 0 false", bit, ok)
+				}
+
+				count, ok, err := store.BitCount("missing", nil, nil)
+				if err != nil {
+					t.Fatalf("BitCount() error = %v", err)
+				}
+				if ok || count != 0 {
+					t.Fatalf("BitCount() = %d, %v, want 0 false", count, ok)
+				}
+			},
+		},
+		{
+			name: "BitCount supports inclusive and negative byte ranges",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+				store.Set("bitmap", []byte{0xff, 0x00, 0x0f}, 0)
+
+				count, _, err := store.BitCount("bitmap", nil, nil)
+				if err != nil {
+					t.Fatalf("BitCount() error = %v", err)
+				}
+				if count != 12 {
+					t.Fatalf("BitCount() = %d, want 12", count)
+				}
+
+				start, end := int64(1), int64(2)
+				count, _, err = store.BitCount("bitmap", &start, &end)
+				if err != nil {
+					t.Fatalf("BitCount(range) error = %v", err)
+				}
+				if count != 4 {
+					t.Fatalf("BitCount(1,2) = %d, want 4", count)
+				}
+
+				start, end = -1, -1
+				count, _, err = store.BitCount("bitmap", &start, &end)
+				if err != nil {
+					t.Fatalf("BitCount(negative range) error = %v", err)
+				}
+				if count != 4 {
+					t.Fatalf("BitCount(-1,-1) = %d, want 4", count)
+				}
+
+				start, end = 5, 1
+				count, _, err = store.BitCount("bitmap", &start, &end)
+				if err != nil {
+					t.Fatalf("BitCount(empty range) error = %v", err)
+				}
+				if count != 0 {
+					t.Fatalf("BitCount(5,1) = %d, want 0", count)
+				}
+			},
+		},
+		{
+			name: "Bitmap ops reject wrong value type",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+				if _, err := store.LeftPush("numbers", [][]byte{[]byte("one")}); err != nil {
+					t.Fatalf("LeftPush() error = %v", err)
+				}
+
+				if _, _, err := store.GetBit("numbers", 0); !errors.Is(err, ErrWrongType) {
+					t.Fatalf("GetBit() error = %v, want ErrWrongType", err)
+				}
+				if _, err := store.SetBit("numbers", 0, 1); !errors.Is(err, ErrWrongType) {
+					t.Fatalf("SetBit() error = %v, want ErrWrongType", err)
+				}
+				if _, _, err := store.BitCount("numbers", nil, nil); !errors.Is(err, ErrWrongType) {
+					t.Fatalf("BitCount() error = %v, want ErrWrongType", err)
 				}
 			},
 		},

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -278,6 +278,41 @@ func TestStoreValueBehavior(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Bitmap ops reject invalid direct arguments",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+
+				if _, _, err := store.GetBit("bitmap", -1); !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("GetBit() error = %v, want ErrValueNotInteger", err)
+				}
+				if _, err := store.SetBit("bitmap", -1, 1); !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("SetBit(negative offset) error = %v, want ErrValueNotInteger", err)
+				}
+				if _, err := store.SetBit("bitmap", 0, 2); !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("SetBit(invalid bit) error = %v, want ErrValueNotInteger", err)
+				}
+				if _, _, err := store.SetBitWithEviction("bitmap", MaxBitmapOffset+1, 1); !errors.Is(err, ErrValueNotInteger) {
+					t.Fatalf("SetBitWithEviction() error = %v, want ErrValueNotInteger", err)
+				}
+			},
+		},
+		{
+			name: "SetBitWithEviction checks memory before sparse allocation",
+			run: func(t *testing.T, store *Store) {
+				t.Helper()
+				store.ConfigureMaxMemory(1, 16)
+
+				if _, _, err := store.SetBitWithEviction("bitmap", MaxBitmapOffset, 1); !errors.Is(err, ErrMemoryLimitExceeded) {
+					t.Fatalf("SetBitWithEviction() error = %v, want ErrMemoryLimitExceeded", err)
+				}
+				if _, ok, err := store.Get("bitmap"); err != nil {
+					t.Fatalf("Get() error = %v", err)
+				} else if ok {
+					t.Fatal("Get() ok = true, want false after rejected sparse SetBit")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -208,6 +208,8 @@ func newStringValue(data []byte, expiresAt int64) *ValueObject {
 	return newOwnedStringValue(cloneBytes(data), expiresAt)
 }
 
+// newOwnedStringValue stores an already-owned string representation without cloning.
+// Callers must only pass byte slices that are not aliased with caller-controlled memory.
 func newOwnedStringValue(data []byte, expiresAt int64) *ValueObject {
 	return &ValueObject{
 		String:         data,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -205,8 +205,12 @@ func (v *ValueObject) StreamValue() (*StreamValue, error) {
 }
 
 func newStringValue(data []byte, expiresAt int64) *ValueObject {
+	return newOwnedStringValue(cloneBytes(data), expiresAt)
+}
+
+func newOwnedStringValue(data []byte, expiresAt int64) *ValueObject {
 	return &ValueObject{
-		String:         cloneBytes(data),
+		String:         data,
 		ExpiresAt:      expiresAt,
 		LastAccessedAt: time.Now().UnixMilli(),
 		Kind:           ValueKindString,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -102,6 +102,9 @@ func TestServerHandlesPhaseOneCommands(t *testing.T) {
 	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 2}, "INCR", "counter")
 	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "bad", "hello")
 	assertCommandResponse(t, conn, parser, protocol.ErrorValue{Message: "ERR value is not an integer or out of range"}, "INCR", "bad")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 0}, "SETBIT", "bits", "16", "1")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 1}, "GETBIT", "bits", "16")
+	assertCommandResponse(t, conn, parser, protocol.Integer{Value: 1}, "BITCOUNT", "bits")
 	assertCommandResponse(t, conn, parser, protocol.SimpleString{Value: "OK"}, "SET", "temp", "1", "PX", "15")
 
 	time.Sleep(25 * time.Millisecond)


### PR DESCRIPTION
## Summary
- Add Redis-compatible `SETBIT`, `GETBIT`, and `BITCOUNT` commands over string values.
- Preserve string storage semantics while supporting sparse bit writes, byte-range counting, WRONGTYPE handling, and maxmemory accounting.
- Add storage, executor, integration, propagation, race-safe behavior, and benchmark coverage for bitmap paths.

## Verification
- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test -race ./...`
- focused `go test -bench ... -benchmem ./internal/storage`

Closes #15